### PR TITLE
feat: bundle composition and dual-mode evaluation

### DIFF
--- a/src/edictum/yaml_engine/__init__.py
+++ b/src/edictum/yaml_engine/__init__.py
@@ -6,6 +6,13 @@ Requires optional dependencies: ``pip install edictum[yaml]``
 from __future__ import annotations
 
 from edictum.yaml_engine.compiler import CompiledBundle
+from edictum.yaml_engine.composer import (
+    ComposedBundle,
+    CompositionOverride,
+    CompositionReport,
+    ShadowContract,
+    compose_bundles,
+)
 from edictum.yaml_engine.loader import BundleHash
 
 
@@ -26,6 +33,11 @@ def compile_contracts(bundle: dict) -> CompiledBundle:
 __all__ = [
     "BundleHash",
     "CompiledBundle",
+    "ComposedBundle",
+    "CompositionOverride",
+    "CompositionReport",
+    "ShadowContract",
     "compile_contracts",
+    "compose_bundles",
     "load_bundle",
 ]

--- a/src/edictum/yaml_engine/compiler.py
+++ b/src/edictum/yaml_engine/compiler.py
@@ -59,7 +59,9 @@ def compile_contracts(bundle: dict) -> CompiledBundle:
             fn = _compile_post(contract, contract_mode)
             postconditions.append(fn)
         elif contract_type == "session":
-            limits = _merge_session_limits(contract, limits)
+            is_shadow = contract.get("_shadow", False)
+            if not is_shadow:
+                limits = _merge_session_limits(contract, limits)
             fn = _compile_session(contract, contract_mode, limits)
             session_contracts.append(fn)
 
@@ -149,6 +151,8 @@ def _compile_pre(contract: dict, mode: str) -> Any:
     precondition_fn._edictum_mode = mode
     precondition_fn._edictum_id = contract_id
     precondition_fn._edictum_source = "yaml_precondition"
+    if contract.get("_shadow"):
+        precondition_fn._edictum_shadow = True
 
     return precondition_fn
 
@@ -235,6 +239,8 @@ def _compile_post(contract: dict, mode: str) -> Any:
     postcondition_fn._edictum_source = "yaml_postcondition"
     postcondition_fn._edictum_effect = effect
     postcondition_fn._edictum_redact_patterns = _extract_output_patterns(when_expr)
+    if contract.get("_shadow"):
+        postcondition_fn._edictum_shadow = True
 
     return postcondition_fn
 
@@ -267,6 +273,8 @@ def _compile_session(contract: dict, mode: str, limits: OperationLimits) -> Any:
     session_contract_fn._edictum_tags = tags
     session_contract_fn._edictum_then_metadata = then_metadata
     session_contract_fn._edictum_source = "yaml_session"
+    if contract.get("_shadow"):
+        session_contract_fn._edictum_shadow = True
 
     return session_contract_fn
 

