### PR TITLE
fix: rename to_sdk_hooks() to to_hook_callables() and document bridge recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Edictum integrates with six agent frameworks. Same YAML contracts, same enforcem
 | Agno | `as_tool_hook()` | Full interception | Low |
 | Semantic Kernel | `register()` | Full interception | Medium-High |
 | CrewAI | `register()` | Partial | High |
-| Claude Agent SDK | `to_sdk_hooks()` | Logged only | Low |
+| Claude Agent SDK | `to_hook_callables()` | Logged only | Low |
 
 See [Adapter Docs](https://acartag7.github.io/edictum/adapters/overview/) for setup, known limitations, and recommendations.
 

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -35,7 +35,7 @@ wrapper = adapter.as_tool_wrapper()
 
 | Framework | Adapter Class | Integration Method | Returns |
 |-----------|--------------|-------------------|---------|
-| Claude Agent SDK | `ClaudeAgentSDKAdapter` | `to_sdk_hooks()` | `dict` with `pre_tool_use` and `post_tool_use` async functions |
+| Claude Agent SDK | `ClaudeAgentSDKAdapter` | `to_hook_callables()` | `dict` with `pre_tool_use` and `post_tool_use` async functions |
 | LangChain | `LangChainAdapter` | `as_tool_wrapper()` | Wrapper function for `ToolNode` |
 | CrewAI | `CrewAIAdapter` | `register()` | Registers global before/after hooks |
 | Agno | `AgnoAdapter` | `as_tool_hook()` | Wrap-around function |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ Adapters are thin translation layers between framework-specific hook APIs and th
 | `AgnoAdapter` | Agno | `as_tool_hook()` -- wrap-around hook |
 | `SemanticKernelAdapter` | Semantic Kernel | `register(kernel)` -- auto-invocation filter |
 | `OpenAIAgentsAdapter` | OpenAI Agents | `as_guardrails()` -- input/output guardrails |
-| `ClaudeAgentSDKAdapter` | Claude Agent SDK | `to_sdk_hooks()` -- pre/post tool use hooks |
+| `ClaudeAgentSDKAdapter` | Claude Agent SDK | `to_hook_callables()` -- pre/post tool use hooks |
 
 Adapters never contain enforcement logic. They translate formats. If you need to add a new rule, add a contract or hook -- not adapter code.
 

--- a/docs/guides/adapter-comparison.md
+++ b/docs/guides/adapter-comparison.md
@@ -13,7 +13,7 @@ Edictum ships six framework adapters. This guide helps you choose the right one 
 | CrewAI | `register()` | Yes (callback return replaces result) | before_hook returns False | $0.040 |
 | Agno | `as_tool_hook()` | Yes (hook wraps execution) | Hook returns denial string | N/A |
 | Semantic Kernel | `register(kernel)` | Yes (filter modifies FunctionResult) | Filter sets cancel + error | $0.008 |
-| Claude SDK | `to_sdk_hooks()` | No (side-effect only) | Returns deny dict to SDK | N/A |
+| Claude SDK | `to_hook_callables()` | No (side-effect only) | Returns deny dict to SDK | N/A |
 
 Cost column reflects benchmarks from [edictum-demo](https://github.com/acartag7/edictum-demo) using each framework's default model. N/A indicates no published benchmark data.
 
@@ -100,8 +100,8 @@ from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
 
 guard = Edictum.from_yaml("contracts.yaml")
 adapter = ClaudeAgentSDKAdapter(guard=guard, principal=Principal(role="sre"))
-hooks = adapter.to_sdk_hooks()
-# Pass to your Claude agent/client setup: hooks=hooks
+hooks = adapter.to_hook_callables()
+# Use in your agent loop — see bridge recipe in Claude SDK adapter docs
 ```
 
 ---
@@ -130,7 +130,7 @@ hooks = adapter.to_sdk_hooks()
 
 ### Claude SDK
 
-- Side-effect only -- the native hook (`to_sdk_hooks()`) cannot replace the tool result. PII detection is logged but not intercepted before reaching the model. Postcondition `redact`/`deny` effects set `PostCallResult.result` for wrapper consumers but cannot modify the SDK's result flow. A warning is logged at adapter construction when postconditions declare these effects. See [Claude SDK adapter docs](../adapters/claude-sdk.md).
+- Side-effect only -- the hook callables (`to_hook_callables()`) cannot replace the tool result. PII detection is logged but not intercepted before reaching the model. Postcondition `redact`/`deny` effects set `PostCallResult.result` for wrapper consumers but cannot modify the SDK's result flow. A warning is logged at adapter construction when postconditions declare these effects. See [Claude SDK adapter docs](../adapters/claude-sdk.md).
 
 ### OpenAI Agents (postcondition enforcement)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ Edictum integrates with six agent frameworks. Same YAML contracts, same enforcem
 | CrewAI | `CrewAIAdapter` | `register()` |
 | Agno | `AgnoAdapter` | `as_tool_hook()` |
 | Semantic Kernel | `SemanticKernelAdapter` | `register(kernel)` |
-| Claude Agent SDK | `ClaudeAgentSDKAdapter` | `to_sdk_hooks()` |
+| Claude Agent SDK | `ClaudeAgentSDKAdapter` | `to_hook_callables()` |
 
 See the [adapter overview](adapters/overview.md) for setup guides and known limitations.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -189,7 +189,7 @@ adapter.register(kernel)
 from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
 
 adapter = ClaudeAgentSDKAdapter(guard)
-hooks = adapter.to_sdk_hooks()
+hooks = adapter.to_hook_callables()
 # hooks = {"pre_tool_use": ..., "post_tool_use": ...}
 ```
 

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -161,10 +161,10 @@ class TestClaudeAgentSDKAdapter:
         adapter = ClaudeAgentSDKAdapter(guard)
         assert adapter.session_id  # should be a UUID string
 
-    async def test_to_sdk_hooks(self):
+    async def test_to_hook_callables(self):
         guard = make_guard()
         adapter = ClaudeAgentSDKAdapter(guard)
-        hooks = adapter.to_sdk_hooks()
+        hooks = adapter.to_hook_callables()
         assert "pre_tool_use" in hooks
         assert "post_tool_use" in hooks
 
@@ -262,22 +262,22 @@ class TestEdictumRun:
 
 
 class TestClaudeSDKPostconditionCallback:
-    """Test on_postcondition_warn callback via to_sdk_hooks()."""
+    """Test on_postcondition_warn callback via to_hook_callables()."""
 
-    async def test_to_sdk_hooks_accepts_postcondition_callback(self):
-        """to_sdk_hooks() should accept on_postcondition_warn parameter."""
+    async def test_to_hook_callables_accepts_postcondition_callback(self):
+        """to_hook_callables() should accept on_postcondition_warn parameter."""
         guard = make_guard()
         adapter = ClaudeAgentSDKAdapter(guard)
         callback = MagicMock(return_value="redacted")
-        hooks = adapter.to_sdk_hooks(on_postcondition_warn=callback)
+        hooks = adapter.to_hook_callables(on_postcondition_warn=callback)
         assert "pre_tool_use" in hooks
         assert "post_tool_use" in hooks
 
     async def test_postcondition_callback_optional(self):
-        """to_sdk_hooks() should work without callback (backward compatible)."""
+        """to_hook_callables() should work without callback (backward compatible)."""
         guard = make_guard()
         adapter = ClaudeAgentSDKAdapter(guard)
-        hooks = adapter.to_sdk_hooks()
+        hooks = adapter.to_hook_callables()
         assert "pre_tool_use" in hooks
         assert "post_tool_use" in hooks
 
@@ -291,7 +291,7 @@ class TestClaudeSDKPostconditionCallback:
         callback = MagicMock(return_value="redacted")
         guard = make_guard(contracts=[detect_pii])
         adapter = ClaudeAgentSDKAdapter(guard)
-        hooks = adapter.to_sdk_hooks(on_postcondition_warn=callback)
+        hooks = adapter.to_hook_callables(on_postcondition_warn=callback)
 
         await hooks["pre_tool_use"]("TestTool", {"key": "val"}, "tu-1")
         await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="Patient SSN: 123-45-6789")
@@ -310,7 +310,7 @@ class TestClaudeSDKPostconditionCallback:
         guard = make_guard()
         adapter = ClaudeAgentSDKAdapter(guard)
         callback = MagicMock(return_value="redacted")
-        hooks = adapter.to_sdk_hooks(on_postcondition_warn=callback)
+        hooks = adapter.to_hook_callables(on_postcondition_warn=callback)
 
         await hooks["pre_tool_use"]("TestTool", {"key": "val"}, "tu-1")
         await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="ok")
