### PR TITLE
fix: RedactionPolicy sensitive_keys merges with defaults

### DIFF
--- a/docs/audit/sinks.md
+++ b/docs/audit/sinks.md
@@ -298,7 +298,7 @@ dropping events due to oversized payloads.
 from edictum.audit import RedactionPolicy
 
 policy = RedactionPolicy(
-    sensitive_keys={"my_custom_key", "internal_token"},  # merged with defaults via substring matching
+    sensitive_keys={"my_custom_key", "internal_token"},  # merged with defaults (union)
     custom_patterns=[
         (r"(MY_PREFIX_)\S+", r"\1[REDACTED]"),           # custom regex substitutions
     ],

--- a/src/edictum/audit.py
+++ b/src/edictum/audit.py
@@ -126,7 +126,7 @@ class RedactionPolicy:
         custom_patterns: list[tuple[str, str]] | None = None,
         detect_secret_values: bool = True,
     ):
-        base_keys = sensitive_keys or self.DEFAULT_SENSITIVE_KEYS
+        base_keys = self.DEFAULT_SENSITIVE_KEYS | sensitive_keys if sensitive_keys else self.DEFAULT_SENSITIVE_KEYS
         self._keys = {k.lower() for k in base_keys}
         self._patterns = (custom_patterns or []) + self.BASH_REDACTION_PATTERNS
         self._detect_values = detect_secret_values


### PR DESCRIPTION
## Summary
- Custom `sensitive_keys` passed to `RedactionPolicy` replaced `DEFAULT_SENSITIVE_KEYS` instead of merging with them
- Keys like `authorization` that aren't caught by substring matching leaked through when custom keys were provided
- Docs comment at `sinks.md:301` said "merged" but code did replacement — now both are correct

## Root Cause
`audit.py:129` used `sensitive_keys or self.DEFAULT_SENSITIVE_KEYS` — Python's `or` returns the first truthy operand, so a non-empty custom set completely replaced the defaults. Keys only caught by exact match (not by substring matching in `_is_sensitive_key`) would leak.

## Fix
Changed to `self.DEFAULT_SENSITIVE_KEYS | sensitive_keys if sensitive_keys else self.DEFAULT_SENSITIVE_KEYS` (set union). Updated docs comment from "merged with defaults via substring matching" to "merged with defaults (union)" to accurately describe the mechanism.

## Test Plan
- [x] Behavior test `test_default_authorization_key_preserved_with_custom` now passes (was failing)
- [x] All 7 redaction behavior tests pass
- [x] Full test suite: 919 passed, 4 pre-existing failures (unrelated)
- [x] Lint passes (`ruff check`)
- [x] Docs build passes (`mkdocs build --strict`)
- [x] Docs-code sync passes (pre-existing `pii.py` reference failure only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical security bug where custom `sensitive_keys` replaced defaults instead of merging, causing keys like `authorization` to leak through redaction when custom keys were provided. Changed implementation from Python's `or` operator to explicit set union (`|`), and updated docs to accurately describe the merge behavior.

- Changed `audit.py:129` from `sensitive_keys or self.DEFAULT_SENSITIVE_KEYS` to `self.DEFAULT_SENSITIVE_KEYS | sensitive_keys if sensitive_keys else self.DEFAULT_SENSITIVE_KEYS`
- Updated `sinks.md:301` comment from "merged with defaults via substring matching" to "merged with defaults (union)" to reflect actual implementation
- Behavior test `test_default_authorization_key_preserved_with_custom` now passes (was failing before)
- All 7 redaction behavior tests pass, verifying that both default and custom keys are redacted correctly

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix directly addresses a documented security bug using the correct set union operator, includes comprehensive behavior tests that now pass, and aligns with the project's API design checklist requirement for documented merge semantics. The change is minimal (one line of code logic, one comment), the fix is idiomatic Python, and all tests pass
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/audit.py | Fixed set union logic to correctly merge custom sensitive_keys with defaults, preventing security leak |
| docs/audit/sinks.md | Updated comment to accurately reflect union merge semantics instead of misleading substring matching claim |

</details>


</details>


<sub>Last reviewed commit: e8ed40c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->