### PR TITLE
feat: Claude Code GitHub Actions with GLM backend

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,36 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+        env:
+          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          API_TIMEOUT_MS: "3000000"
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-4.5-air
+          ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5
+          ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,8 @@ jobs:
           # Pass GLM token as anthropic_api_key to satisfy action validation.
           # Actual auth is handled by ANTHROPIC_AUTH_TOKEN (Bearer) below.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
           claude_args: '--model glm-5 --max-turns 10'
         env:
           # Redirect all API calls to GLM endpoint


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml` for `@claude` mentions in issues/PRs
- Routes through GLM API (`api.z.ai`) instead of direct Anthropic API
- Uses `ANTHROPIC_AUTH_TOKEN` for Bearer auth, `ANTHROPIC_BASE_URL` for endpoint redirect, and model alias mappings (`glm-5`, `glm-4.5-air`)

## Test plan
- [ ] Tag `@claude` in a test issue to verify the workflow triggers
- [ ] Confirm GLM API receives the request (check Actions run logs)
- [ ] Verify model resolution (`glm-5`) in the response