@@ -329,7 +329,7 @@ class TestClaudeSDKPostconditionCallback:
 
         guard = make_guard(contracts=[detect_issue])
         adapter = ClaudeAgentSDKAdapter(guard)
-        hooks = adapter.to_sdk_hooks(on_postcondition_warn=exploding_callback)
+        hooks = adapter.to_hook_callables(on_postcondition_warn=exploding_callback)
 
         await hooks["pre_tool_use"]("TestTool", {}, "tu-1")
         # Should not raise
@@ -351,7 +351,7 @@ class TestClaudeSDKPostconditionCallback:
 
         guard = make_guard(contracts=[detect_secret])
         adapter = ClaudeAgentSDKAdapter(guard)
-        hooks = adapter.to_sdk_hooks(on_postcondition_warn=capture_callback)
+        hooks = adapter.to_hook_callables(on_postcondition_warn=capture_callback)
 
         await hooks["pre_tool_use"]("TestTool", {}, "tu-1")
         await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="token=abc123")


### PR DESCRIPTION
## Summary

- Renames `to_sdk_hooks()` to `to_hook_callables()` to honestly describe what the method returns — raw async callables for manual agent-loop integration, **not** SDK-native hooks
- Adds a bridge recipe in the Claude SDK adapter docs showing how to wrap callables into `ClaudeAgentOptions(hooks=...)` format (~10 lines, lives in user-land)
- Updates all 25 references across adapter source, tests, docs, README, and architecture docs

