### PR TITLE
fix: expose __version__ and clarify @session_contract signature

### DIFF
--- a/src/callguard/__init__.py
+++ b/src/callguard/__init__.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("callguard")
+except Exception:  # pragma: no cover — editable installs, test envs
+    __version__ = "0.0.0-dev"
+
 import asyncio
 import uuid
 from collections.abc import Callable
@@ -36,6 +43,7 @@ from callguard.telemetry import GovernanceTelemetry
 from callguard.types import HookRegistration
 
 __all__ = [
+    "__version__",
     "CallGuard",
     "CallGuardConfigError",
     "CallGuardDenied",

--- a/src/callguard/contracts.py
+++ b/src/callguard/contracts.py
@@ -59,6 +59,9 @@ def postcondition(tool: str, when: Callable | None = None):
 def session_contract(func: Callable) -> Callable:
     """Cross-turn governance using persisted atomic counters.
 
+    The decorated function **must** accept a ``session`` parameter —
+    the pipeline calls ``contract(session)`` at evaluation time.
+
     Session methods are ASYNC. Session contracts must be async:
 
         @session_contract


### PR DESCRIPTION
## Summary

- Expose `__version__` on the `callguard` module via `importlib.metadata`, so users can do `import callguard; print(callguard.__version__)`
- Clarify in the `@session_contract` docstring that decorated functions **must** accept a `session` parameter (the pipeline calls `contract(session)` at evaluation time)

## Context

Discovered during a v0.3.0 PyPI smoke test run (5 groups, 47 tests, all in isolated `python:3.12-slim` Docker containers). Two originally-reported "failures" turned out to be test script bugs (Python string over-escaping of regex backslashes), not library bugs:

- **`matches` operator works correctly** — YAML single-quoted `'\brm\s+-rf\b'` flows through `yaml.safe_load` → `re.compile` without any corruption. The test script had `\\\\b` in Python (producing `\\b` in YAML) instead of `\\b` (producing `\b`).
- **`@session_contract` works correctly** — but requires a `session` parameter that wasn't obvious from the existing docstring.

## Test plan

- [x] 600 existing tests pass (`pytest tests/ -x -q`)
- [x] Full 47-test smoke suite passes in Docker containers (Groups 1-5: core, yaml, cli, templates, sinks)
- [x] `__version__` returns `"0.3.0"` when installed from source
- [x] Ruff lint + format pass (pre-commit hooks)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `__version__` attribute support and clarifies `@session_contract` documentation based on v0.3.0 smoke testing feedback.

## Changes
- **Version exposure**: Added `__version__` attribute using `importlib.metadata.version()` with graceful fallback to `"0.0.0-dev"` for development environments
- **Documentation improvement**: Enhanced `@session_contract` docstring to explicitly state that decorated functions must accept a `session` parameter

## Analysis
Both changes are straightforward improvements:
- The version implementation follows standard Python packaging best practices using `importlib.metadata`
- The broad exception handler is appropriate for handling various installation scenarios (editable installs, test environments)
- The docstring clarification addresses a real usability issue discovered during testing
- No behavioral changes to existing functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are non-breaking additions that improve usability without modifying existing behavior. The `__version__` implementation follows Python best practices with proper error handling, and the docstring clarification only adds helpful documentation. All 600 existing tests pass, plus comprehensive smoke testing in Docker containers validates the changes.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/callguard/__init__.py | Added `__version__` attribute using `importlib.metadata` with fallback to "0.0.0-dev" for development environments, properly exported in `__all__` |
| src/callguard/contracts.py | Enhanced `@session_contract` docstring to clarify that decorated functions must accept a `session` parameter required by the pipeline |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant callguard
    participant importlib.metadata
    participant session_contract

    User->>callguard: import callguard
    callguard->>importlib.metadata: _pkg_version("callguard")
    alt Package installed
        importlib.metadata-->>callguard: "0.3.0"
        callguard->>callguard: __version__ = "0.3.0"
    else Dev/editable install
        importlib.metadata-->>callguard: Exception
        callguard->>callguard: __version__ = "0.0.0-dev"
    end
    User->>callguard: print(callguard.__version__)
    callguard-->>User: "0.3.0" or "0.0.0-dev"

    Note over User,session_contract: Session Contract Usage

    User->>session_contract: @session_contract decorator
    Note over session_contract: Decorated function MUST<br/>accept session parameter
    User->>session_contract: async def contract(session)
    session_contract->>session_contract: contract._callguard_type = "session_contract"
    User->>callguard: pipeline.pre_execute(...)
    callguard->>session_contract: contract(session)
    session_contract-->>callguard: Verdict
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->