### PR TITLE
fix: raise NotImplementedError when TTL passed to MemoryBackend.set()

### DIFF
--- a/src/edictum/storage.py
+++ b/src/edictum/storage.py
@@ -42,6 +42,8 @@ class MemoryBackend:
         return None
 
     async def set(self, key: str, value: str, ttl: int | None = None) -> None:
+        if ttl is not None:
+            raise NotImplementedError("MemoryBackend does not support TTL")
         self._data[key] = value
 
     async def delete(self, key: str) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -66,7 +66,12 @@ class TestMemoryBackend:
         # Counter store has the number
         assert backend._counters["key1"] == 10
 
-    async def test_ttl_accepted_but_ignored(self, backend):
-        """TTL is accepted but not enforced in MemoryBackend."""
-        await backend.set("key1", "value1", ttl=60)
+    async def test_ttl_raises_not_implemented(self, backend):
+        """TTL raises NotImplementedError in MemoryBackend."""
+        with pytest.raises(NotImplementedError, match="does not support TTL"):
+            await backend.set("key1", "value1", ttl=60)
+
+    async def test_set_without_ttl_works(self, backend):
+        """set() without ttl still works normally."""
+        await backend.set("key1", "value1")
         assert await backend.get("key1") == "value1"


### PR DESCRIPTION
## Summary
- MemoryBackend.set() accepted a `ttl` parameter but silently ignored it, causing time-windowed session limits to never expire
- Now raises `NotImplementedError` so users get explicit feedback

## Root Cause
`set()` matched the `StorageBackend` protocol signature (which includes `ttl`) but had no implementation — the parameter was accepted and discarded without error.

## Fix
Added a guard at the top of `MemoryBackend.set()` that raises `NotImplementedError("MemoryBackend does not support TTL")` when `ttl is not None`. Updated existing unit test from `test_ttl_accepted_but_ignored` to `test_ttl_raises_not_implemented`.

## Test Plan
- [x] Behavior test in `tests/test_behavior/test_storage_behavior.py` covers the TTL parameter
- [x] Unit test `test_ttl_raises_not_implemented` verifies the error
- [x] Unit test `test_set_without_ttl_works` confirms normal path unaffected
- [x] Full test suite passes (921 passed, 3 pre-existing failures unrelated to this change)
- [x] Lint passes (`ruff check`)
- [x] Docs build passes (`mkdocs build --strict`)
- [x] Pre-commit hooks pass (ruff, ruff-format, check-terminology)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed silent acceptance of `ttl` parameter in `MemoryBackend.set()` by adding a guard that raises `NotImplementedError` when TTL is passed. This prevents a correctness bug where users might expect time-windowed session limits to work when they don't.

- Added `NotImplementedError` guard at the top of `MemoryBackend.set()` in src/edictum/storage.py:45-46
- Updated unit test from `test_ttl_accepted_but_ignored` to `test_ttl_raises_not_implemented` to verify the new behavior
- Added `test_set_without_ttl_works` to ensure normal operation without TTL is unaffected
- Behavior test in `tests/test_behavior/test_storage_behavior.py` already covers this requirement
- Change aligns with CLAUDE.md API Design Checklist: "Every accepted parameter has an observable effect. If the parameter is in the signature, there must be a test proving it changes behavior. If unimplemented, raise NotImplementedError — never silently ignore."

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a simple, well-tested bug fix with clear behavior change, comprehensive test coverage (unit tests + behavior tests), and alignment with documented API design principles. The change is minimal (2 lines of production code), defensive in nature (prevents silent failures), and all tests pass.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/storage.py | Added TTL guard to prevent silent failures, correctly raises NotImplementedError when TTL is passed |
| tests/test_storage.py | Updated unit tests to verify TTL raises NotImplementedError and normal operation without TTL works correctly |

</details>


</details>


<sub>Last reviewed commit: 9e439b3</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e37a8046-77ec-4289-8d92-6c2e2896a820))

<!-- /greptile_comment -->