## Context

`to_sdk_hooks()` was misleading — its output (snake_case keys, bare callables, Edictum's own callback signature) is incompatible with `ClaudeAgentOptions(hooks=...)` which expects PascalCase keys, `HookMatcher` wrappers, and the SDK's `(HookInput, tool_use_id, HookContext)` callback signature. Our demo avoided this by calling `_pre_tool_use`/`_post_tool_use` directly, but anyone trying the obvious integration path would hit silent failures.

Rather than coupling to `claude-agent-sdk`'s pre-1.0 types via a `to_native_hooks()` method, we rename the method to be honest and document the bridge pattern. The coupling to SDK types stays in user-land where it belongs.

## Changes

| File | Change |
|------|--------|
| `src/edictum/adapters/claude_agent_sdk.py` | Rename method, update docstring with usage example and incompatibility note |
| `tests/test_adapter_claude.py` | Update all 12 references |
| `docs/adapters/claude-sdk.md` | Rewrite integration section, add bridge recipe with full working example |
| `docs/adapters/overview.md` | Update table |
| `docs/architecture.md` | Update table |
| `docs/guides/adapter-comparison.md` | Update table, snippet, and limitation note |
| `docs/quickstart.md` | Update snippet |
| `docs/index.md` | Update table |
| `README.md` | Update table |

756 tests passing, ruff clean.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR renames the Claude Agent SDK adapter integration method from `to_sdk_hooks()` to `to_hook_callables()` across source, tests, and all docs, and expands the Claude SDK adapter documentation with a “bridge recipe” showing how to wrap Edictum’s raw callables into SDK-native `ClaudeAgentOptions(hooks=...)` structures.

In the codebase, `ClaudeAgentSDKAdapter.to_hook_callables()` continues to return the same two async callables (`pre_tool_use` / `post_tool_use`) used to drive Edictum’s pre/post governance pipeline around tool execution; the change is primarily a public API rename intended to avoid implying direct compatibility with SDK-native hook types.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but contains a breaking public API rename that will hard-fail existing callers.
- All changes are consistent across repo and tests were updated, but removing/renaming a public method (`to_sdk_hooks`) without an alias/deprecation path will cause runtime AttributeError for downstream users relying on the old name.
- src/edictum/adapters/claude_agent_sdk.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Updates Claude Agent SDK adapter integration method name in the adapter table. |
| docs/adapters/claude-sdk.md | Rewrites integration docs to use to_hook_callables() and adds a bridge recipe; no code changes. |
| docs/adapters/overview.md | Updates adapter overview table to reflect method rename to to_hook_callables(). |
| docs/architecture.md | Updates architecture adapter table to reflect method rename to to_hook_callables(). |
| docs/guides/adapter-comparison.md | Updates comparison guide references/snippets to use to_hook_callables() and clarifies limitations wording. |
| docs/index.md | Updates docs index table to use to_hook_callables() for Claude Agent SDK adapter. |
| docs/quickstart.md | Updates quickstart snippet to call to_hook_callables() instead of to_sdk_hooks(). |
| src/edictum/adapters/claude_agent_sdk.py | Renames public method to_hook_callables() and updates docstring/warnings; introduces a breaking API change for existing callers of to_sdk_hooks(). |
| tests/test_adapter_claude.py | Updates tests to call to_hook_callables(); verifies callback behavior remains the same. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    autonumber
    participant U as User code
    participant A as ClaudeAgentSDKAdapter
    participant P as GovernancePipeline
    participant S as Session
    participant T as Telemetry
    participant AS as AuditSink

    U->>A: to_hook_callables(on_postcondition_warn?)
    A-->>U: {pre_tool_use: _pre_tool_use, post_tool_use: _post_tool_use}

    U->>A: pre_tool_use(tool_name, tool_input, tool_use_id)
    A->>S: increment_attempts()
    A->>T: start_tool_span(envelope)
    A->>P: pre_execute(envelope, session)
    alt observe mode + deny
        A->>AS: emit(CALL_WOULD_DENY)
        A-->>U: {} (allow through)
    else deny
        A->>AS: emit(CALL_DENIED)
        A->>T: record_denial(...)
        A-->>U: hookSpecificOutput(permissionDecision=deny)
    else allow
        A->>AS: emit(CALL_ALLOWED)
        A-->>U: {} (allow)
    end

    U->>A: post_tool_use(tool_use_id, tool_response)
    A->>P: post_execute(envelope, tool_response, tool_success)
    A->>S: record_execution(tool_name, success)
    A->>AS: emit(CALL_EXECUTED/CALL_FAILED)
    A->>T: span.end()
    opt warnings present
        A-->>U: hookSpecificOutput(additionalContext=warnings)
    end
    opt postconditions failed + callback set
        A-->>U: on_postcondition_warn(effective_response, findings)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->