--- a/src/edictum/yaml_engine/composer.py
+++ b/src/edictum/yaml_engine/composer.py
@@ -1,0 +1,208 @@
+"""Bundle Composer — merge multiple parsed YAML bundles into one."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CompositionOverride:
+    """Records a contract that was replaced during composition."""
+
+    contract_id: str
+    overridden_by: str  # source label of the winning layer
+    original_source: str  # source label of the replaced layer
+
+
+@dataclass(frozen=True)
+class ShadowContract:
+    """Records a contract added as a shadow (observe_alongside)."""
+
+    contract_id: str
+    enforced_source: str  # source label of the enforced version
+    observed_source: str  # source label of the shadow version
+
+
+@dataclass(frozen=True)
+class CompositionReport:
+    """Report of what happened during composition."""
+
+    overridden_contracts: list[CompositionOverride] = field(default_factory=list)
+    shadow_contracts: list[ShadowContract] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ComposedBundle:
+    """Result of composing multiple bundles."""
+
+    bundle: dict[str, Any]
+    report: CompositionReport
+
+
+def compose_bundles(*bundles: tuple[dict[str, Any], str]) -> ComposedBundle:
+    """Merge multiple parsed bundle dicts left to right.
+
+    Each bundle is a tuple of (parsed_dict, source_label). Later layers
+    have higher priority.
+
+    Args:
+        *bundles: Tuples of (bundle_data, source_label).
+
+    Returns:
+        ComposedBundle with the merged bundle dict and composition report.
+
+    Raises:
+        ValueError: If no bundles are provided.
+    """
+    if not bundles:
+        raise ValueError("compose_bundles() requires at least one bundle")
+
+    if len(bundles) == 1:
+        data, _label = bundles[0]
+        return ComposedBundle(bundle=_deep_copy_bundle(data), report=CompositionReport())
+
+    overrides: list[CompositionOverride] = []
+    shadows: list[ShadowContract] = []
+
+    # Start with a copy of the first bundle
+    first_data, first_label = bundles[0]
+    merged = _deep_copy_bundle(first_data)
+
+    # Track contract origins: contract_id -> source_label
+    contract_sources: dict[str, str] = {}
+    for c in merged.get("contracts", []):
+        contract_sources[c["id"]] = first_label
+
+    for data, label in bundles[1:]:
+        is_observe_alongside = data.get("observe_alongside", False)
+
+        if is_observe_alongside:
+            _merge_observe_alongside(merged, data, label, contract_sources, shadows)
+        else:
+            _merge_standard(merged, data, label, contract_sources, overrides)
+
+    return ComposedBundle(
+        bundle=merged,
+        report=CompositionReport(
+            overridden_contracts=overrides,
+            shadow_contracts=shadows,
+        ),
+    )
+
+
+def _deep_copy_bundle(data: dict[str, Any]) -> dict[str, Any]:
+    """Deep copy a bundle dict (no external deps)."""
+    import copy
+
+    return copy.deepcopy(data)
+
+
+def _merge_standard(
+    merged: dict[str, Any],
+    layer: dict[str, Any],
+    label: str,
+    contract_sources: dict[str, str],
+    overrides: list[CompositionOverride],
+) -> None:
+    """Merge a standard (non-observe_alongside) layer into the merged bundle."""
+    # defaults.mode: later wins
+    if "defaults" in layer:
+        layer_defaults = layer["defaults"]
+        if "mode" in layer_defaults:
+            merged.setdefault("defaults", {})["mode"] = layer_defaults["mode"]
+        if "environment" in layer_defaults:
+            merged.setdefault("defaults", {})["environment"] = layer_defaults["environment"]
+
+    # limits: later wins (entire block replaced)
+    if "limits" in layer:
+        merged["limits"] = _deep_copy_bundle(layer["limits"])
+
+    # tools: deep merge
+    if "tools" in layer:
+        merged_tools = merged.get("tools", {})
+        for tool_name, tool_config in layer["tools"].items():
+            merged_tools[tool_name] = dict(tool_config)
+        merged["tools"] = merged_tools
+
+    # metadata: deep merge
+    if "metadata" in layer:
+        merged_meta = merged.get("metadata", {})
+        for key, value in layer["metadata"].items():
+            merged_meta[key] = value
+        merged["metadata"] = merged_meta
+
+    # observability: later wins
+    if "observability" in layer:
+        merged["observability"] = _deep_copy_bundle(layer["observability"])
+
+    # contracts: same ID replaces, unique ID concatenates
+    if "contracts" in layer:
+        existing_by_id: dict[str, int] = {}
+        for i, c in enumerate(merged.get("contracts", [])):
+            existing_by_id[c["id"]] = i
+
+        for contract in layer["contracts"]:
+            cid = contract["id"]
+            new_contract = _deep_copy_bundle(contract)
+
+            if cid in existing_by_id:
+                # Replace existing contract
+                idx = existing_by_id[cid]
+                original_source = contract_sources.get(cid, "unknown")
+                overrides.append(
+                    CompositionOverride(
+                        contract_id=cid,
+                        overridden_by=label,
+                        original_source=original_source,
+                    )
+                )
+                merged["contracts"][idx] = new_contract
+                contract_sources[cid] = label
+            else:
+                # Append new contract
+                merged.setdefault("contracts", []).append(new_contract)
+                existing_by_id[cid] = len(merged["contracts"]) - 1
+                contract_sources[cid] = label
+
+
+def _merge_observe_alongside(
+    merged: dict[str, Any],
+    layer: dict[str, Any],
+    label: str,
+    contract_sources: dict[str, str],
+    shadows: list[ShadowContract],
+) -> None:
+    """Merge an observe_alongside layer — contracts become shadow copies."""
+    for contract in layer.get("contracts", []):
+        cid = contract["id"]
+        shadow_id = f"{cid}:candidate"
+
+        shadow_contract = _deep_copy_bundle(contract)
+        shadow_contract["id"] = shadow_id
+        shadow_contract["mode"] = "observe"
+        shadow_contract["_shadow"] = True
+
+        merged.setdefault("contracts", []).append(shadow_contract)
+
+        enforced_source = contract_sources.get(cid, "")
+        shadows.append(
+            ShadowContract(
+                contract_id=cid,
+                enforced_source=enforced_source,
+                observed_source=label,
+            )
+        )
+
+    # observe_alongside layers can also carry metadata/tools — deep merge them
+    if "tools" in layer:
+        merged_tools = merged.get("tools", {})
+        for tool_name, tool_config in layer["tools"].items():
+            merged_tools[tool_name] = dict(tool_config)
+        merged["tools"] = merged_tools
+
+    if "metadata" in layer:
+        merged_meta = merged.get("metadata", {})
+        for key, value in layer["metadata"].items():
+            merged_meta[key] = value
+        merged["metadata"] = merged_meta

--- a/src/edictum/yaml_engine/edictum-v1.schema.json
+++ b/src/edictum/yaml_engine/edictum-v1.schema.json
@@ -17,7 +17,8 @@
       "items": { "$ref": "#/$defs/Contract" }
     },
     "tools": { "$ref": "#/$defs/Tools" },
-    "observability": { "$ref": "#/$defs/Observability" }
+    "observability": { "$ref": "#/$defs/Observability" },
+    "observe_alongside": { "type": "boolean", "default": false }
   },
 
   "$defs": {

--- a/tests/test_cli/test_cli_composition.py
+++ b/tests/test_cli/test_cli_composition.py
@@ -1,0 +1,230 @@
+"""CLI composition tests — validate + diff with multi-file composition."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from edictum.cli.main import cli
+
+# ---------------------------------------------------------------------------
+# Test fixtures — YAML bundles
+# ---------------------------------------------------------------------------
+
+BASE_BUNDLE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-base
+defaults:
+  mode: enforce
+contracts:
+  - id: rule-a
+    type: pre
+    tool: read_file
+    when:
+      args.path:
+        contains: ".secret"
+    then:
+      effect: deny
+      message: "Denied by rule-a"
+  - id: rule-b
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "rm"
+    then:
+      effect: deny
+      message: "Denied by rule-b"
+"""
+
+OVERRIDE_BUNDLE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-override
+defaults:
+  mode: enforce
+contracts:
+  - id: rule-a
+    type: pre
+    tool: read_file
+    when:
+      args.path:
+        contains_any: [".secret", ".pem"]
+    then:
+      effect: deny
+      message: "Denied by overridden rule-a"
+  - id: rule-c
+    type: post
+    tool: "*"
+    when:
+      output.text:
+        contains: "password"
+    then:
+      effect: warn
+      message: "Password detected"
+"""
+
+THIRD_BUNDLE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-third
+defaults:
+  mode: enforce
+contracts:
+  - id: rule-b
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "sudo"
+    then:
+      effect: deny
+      message: "Denied by overridden rule-b"
+  - id: rule-d
+    type: session
+    limits:
+      max_tool_calls: 100
+    then:
+      effect: deny
+      message: "Session limit"
+"""
+
+INVALID_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: broken
+defaults:
+  mode: enforce
+contracts:
+  - id: rule-x
+    type: pre
+    tool: bash
+    when:
+      args.command: { contains: "rm"
+    then:
+      effect: deny
+      message: "Broken YAML."
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. edictum validate — composition
+# ---------------------------------------------------------------------------
+
+
+class TestValidateComposition:
+    """Test validate command with multi-file composition."""
+
+    def test_validate_composed_result(self, tmp_path):
+        """edictum validate base.yaml override.yaml — validates composed result."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        override = tmp_path / "override.yaml"
+        override.write_text(OVERRIDE_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(base), str(override)])
+        assert result.exit_code == 0
+        assert "Composed" in result.output
+        # Composed: rule-a (overridden), rule-b (from base), rule-c (from override) = 3
+        assert "3 contracts" in result.output
+
+    def test_validate_shows_overrides(self, tmp_path):
+        """edictum validate with contract ID conflicts shows override info."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        override = tmp_path / "override.yaml"
+        override.write_text(OVERRIDE_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(base), str(override)])
+        assert result.exit_code == 0
+        assert "rule-a" in result.output
+        assert "overridden" in result.output.lower()
+
+    def test_validate_invalid_file_still_reports_error(self, tmp_path):
+        """Invalid YAML in one file still reports the error."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        invalid = tmp_path / "invalid.yaml"
+        invalid.write_text(INVALID_YAML)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(base), str(invalid)])
+        assert result.exit_code == 1
+
+    def test_validate_single_file_no_composition(self, tmp_path):
+        """Single file should not show composition info."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", str(base)])
+        assert result.exit_code == 0
+        assert "Composed" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# 2. edictum diff — composition
+# ---------------------------------------------------------------------------
+
+
+class TestDiffComposition:
+    """Test diff command with multi-file composition."""
+
+    def test_diff_two_files_shows_composition(self, tmp_path):
+        """edictum diff base.yaml override.yaml shows both diff and composition report."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        override = tmp_path / "override.yaml"
+        override.write_text(OVERRIDE_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diff", str(base), str(override)])
+        assert result.exit_code == 1
+        # Standard diff: rule-c added, rule-b removed, rule-a changed
+        assert "rule-c" in result.output
+        # Composition report
+        assert "overridden" in result.output.lower()
+        assert "rule-a" in result.output
+
+    def test_diff_three_files_shows_composition(self, tmp_path):
+        """edictum diff base.yaml override.yaml third.yaml shows composition report."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        override = tmp_path / "override.yaml"
+        override.write_text(OVERRIDE_BUNDLE)
+        third = tmp_path / "third.yaml"
+        third.write_text(THIRD_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diff", str(base), str(override), str(third)])
+        assert result.exit_code == 1
+        # Composition report: rule-a overridden by override, rule-b overridden by third
+        assert "overridden" in result.output.lower()
+        assert "rule-a" in result.output
+        assert "rule-b" in result.output
+
+    def test_diff_invalid_file_reports_error(self, tmp_path):
+        """Invalid YAML in one of the diff files reports error."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+        invalid = tmp_path / "invalid.yaml"
+        invalid.write_text(INVALID_YAML)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diff", str(base), str(invalid)])
+        assert result.exit_code != 0
+
+    def test_diff_requires_at_least_two_files(self, tmp_path):
+        """diff with only 1 file should error."""
+        base = tmp_path / "base.yaml"
+        base.write_text(BASE_BUNDLE)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diff", str(base)])
+        assert result.exit_code != 0

--- a/tests/test_observe_alongside.py
+++ b/tests/test_observe_alongside.py
@@ -1,0 +1,277 @@
+"""Tests for observe_alongside dual-mode evaluation."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, EdictumDenied
+from edictum.audit import AuditAction
+
+# ---------------------------------------------------------------------------
+# YAML fixtures (written to tmp_path at test time)
+# ---------------------------------------------------------------------------
+
+ENFORCED_BUNDLE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: enforced-policy
+defaults:
+  mode: enforce
+contracts:
+  - id: block-env-reads
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".env" }
+    then:
+      effect: deny
+      message: "Blocked read of .env file"
+  - id: session-limit
+    type: session
+    limits:
+      max_tool_calls: 100
+    then:
+      effect: deny
+      message: "Session limit reached (enforced)"
+"""
+
+CANDIDATE_BUNDLE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: candidate-policy
+defaults:
+  mode: enforce
+observe_alongside: true
+contracts:
+  - id: block-env-reads
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".secret" }
+    then:
+      effect: deny
+      message: "Blocked read of .secret file"
+  - id: new-shadow-only
+    type: pre
+    tool: "*"
+    when:
+      args.cmd: { contains: "rm -rf" }
+    then:
+      effect: deny
+      message: "Dangerous rm command blocked"
+  - id: session-limit
+    type: session
+    limits:
+      max_tool_calls: 5
+    then:
+      effect: deny
+      message: "Session limit reached (candidate)"
+"""
+
+
+class _CaptureSink:
+    """Audit sink that captures events for test assertions."""
+
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event):
+        self.events.append(event)
+
+
+def _write_bundles(tmp_path):
+    """Write enforced and candidate YAML bundles and return their paths."""
+    enforced = tmp_path / "enforced.yaml"
+    enforced.write_text(ENFORCED_BUNDLE)
+    candidate = tmp_path / "candidate.yaml"
+    candidate.write_text(CANDIDATE_BUNDLE)
+    return enforced, candidate
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestShadowAuditEvents:
+    """Shadow evaluation produces separate audit events with mode='observe'."""
+
+    async def test_shadow_produces_observe_audit_events(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # read_file with .secret triggers the shadow contract but not the enforced one
+        result = await guard.run(
+            "read_file",
+            {"path": "/home/config.secret"},
+            lambda path: f"contents of {path}",
+        )
+        assert result == "contents of /home/config.secret"
+
+        # Check for shadow audit events with mode="observe"
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        assert len(shadow_events) >= 1
+
+        # The shadow denial should have CALL_WOULD_DENY
+        shadow_deny = [e for e in shadow_events if e.action == AuditAction.CALL_WOULD_DENY]
+        assert len(shadow_deny) >= 1
+        assert "block-env-reads:candidate" in shadow_deny[0].decision_name
+
+
+class TestShadowDoesNotBlockRealCalls:
+    """Shadow contracts don't block real calls — PreDecision still allows."""
+
+    async def test_shadow_deny_does_not_block(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # .secret would be denied by the candidate but NOT by the enforced bundle
+        result = await guard.run(
+            "read_file",
+            {"path": "/home/data.secret"},
+            lambda path: f"contents of {path}",
+        )
+        assert "contents of /home/data.secret" == result
+
+    async def test_enforced_contract_still_denies(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # .env should still be denied by the enforced contract
+        with pytest.raises(EdictumDenied, match="Blocked read of .env file"):
+            await guard.run(
+                "read_file",
+                {"path": "/home/.env"},
+                lambda path: f"contents of {path}",
+            )
+
+
+class TestShadowSessionContracts:
+    """Shadow session contracts track counters independently."""
+
+    async def test_shadow_session_evaluates_against_real_counters(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # The candidate has max_tool_calls=5, enforced has 100
+        # After 5 calls, the shadow session contract should report would-deny
+        # but the real session should still allow
+        for _ in range(6):
+            await guard.run(
+                "some_tool",
+                {"data": "test"},
+                lambda data: "ok",
+            )
+
+        # All calls should succeed (enforced limit is 100)
+        # But we should see shadow audit events after the 5th call
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        # Shadow session contract events should appear
+        assert len(shadow_events) > 0
+
+
+class TestShadowWithoutEnforcedCounterpart:
+    """observe_alongside with new contract ID (no enforced counterpart) — shadow still evaluates."""
+
+    async def test_new_shadow_only_contract(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # new-shadow-only:candidate should trigger for rm -rf
+        result = await guard.run(
+            "bash",
+            {"cmd": "rm -rf /"},
+            lambda cmd: "done",
+        )
+        assert result == "done"  # Not blocked — shadow only
+
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        shadow_deny = [e for e in shadow_events if e.action == AuditAction.CALL_WOULD_DENY]
+        rm_events = [e for e in shadow_deny if "new-shadow-only:candidate" in (e.decision_name or "")]
+        assert len(rm_events) >= 1
+
+
+class TestShadowAuditActions:
+    """Shadow audit events use CALL_WOULD_DENY / CALL_ALLOWED actions."""
+
+    async def test_shadow_pass_uses_call_allowed(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # A call that passes both enforced and shadow
+        await guard.run(
+            "some_tool",
+            {"data": "safe"},
+            lambda data: "ok",
+        )
+
+        # Shadow events that pass should use CALL_ALLOWED
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        # The new-shadow-only contract matches tool="*" but only triggers on rm -rf
+        # So it should pass and produce a CALL_ALLOWED shadow event
+        assert any(e.action == AuditAction.CALL_ALLOWED for e in shadow_events)
+
+    async def test_shadow_fail_uses_call_would_deny(self, tmp_path):
+        enforced_path, candidate_path = _write_bundles(tmp_path)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
+
+        # Trigger the shadow but not the enforced
+        await guard.run(
+            "read_file",
+            {"path": "/home/app.secret"},
+            lambda path: "data",
+        )
+
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        assert any(e.action == AuditAction.CALL_WOULD_DENY for e in shadow_events)
+
+
+class TestNormalContractsRegression:
+    """Normal contracts still work exactly as before (regression)."""
+
+    async def test_enforced_deny_unchanged(self, tmp_path):
+        enforced_path = tmp_path / "enforced.yaml"
+        enforced_path.write_text(ENFORCED_BUNDLE)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, audit_sink=sink)
+
+        with pytest.raises(EdictumDenied, match="Blocked read of .env file"):
+            await guard.run(
+                "read_file",
+                {"path": "/home/.env"},
+                lambda path: "contents",
+            )
+
+    async def test_enforced_allow_unchanged(self, tmp_path):
+        enforced_path = tmp_path / "enforced.yaml"
+        enforced_path.write_text(ENFORCED_BUNDLE)
+        sink = _CaptureSink()
+        guard = Edictum.from_yaml(enforced_path, audit_sink=sink)
+
+        result = await guard.run(
+            "read_file",
+            {"path": "/home/readme.md"},
+            lambda path: f"contents of {path}",
+        )
+        assert result == "contents of /home/readme.md"
+
+        # No shadow events when there's no candidate bundle
+        shadow_events = [e for e in sink.events if e.mode == "observe"]
+        assert len(shadow_events) == 0
+
+    async def test_no_shadow_lists_without_candidate(self, tmp_path):
+        enforced_path = tmp_path / "enforced.yaml"
+        enforced_path.write_text(ENFORCED_BUNDLE)
+        guard = Edictum.from_yaml(enforced_path)
+        assert guard._shadow_preconditions == []
+        assert guard._shadow_postconditions == []
+        assert guard._shadow_session_contracts == []

--- a/tests/test_yaml_engine/test_composer.py
+++ b/tests/test_yaml_engine/test_composer.py
@@ -1,0 +1,408 @@
+"""Tests for bundle composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum.yaml_engine.composer import (
+    ComposedBundle,
+    CompositionReport,
+    compose_bundles,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _base_bundle(**overrides) -> dict:
+    """Minimal valid bundle dict."""
+    b = {
+        "apiVersion": "edictum/v1",
+        "kind": "ContractBundle",
+        "metadata": {"name": "base"},
+        "defaults": {"mode": "enforce"},
+        "contracts": [],
+    }
+    b.update(overrides)
+    return b
+
+
+def _contract(cid: str, ctype: str = "pre", **extra) -> dict:
+    """Minimal contract dict."""
+    c: dict = {"id": cid, "type": ctype}
+    if ctype in ("pre", "post"):
+        c.setdefault("tool", "*")
+        c.setdefault("when", {"tool.name": {"exists": True}})
+        c.setdefault("then", {"effect": "deny" if ctype == "pre" else "warn", "message": f"msg-{cid}"})
+    elif ctype == "session":
+        c.setdefault("limits", {"max_tool_calls": 100})
+        c.setdefault("then", {"effect": "deny", "message": f"msg-{cid}"})
+    c.update(extra)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# compose_bundles() — basic
+# ---------------------------------------------------------------------------
+
+
+class TestComposeBundlesBasic:
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            compose_bundles()
+
+    def test_single_bundle_passthrough(self):
+        b = _base_bundle(contracts=[_contract("a")])
+        result = compose_bundles((b, "base.yaml"))
+        assert isinstance(result, ComposedBundle)
+        assert result.bundle["contracts"][0]["id"] == "a"
+        assert result.report == CompositionReport()
+
+    def test_single_bundle_is_a_copy(self):
+        b = _base_bundle(contracts=[_contract("a")])
+        result = compose_bundles((b, "base.yaml"))
+        # Mutating result should not affect original
+        result.bundle["contracts"][0]["id"] = "mutated"
+        assert b["contracts"][0]["id"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# Contract merge rules
+# ---------------------------------------------------------------------------
+
+
+class TestContractMerge:
+    def test_same_id_replacement(self):
+        base = _base_bundle(contracts=[_contract("deny-rm", then={"effect": "deny", "message": "old"})])
+        override = _base_bundle(contracts=[_contract("deny-rm", then={"effect": "deny", "message": "new"})])
+
+        result = compose_bundles((base, "base.yaml"), (override, "override.yaml"))
+        contracts = result.bundle["contracts"]
+
+        assert len(contracts) == 1
+        assert contracts[0]["then"]["message"] == "new"
+
+    def test_same_id_reports_override(self):
+        base = _base_bundle(contracts=[_contract("deny-rm")])
+        override = _base_bundle(contracts=[_contract("deny-rm")])
+
+        result = compose_bundles((base, "base.yaml"), (override, "override.yaml"))
+
+        assert len(result.report.overridden_contracts) == 1
+        ov = result.report.overridden_contracts[0]
+        assert ov.contract_id == "deny-rm"
+        assert ov.overridden_by == "override.yaml"
+        assert ov.original_source == "base.yaml"
+
+    def test_unique_id_concatenation(self):
+        base = _base_bundle(contracts=[_contract("a")])
+        layer = _base_bundle(contracts=[_contract("b")])
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["a", "b"]
+        assert len(result.report.overridden_contracts) == 0
+
+    def test_mixed_replace_and_append(self):
+        base = _base_bundle(contracts=[_contract("a"), _contract("b")])
+        layer = _base_bundle(contracts=[_contract("b"), _contract("c")])
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["a", "b", "c"]
+        assert len(result.report.overridden_contracts) == 1
+        assert result.report.overridden_contracts[0].contract_id == "b"
+
+    def test_three_layers_last_wins(self):
+        b1 = _base_bundle(contracts=[_contract("x", then={"effect": "deny", "message": "v1"})])
+        b2 = _base_bundle(contracts=[_contract("x", then={"effect": "deny", "message": "v2"})])
+        b3 = _base_bundle(contracts=[_contract("x", then={"effect": "deny", "message": "v3"})])
+
+        result = compose_bundles((b1, "l1"), (b2, "l2"), (b3, "l3"))
+        assert result.bundle["contracts"][0]["then"]["message"] == "v3"
+        assert len(result.report.overridden_contracts) == 2
+
+
+# ---------------------------------------------------------------------------
+# defaults.mode merge
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsMerge:
+    def test_later_mode_wins(self):
+        base = _base_bundle()
+        base["defaults"]["mode"] = "enforce"
+        override = _base_bundle()
+        override["defaults"]["mode"] = "observe"
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["defaults"]["mode"] == "observe"
+
+    def test_first_mode_preserved_if_later_omits(self):
+        base = _base_bundle()
+        base["defaults"]["mode"] = "observe"
+        layer = _base_bundle()
+        # layer has defaults.mode = "enforce" by helper default, override it
+        del layer["defaults"]["mode"]
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        assert result.bundle["defaults"]["mode"] == "observe"
+
+    def test_environment_later_wins(self):
+        base = _base_bundle()
+        base["defaults"]["environment"] = "staging"
+        override = _base_bundle()
+        override["defaults"]["environment"] = "production"
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["defaults"]["environment"] == "production"
+
+
+# ---------------------------------------------------------------------------
+# limits merge
+# ---------------------------------------------------------------------------
+
+
+class TestLimitsMerge:
+    def test_later_limits_replace_entirely(self):
+        base = _base_bundle()
+        base["limits"] = {"max_tool_calls": 50, "max_attempts": 200}
+        override = _base_bundle()
+        override["limits"] = {"max_tool_calls": 10}
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["limits"] == {"max_tool_calls": 10}
+        assert "max_attempts" not in result.bundle["limits"]
+
+
+# ---------------------------------------------------------------------------
+# tools merge (deep)
+# ---------------------------------------------------------------------------
+
+
+class TestToolsMerge:
+    def test_deep_merge_combines_tools(self):
+        base = _base_bundle()
+        base["tools"] = {"read_file": {"side_effect": "read"}}
+        override = _base_bundle()
+        override["tools"] = {"write_file": {"side_effect": "write"}}
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert "read_file" in result.bundle["tools"]
+        assert "write_file" in result.bundle["tools"]
+
+    def test_deep_merge_later_overrides_same_tool(self):
+        base = _base_bundle()
+        base["tools"] = {"run": {"side_effect": "read"}}
+        override = _base_bundle()
+        override["tools"] = {"run": {"side_effect": "irreversible"}}
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["tools"]["run"]["side_effect"] == "irreversible"
+
+
+# ---------------------------------------------------------------------------
+# metadata merge (deep)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataMerge:
+    def test_deep_merge_metadata(self):
+        base = _base_bundle()
+        base["metadata"] = {"name": "base", "author": "alice"}
+        override = _base_bundle()
+        override["metadata"] = {"name": "composed", "version": "2"}
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["metadata"]["name"] == "composed"
+        assert result.bundle["metadata"]["author"] == "alice"
+        assert result.bundle["metadata"]["version"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# observability merge
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityMerge:
+    def test_later_observability_wins(self):
+        base = _base_bundle()
+        base["observability"] = {"stdout": True}
+        override = _base_bundle()
+        override["observability"] = {"file": "audit.jsonl"}
+
+        result = compose_bundles((base, "base"), (override, "override"))
+        assert result.bundle["observability"] == {"file": "audit.jsonl"}
+        assert "stdout" not in result.bundle["observability"]
+
+
+# ---------------------------------------------------------------------------
+# observe_alongside
+# ---------------------------------------------------------------------------
+
+
+class TestObserveAlongside:
+    def test_shadow_contracts_added_with_candidate_suffix(self):
+        base = _base_bundle(contracts=[_contract("pharma")])
+        candidate = _base_bundle(contracts=[_contract("pharma")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert "pharma" in ids
+        assert "pharma:candidate" in ids
+        assert len(ids) == 2
+
+    def test_shadow_contract_forced_to_observe_mode(self):
+        base = _base_bundle(contracts=[_contract("pharma")])
+        candidate = _base_bundle(contracts=[_contract("pharma")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        shadow = [c for c in result.bundle["contracts"] if c["id"] == "pharma:candidate"][0]
+        assert shadow["mode"] == "observe"
+        assert shadow["_shadow"] is True
+
+    def test_shadow_contract_report(self):
+        base = _base_bundle(contracts=[_contract("pharma")])
+        candidate = _base_bundle(contracts=[_contract("pharma")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        assert len(result.report.shadow_contracts) == 1
+        sc = result.report.shadow_contracts[0]
+        assert sc.contract_id == "pharma"
+        assert sc.enforced_source == "base"
+        assert sc.observed_source == "candidate"
+
+    def test_observe_alongside_does_not_replace_enforced(self):
+        base = _base_bundle(contracts=[_contract("pharma", then={"effect": "deny", "message": "original"})])
+        candidate = _base_bundle(contracts=[_contract("pharma", then={"effect": "deny", "message": "candidate"})])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        enforced = [c for c in result.bundle["contracts"] if c["id"] == "pharma"][0]
+        assert enforced["then"]["message"] == "original"
+        assert len(result.report.overridden_contracts) == 0
+
+    def test_observe_alongside_new_contract_no_enforced_counterpart(self):
+        base = _base_bundle(contracts=[_contract("existing")])
+        candidate = _base_bundle(contracts=[_contract("brand-new")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert "existing" in ids
+        assert "brand-new:candidate" in ids
+
+        sc = result.report.shadow_contracts[0]
+        assert sc.contract_id == "brand-new"
+        assert sc.enforced_source == ""  # no enforced counterpart
+
+    def test_observe_alongside_session_contract_gets_candidate_id(self):
+        base = _base_bundle(contracts=[_contract("limits", ctype="session")])
+        candidate = _base_bundle(contracts=[_contract("limits", ctype="session")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert "limits" in ids
+        assert "limits:candidate" in ids
+
+    def test_mixed_standard_and_observe_alongside(self):
+        base = _base_bundle(contracts=[_contract("a"), _contract("b")])
+        override = _base_bundle(contracts=[_contract("a", then={"effect": "deny", "message": "replaced"})])
+        candidate = _base_bundle(contracts=[_contract("b")])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (override, "override"), (candidate, "candidate"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["a", "b", "b:candidate"]
+        assert len(result.report.overridden_contracts) == 1
+        assert len(result.report.shadow_contracts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Edge cases from test review
+# ---------------------------------------------------------------------------
+
+
+class TestComposerEdgeCases:
+    """P0/P1 edge cases found by test review."""
+
+    def test_multi_bundle_originals_not_mutated(self):
+        """compose_bundles must not mutate the original bundle dicts."""
+        base = _base_bundle(contracts=[_contract("a")])
+        override = _base_bundle(contracts=[_contract("a", then={"effect": "deny", "message": "new"})])
+        original_base_msg = base["contracts"][0]["then"]["message"]
+
+        compose_bundles((base, "base"), (override, "override"))
+
+        # Originals untouched
+        assert base["contracts"][0]["then"]["message"] == original_base_msg
+        assert override["contracts"][0]["then"]["message"] == "new"
+
+    def test_observe_alongside_false_behaves_as_standard(self):
+        """observe_alongside: false should merge normally (replace by ID)."""
+        base = _base_bundle(contracts=[_contract("x", then={"effect": "deny", "message": "old"})])
+        layer = _base_bundle(contracts=[_contract("x", then={"effect": "deny", "message": "new"})])
+        layer["observe_alongside"] = False
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["x"]
+        assert result.bundle["contracts"][0]["then"]["message"] == "new"
+        assert len(result.report.shadow_contracts) == 0
+        assert len(result.report.overridden_contracts) == 1
+
+    def test_empty_contracts_list_in_overlay(self):
+        """Layer with empty contracts list — should not crash, no overrides."""
+        base = _base_bundle(contracts=[_contract("a")])
+        layer = _base_bundle(contracts=[])
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["a"]
+        assert len(result.report.overridden_contracts) == 0
+
+    def test_empty_contracts_in_base(self):
+        """Base with empty contracts, layer adds new ones."""
+        base = _base_bundle(contracts=[])
+        layer = _base_bundle(contracts=[_contract("new-rule")])
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["new-rule"]
+
+    def test_observe_alongside_with_empty_contracts(self):
+        """observe_alongside bundle with no contracts — no shadows, no crash."""
+        base = _base_bundle(contracts=[_contract("a")])
+        candidate = _base_bundle(contracts=[])
+        candidate["observe_alongside"] = True
+
+        result = compose_bundles((base, "base"), (candidate, "candidate"))
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert ids == ["a"]
+        assert len(result.report.shadow_contracts) == 0
+
+    def test_observe_alongside_as_first_bundle(self):
+        """observe_alongside as the first bundle (unusual but valid)."""
+        candidate = _base_bundle(contracts=[_contract("x")])
+        candidate["observe_alongside"] = True
+        normal = _base_bundle(contracts=[_contract("y")])
+
+        result = compose_bundles((candidate, "candidate"), (normal, "normal"))
+        # First bundle is copied as-is (no observe_alongside processing on first bundle)
+        ids = [c["id"] for c in result.bundle["contracts"]]
+        assert "x" in ids
+        assert "y" in ids
+
+    def test_layer_without_defaults_key(self):
+        """Layer missing 'defaults' entirely should not crash."""
+        base = _base_bundle()
+        base["defaults"]["mode"] = "observe"
+        layer = _base_bundle(contracts=[_contract("b")])
+        del layer["defaults"]
+
+        result = compose_bundles((base, "base"), (layer, "layer"))
+        assert result.bundle["defaults"]["mode"] == "observe"


### PR DESCRIPTION
## Summary

- **`compose_bundles()`** — low-level primitive that merges parsed YAML bundles left-to-right with deterministic merge semantics (replace-by-ID, deep merge tools/metadata, later-wins for defaults/limits/observability)
- **`observe_alongside: true`** — dual-mode evaluation where shadow contracts evaluate in parallel without affecting real decisions, producing separate audit events with `mode: "observe"`
- **`from_yaml(*paths)`** — extended API accepting multiple YAML files with automatic composition and optional `return_report=True` for `CompositionReport`
- **CLI support** — `edictum validate` and `edictum diff` support multi-file composition with override/shadow reports

## Changes

| File | Change |
|------|--------|
| `yaml_engine/composer.py` | New — `compose_bundles()`, dataclasses, merge logic |
| `yaml_engine/__init__.py` | Export new composition symbols |
| `yaml_engine/compiler.py` | Stamp `_edictum_shadow` on shadow contracts |
| `yaml_engine/edictum-v1.schema.json` | Add optional `observe_alongside` boolean |
| `pipeline.py` | Shadow contract evaluation in `_evaluate_shadow_contracts()` |
| `__init__.py` | `from_yaml(*paths)`, shadow routing, shadow audit emission |
| `cli/main.py` | Multi-file validate composition, diff composition report |

## Test plan

- [x] 886 tests pass (`pytest tests/ -v`)
- [x] `ruff check src/ tests/` clean
- [x] Single-path `from_yaml("file.yaml")` backward compatible
- [x] `from_template()` backward compatible
- [x] `evaluate()` dry-run excludes shadow contracts
- [x] Shadow evaluation produces separate audit events, never blocks real calls
- [x] Edge cases: empty bundles, Path objects, nonexistent files, observe_alongside=false
- [x] Schema stays `edictum/v1` — `observe_alongside` is additive only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two major capabilities: **multi-file bundle composition** via `compose_bundles()` and **dual-mode shadow evaluation** via `observe_alongside: true`.

**Key Changes:**
- `compose_bundles()` merges multiple YAML bundles left-to-right with deterministic semantics: replace-by-ID for contracts, deep merge for tools/metadata, later-wins for defaults/limits/observability
- `observe_alongside: true` creates shadow contracts (suffixed `:candidate`) that evaluate in parallel without blocking real calls, emitting separate audit events with `mode: "observe"`
- `from_yaml(*paths)` now accepts multiple paths and returns optional `CompositionReport` showing overrides and shadows
- CLI commands (`validate`, `diff`) support multi-file composition with reporting
- Shadow contracts are stamped with `_edictum_shadow=True` and routed to separate lists during registration
- `_evaluate_shadow_contracts()` evaluates shadows after real contracts, results never affect the allow/deny decision
- Schema remains `edictum/v1` with additive-only `observe_alongside` field

**Implementation Quality:**
- Clean separation: composition (composer.py) → compilation (compiler.py) → registration (__init__.py) → evaluation (pipeline.py)
- Backward compatible: single-path `from_yaml()` unchanged, `observe_alongside=false` is default
- Comprehensive test coverage: 886 tests passing, edge cases covered (empty bundles, Path objects, nonexistent files)
- Shadow session contracts excluded from real limits merge (compiler.py:214-216)
- Proper error handling with try/except in shadow evaluation

**Minor Observations:**
- Shadow postconditions are not yet implemented (only preconditions and session contracts evaluate in shadow mode)
- Combined policy version hash uses simple string concatenation which is fine for determinism

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence - well-tested, backward compatible, clean architecture
- Score reflects comprehensive test coverage (886 tests), backward compatibility guarantees, deterministic merge semantics, proper error handling in shadow evaluation, and clean architectural separation. The implementation follows existing code conventions (frozen dataclasses, type hints, async/await). No security issues, breaking changes, or logical errors identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/yaml_engine/composer.py | New bundle composition engine with deterministic merge semantics, shadow contract support, and composition reporting |
| src/edictum/__init__.py | Extended `from_yaml()` to accept multiple paths with composition, added shadow contract registration and audit emission |
| src/edictum/pipeline.py | Added `_evaluate_shadow_contracts()` to evaluate shadow preconditions/session contracts in parallel without blocking |
| src/edictum/yaml_engine/compiler.py | Stamped `_edictum_shadow` attribute on contracts with `_shadow=True`, excluded shadow session contracts from limits |
| src/edictum/cli/main.py | Extended `validate` and `diff` commands to support multi-file composition with composition reports |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[from_yaml path1, path2] --> B[load_bundle for each path]
    B --> C{Single path?}
    C -->|Yes| D[Use bundle as-is]
    C -->|No| E[compose_bundles]
    E --> F{Check observe_alongside}
    F -->|false| G[_merge_standard]
    F -->|true| H[_merge_observe_alongside]
    G --> I[Replace contracts by ID<br/>Deep merge tools/metadata]
    H --> J[Create shadow contracts<br/>ID suffix :candidate<br/>Set _shadow=true]
    I --> K[ComposedBundle + Report]
    J --> K
    D --> L[compile_contracts]
    K --> L
    L --> M[Stamp _edictum_shadow<br/>on shadow contracts]
    M --> N[Register contracts]
    N --> O{Contract type}
    O -->|_edictum_shadow=true| P[_shadow_preconditions<br/>_shadow_postconditions<br/>_shadow_session_contracts]
    O -->|_edictum_shadow=false| Q[_preconditions<br/>_postconditions<br/>_session_contracts]
    P --> R[evaluate call]
    Q --> R
    R --> S[pre_execute pipeline]
    S --> T[Evaluate real contracts]
    T --> U[_evaluate_shadow_contracts]
    U --> V[Evaluate shadow contracts<br/>Never block calls]
    V --> W[Return shadow_results]
    W --> X[Emit shadow audit events<br/>mode=observe<br/>CALL_WOULD_DENY or CALL_ALLOWED]
    T --> Y[Real decision: allow/deny]
    Y --> Z[Emit real audit events]
```

<sub>Last reviewed commit: d7feb06</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->