### PR TITLE
fix: OpenAI output guardrail enforces postcondition effect=deny

### DIFF
--- a/docs/adapters/openai-agents.md
+++ b/docs/adapters/openai-agents.md
@@ -39,10 +39,12 @@ tool name and arguments from the guardrail data context. Returns
 `ToolGuardrailFunctionOutput.reject_content(reason)` to block it.
 
 **Output guardrail (post-execution)**: Fires after tool execution. Runs
-postconditions and records the execution in the session. The output guardrail
-always returns `ToolGuardrailFunctionOutput.allow()` -- post-execution
-evaluation produces audit events and warnings but does not block the response.
-The SDK does not support transforming the tool result from an output guardrail.
+postconditions and records the execution in the session. Postconditions with
+`effect: deny` on pure/read tools return
+`ToolGuardrailFunctionOutput.reject_content(reason)` to deny the output.
+All other postcondition results return `ToolGuardrailFunctionOutput.allow()`.
+The SDK does not support transforming the tool result from an output guardrail,
+so `effect: redact` requires the wrapper integration path.
 
 ## PII Redaction Callback
 

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -51,7 +51,7 @@ wrapper = adapter.as_tool_wrapper()
 | Agno | Yes (hook wraps execution) | Hook returns denial string |
 | Semantic Kernel | Yes (filter modifies FunctionResult) | Filter sets terminate + error |
 | Claude SDK | No (side-effect only) | Returns deny dict to SDK |
-| OpenAI Agents | No (side-effect only) | `reject_content(reason)` |
+| OpenAI Agents | Deny only (`reject_content`) | `reject_content(reason)` |
 
 For regulated environments requiring PII interception (not just detection), use
 LangChain, CrewAI, Agno, or Semantic Kernel.

--- a/docs/guides/adapter-comparison.md
+++ b/docs/guides/adapter-comparison.md
@@ -9,7 +9,7 @@ Edictum ships six framework adapters. This guide helps you choose the right one 
 | Framework | Integration Method | Can Redact Before LLM | Deny Mechanism | Cost (same task) |
 |-----------|-------------------|----------------------|----------------|-----------------|
 | LangChain | `as_tool_wrapper()` | Yes | Return "DENIED: reason" as ToolMessage | $0.025 |
-| OpenAI Agents | `as_guardrails()` | No (side-effect only) | `reject_content(reason)` | $0.018 |
+| OpenAI Agents | `as_guardrails()` | Deny only (`reject_content`) | `reject_content(reason)` | $0.018 |
 | CrewAI | `register()` | Yes (callback return replaces result) | before_hook returns False | $0.040 |
 | Agno | `as_tool_hook()` | Yes (hook wraps execution) | Hook returns denial string | N/A |
 | Semantic Kernel | `register(kernel)` | Yes (filter modifies FunctionResult) | Filter sets cancel + error | $0.008 |
@@ -134,4 +134,4 @@ hooks = adapter.to_hook_callables()
 
 ### OpenAI Agents (postcondition enforcement)
 
-- The output guardrail can only `.allow()` or `.reject_content()` -- it cannot substitute the tool result. Postcondition `redact`/`deny` effects set `PostCallResult.result` for wrapper consumers and invoke `on_postcondition_warn` callbacks, but the original result still reaches the model via the SDK. A warning is logged at adapter construction when postconditions declare these effects.
+- The output guardrail can `.allow()` or `.reject_content()` but cannot substitute the tool result. Postcondition `effect: deny` on pure/read tools returns `.reject_content()`, fully enforcing the denial. Postcondition `effect: redact` requires the wrapper integration path since the guardrail cannot transform the result. A warning is logged at adapter construction when postconditions declare `effect: redact`.

--- a/src/edictum/findings.py
+++ b/src/edictum/findings.py
@@ -66,6 +66,7 @@ class PostCallResult:
     result: Any  # the original tool result
     postconditions_passed: bool = True  # did all postconditions pass?
     findings: list[Finding] = field(default_factory=list)
+    output_suppressed: bool = False  # True when a postcondition with effect=deny fired
 
 
 def classify_finding(contract_id: str, verdict_message: str) -> str:


### PR DESCRIPTION
## Summary
- Output guardrail now returns `reject_content()` instead of always `allow()` when postconditions with `effect: deny` fail on pure/read tools

## Root Cause
`output_guardrail_fn` in `openai_agents.py` unconditionally returned `ToolGuardrailFunctionOutput.allow()` at line 134, ignoring the pipeline's `output_suppressed` signal from `PostDecision`. This meant postcondition denials silently degraded to warns on the guardrails path.

## Fix
- Added `output_suppressed: bool` field to `PostCallResult` to propagate the pipeline's suppress decision
- `_post()` now sets `output_suppressed` from `PostDecision.output_suppressed`
- `output_guardrail_fn` checks `post_result.output_suppressed` and returns `reject_content()` instead of `allow()`
- Narrowed construction-time warning to `effect=redact` only (since `effect=deny` is now natively enforced)
- Updated docs (adapter overview, comparison guide, OpenAI adapter page)

## Test Plan
- [x] Behavior test added: `test_postcondition_deny_output_guardrail_rejects` in `tests/test_behavior/test_enforcement_behavior.py`
- [x] Full test suite passes (920 passed, 4 pre-existing failures unrelated to this change)
- [x] Lint passes (`ruff check`)
- [x] Docs build passes (`mkdocs build --strict`)
- [x] Docs-code sync passes (pre-existing `pii.py` failure only)
- [x] No banned terminology in changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical bug where the OpenAI Agents output guardrail unconditionally returned `allow()` even when postconditions with `effect: deny` failed on pure/read tools. The fix propagates the pipeline's `output_suppressed` signal through `PostCallResult` so the guardrail can return `reject_content()` instead.

**Key changes:**
- Added `output_suppressed: bool = False` field to `PostCallResult` (backward-compatible with default value)
- `output_guardrail_fn` now checks `post_result.output_suppressed` and returns `reject_content()` when true
- Narrowed construction-time warning to only `effect=redact` (since `effect=deny` is now natively enforced)
- Updated adapter documentation to accurately reflect the new enforcement capability
- Added comprehensive behavior test that validates the fix end-to-end

**Impact:**
This change elevates the OpenAI Agents adapter from "side-effect only" to "Deny enforcement" for postconditions on pure/read tools, bringing it closer to parity with other adapters while respecting the SDK's constraint that output guardrails cannot transform results (only allow or reject).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is clean, focused, and backward-compatible. The new `output_suppressed` field has a default value so existing code continues to work. The fix is well-tested with a comprehensive behavior test, and all documentation is updated consistently. The change follows established patterns from the pipeline and aligns with the project's API design principles.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/findings.py | Added `output_suppressed` field to `PostCallResult` with default `False` - clean and backward-compatible |
| src/edictum/adapters/openai_agents.py | Implements postcondition `effect=deny` enforcement via `reject_content()`, updated warnings to be specific to `effect=redact` |
| tests/test_behavior/test_enforcement_behavior.py | Comprehensive behavior test validates output guardrail rejects when postcondition has `effect=deny` |

</details>


</details>


<sub>Last reviewed commit: ff5777c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->