### PR TITLE
fix: CrewAI double callback and boolean deny

### DIFF
--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -47,14 +47,14 @@ wrapper = adapter.as_tool_wrapper()
 | Framework | Can Redact Before LLM | Deny Mechanism |
 |-----------|----------------------|----------------|
 | LangChain | Yes | Return "DENIED: reason" as ToolMessage |
-| CrewAI | Yes (callback return replaces result) | before_hook returns False |
+| CrewAI | No (side-effect only) | before_hook returns "DENIED: reason" |
 | Agno | Yes (hook wraps execution) | Hook returns denial string |
 | Semantic Kernel | Yes (filter modifies FunctionResult) | Filter sets terminate + error |
 | Claude SDK | No (side-effect only) | Returns deny dict to SDK |
 | OpenAI Agents | Deny only (`reject_content`) | `reject_content(reason)` |
 
 For regulated environments requiring PII interception (not just detection), use
-LangChain, CrewAI, Agno, or Semantic Kernel.
+LangChain, Agno, or Semantic Kernel.
 
 ## Common Constructor
 

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -149,7 +149,7 @@ The callback behavior differs depending on whether the adapter controls tool exe
 | **LangChain** | Wrap-around | **Replaces** tool result — the LLM sees the callback return value |
 | **Agno** | Wrap-around | **Replaces** tool result |
 | **Semantic Kernel** | Filter | **Replaces** `context.function_result` |
-| **CrewAI** | Hook | **Replaces** tool result — callback return value replaces the original |
+| **CrewAI** | Hook | Side-effect only — return value ignored |
 | **Claude Agent SDK** | Hook | Side-effect only — return value ignored |
 | **OpenAI Agents SDK** | Guardrail | Side-effect only — return value ignored |
 
@@ -184,7 +184,7 @@ transformed result reaches the LLM depends on the framework:
 | Agno | `str` | Yes — return new string | Full |
 | Semantic Kernel | `str` (wrapped in `FunctionResult`) | Yes | Full |
 | OpenAI Agents | `str` | No — allow/reject only | Logged only |
-| CrewAI | `str` | Yes — via register() callback | Via callback |
+| CrewAI | `str` | No — side-effect only | Logged only |
 | Claude Agent SDK | `Any` | No — side-effect only | Logged only |
 
 For regulated environments requiring PII interception, use LangChain, Agno,

--- a/docs/guides/adapter-comparison.md
+++ b/docs/guides/adapter-comparison.md
@@ -10,7 +10,7 @@ Edictum ships six framework adapters. This guide helps you choose the right one 
 |-----------|-------------------|----------------------|----------------|-----------------|
 | LangChain | `as_tool_wrapper()` | Yes | Return "DENIED: reason" as ToolMessage | $0.025 |
 | OpenAI Agents | `as_guardrails()` | Deny only (`reject_content`) | `reject_content(reason)` | $0.018 |
-| CrewAI | `register()` | Yes (callback return replaces result) | before_hook returns False | $0.040 |
+| CrewAI | `register()` | No (side-effect only) | before_hook returns "DENIED: reason" | $0.040 |
 | Agno | `as_tool_hook()` | Yes (hook wraps execution) | Hook returns denial string | N/A |
 | Semantic Kernel | `register(kernel)` | Yes (filter modifies FunctionResult) | Filter sets cancel + error | $0.008 |
 | Claude SDK | `to_hook_callables()` | No (side-effect only) | Returns deny dict to SDK | N/A |
@@ -21,7 +21,7 @@ Cost column reflects benchmarks from [edictum-demo](https://github.com/acartag7/
 
 ## Which Adapter Should I Use?
 
-- **Need full PII interception?** -- Use LangChain, CrewAI, Agno, or Semantic Kernel. These adapters can replace the tool result before the LLM sees it.
+- **Need full PII interception?** -- Use LangChain, Agno, or Semantic Kernel. These adapters can replace the tool result before the LLM sees it.
 - **Cheapest per-task cost?** -- Semantic Kernel ($0.008 per task in benchmarks).
 - **Simplest integration?** -- Claude SDK or Agno. Both require minimal wiring.
 - **Using CrewAI?** -- CrewAI adapter is the only option. Note that CrewAI hooks are global (applied to every tool across all agents in the crew).
@@ -119,6 +119,7 @@ hooks = adapter.to_hook_callables()
 ### CrewAI
 
 - Hooks are global -- they apply to every tool across all agents in the crew. There is no per-agent hook scoping. See [CrewAI adapter docs](../adapters/crewai.md).
+- Side-effect only -- `on_postcondition_warn` callbacks fire for side effects (logging, alerting) but cannot replace the tool result. Postcondition `redact`/`deny` effects set `PostCallResult.result` for wrapper consumers but cannot modify what CrewAI passes to the model.
 
 ### Agno
 

--- a/docs/guides/postcondition-design.md
+++ b/docs/guides/postcondition-design.md
@@ -158,15 +158,15 @@ Whether the `on_postcondition_warn` callback can replace the tool result depends
 | LangChain | Wrap-around | Yes | Yes |
 | Agno | Wrap-around | Yes | Yes |
 | Semantic Kernel | Filter | Yes | Yes |
-| CrewAI | Hook | Yes (callback return replaces result) | Yes |
+| CrewAI | Hook | Side-effect only | Side-effect only |
 | Claude SDK | Native hook | Side-effect only | Side-effect only |
 | OpenAI Agents | Native guardrail | Side-effect only | Side-effect only |
 
-For **wrap-around** adapters (LangChain, Agno, Semantic Kernel, CrewAI), both `on_postcondition_warn` callbacks and built-in `redact`/`deny` effects work fully. The LLM sees the modified result.
+For **wrap-around** adapters (LangChain, Agno, Semantic Kernel), both `on_postcondition_warn` callbacks and built-in `redact`/`deny` effects work fully. The LLM sees the modified result.
 
-For **native hook** adapters (Claude SDK, OpenAI Agents), the SDK controls the result flow and the hook cannot substitute it. Built-in `redact`/`deny` effects set the `PostCallResult.result` field (available to wrapper consumers and callbacks) but cannot intercept the result before the SDK passes it to the model. A warning is logged at adapter construction time when postconditions declare `redact` or `deny` effects with these adapters.
+For **native hook** adapters (CrewAI, Claude SDK, OpenAI Agents), the framework controls the result flow and the hook cannot substitute it. Built-in `redact`/`deny` effects set the `PostCallResult.result` field (available to wrapper consumers and callbacks) but cannot intercept the result before the framework passes it to the model. A warning is logged at adapter construction time when postconditions declare `redact` or `deny` effects with these adapters.
 
-If your environment requires PII interception (not just detection), use LangChain, CrewAI, Agno, or Semantic Kernel.
+If your environment requires PII interception (not just detection), use LangChain, Agno, or Semantic Kernel.
 
 ---
 

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -60,7 +60,7 @@ class TestCrewAIAdapter:
         guard = make_guard(contracts=[always_deny], audit_sink=sink)
         adapter = CrewAIAdapter(guard)
         result = await adapter._before_hook(_make_before_context())
-        assert result is False
+        assert isinstance(result, str) and "DENIED" in result
         # Verify audit contains the reason
         deny_events = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
         assert len(deny_events) == 1

--- a/tests/test_adapter_parity.py
+++ b/tests/test_adapter_parity.py
@@ -68,8 +68,11 @@ def _adapter_configs():
     from edictum.adapters.langchain import LangChainAdapter
     from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
+    def _crewai_deny(r):
+        return isinstance(r, str) and "DENIED" in r
+
     return [
-        ("CrewAI", CrewAIAdapter, _crewai_pre, _crewai_post, lambda r: r is None, lambda r: r is False),
+        ("CrewAI", CrewAIAdapter, _crewai_pre, _crewai_post, lambda r: r is None, _crewai_deny),
         ("OpenAI", OpenAIAgentsAdapter, _openai_pre, _openai_post, lambda r: r is None, lambda r: r is not None),
         ("LangChain", LangChainAdapter, _langchain_pre, _langchain_post, lambda r: r is None, lambda r: r is not None),
     ]

--- a/tests/test_behavior/test_callback_behavior.py
+++ b/tests/test_behavior/test_callback_behavior.py
@@ -5,8 +5,9 @@ Callbacks must fire exactly once per event. No double-firing.
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from edictum import Edictum, Verdict, postcondition
 from edictum.storage import MemoryBackend
@@ -57,6 +58,64 @@ class TestCallbackInvocationCount:
             "Check for double invocation in _after_hook and the outer register() wrapper."
         )
 
+    def test_crewai_register_wrapper_no_double_fire(self):
+        """register() outer wrapper must not re-invoke the callback.
+
+        The callback lives in _after_hook(). The register() closure must
+        NOT call it a second time when translating PostCallResult for CrewAI.
+
+        Uses lowercase tool name to match the register() normalization.
+        """
+        from edictum.adapters.crewai import CrewAIAdapter
+
+        @postcondition("testtool")
+        def detect_issue(envelope, result):
+            return Verdict.fail("issue detected")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[detect_issue],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+        callback = MagicMock()
+        adapter = CrewAIAdapter(guard)
+
+        # Mock CrewAI hook registration to capture the installed hooks
+        captured = {}
+        mock_tool_hooks = MagicMock()
+        mock_tool_hooks.register_before_tool_call_hook = lambda h: captured.update(before=h)
+        mock_tool_hooks.register_after_tool_call_hook = lambda h: captured.update(after=h)
+
+        with patch.dict(
+            sys.modules,
+            {
+                "crewai": MagicMock(),
+                "crewai.hooks": MagicMock(),
+                "crewai.hooks.tool_hooks": mock_tool_hooks,
+            },
+        ):
+            adapter.register(on_postcondition_warn=callback)
+
+        # Drive the hooks exactly as CrewAI would
+        before_ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
+        captured["before"](before_ctx)
+
+        after_ctx = SimpleNamespace(
+            tool_name="TestTool",
+            tool_input={},
+            tool_result="test output",
+            agent=None,
+            task=None,
+        )
+        captured["after"](after_ctx)
+
+        assert callback.call_count == 1, (
+            f"on_postcondition_warn called {callback.call_count} times via register(), "
+            "expected exactly 1. The register() wrapper must not duplicate the "
+            "callback invocation from _after_hook()."
+        )
+
     async def test_openai_callback_fires_exactly_once(self):
         """OpenAI adapter callback must also fire exactly once."""
         from edictum.adapters.openai_agents import OpenAIAgentsAdapter
@@ -70,6 +129,41 @@ class TestCallbackInvocationCount:
         await adapter._post("call-1", "test output")
 
         assert callback.call_count == 1, f"OpenAI on_postcondition_warn called {callback.call_count} times, expected 1."
+
+
+class TestCrewAIDenyReturnValue:
+    """CrewAI _deny() must return the reason string, not a boolean."""
+
+    async def test_deny_returns_reason_string(self):
+        """_deny() must return 'DENIED: {reason}' so the agent sees why."""
+        from edictum.adapters.crewai import CrewAIAdapter
+
+        result = CrewAIAdapter._deny("budget exceeded")
+        assert isinstance(result, str), f"_deny() returned {type(result).__name__}, expected str"
+        assert "DENIED" in result, f"_deny() returned {result!r}, expected 'DENIED: ...'"
+        assert "budget exceeded" in result, f"_deny() lost the reason. Got: {result!r}"
+
+    async def test_deny_propagates_through_before_hook(self):
+        """_before_hook() must return the denial reason string on deny."""
+        from edictum import precondition
+        from edictum.adapters.crewai import CrewAIAdapter
+
+        @precondition("*")
+        def block_all(envelope):
+            return Verdict.fail("budget exceeded")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[block_all],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+        adapter = CrewAIAdapter(guard)
+        ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
+        result = await adapter._before_hook(ctx)
+
+        assert isinstance(result, str), f"_before_hook returned {type(result).__name__} on deny, expected str"
+        assert "budget exceeded" in result, f"Denial reason lost. Got: {result!r}"
 
 
 class TestCallbackArguments:

--- a/tests/test_behavior/test_enforcement_behavior.py
+++ b/tests/test_behavior/test_enforcement_behavior.py
@@ -32,15 +32,17 @@ def _make_deny_guard(**extra):
 class TestPreconditionDenyEnforcement:
     """Precondition deny must propagate through every adapter."""
 
-    async def test_crewai_deny_returns_false(self):
-        """CrewAI _before_hook must return False on deny."""
+    async def test_crewai_deny_returns_reason_string(self):
+        """CrewAI _before_hook must return a 'DENIED: ...' string on deny."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         guard = _make_deny_guard()
         adapter = CrewAIAdapter(guard)
         ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
         result = await adapter._before_hook(ctx)
-        assert result is False, "CrewAI must return False on deny (not None, which means allow)"
+        assert (
+            isinstance(result, str) and "DENIED" in result
+        ), f"CrewAI must return 'DENIED: ...' string on deny (not {type(result).__name__})"
 
     async def test_openai_deny_returns_denied_string(self):
         """OpenAI _pre must return a DENIED: string on deny."""


### PR DESCRIPTION
## Summary
- Remove duplicate `on_postcondition_warn` invocation from `register()` outer wrapper — callback now fires only in `_after_hook()`
- Change `_deny()` to return `'DENIED: {reason}'` string instead of `False` so the agent sees the denial reason

## Root Cause
**Bug A:** The `on_postcondition_warn` callback was invoked in `_after_hook()` (line 298) AND again in the `register()` closure (line 138), causing double-firing whenever postconditions triggered warnings.

**Bug B:** `_deny()` returned `False` (a boolean), discarding the denial reason. All other adapters return `f'DENIED: {reason}'` so the agent knows why the call was denied.

## Fix
- Removed the duplicate callback invocation from `register()`'s `after_hook` closure — the callback now fires exactly once in `_after_hook()`
- Changed `_deny()` to return `f"DENIED: {reason}"` matching every other adapter
- Updated `_before_hook` return type from `bool | None` to `str | None`

## Test Plan
- [x] Behavior test for double-fire through `register()` path (`test_crewai_register_wrapper_no_double_fire`)
- [x] Behavior tests for deny return value (`TestCrewAIDenyReturnValue`)
- [x] Updated existing tests expecting `False` return (`test_deny_returns_correct_format`, `test_crewai_deny_returns_reason_string`)
- [x] Updated adapter parity deny check for CrewAI
- [x] Full test suite passes (922 passed, 4 pre-existing failures)
- [x] Lint passes (`ruff check src/ tests/`)
- [x] Docs build passes (`mkdocs build --strict`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two bugs in the CrewAI adapter: eliminated duplicate `on_postcondition_warn` callback invocation (previously fired in both `_after_hook()` and the `register()` wrapper) and changed `_deny()` to return `'DENIED: {reason}'` string instead of `False` boolean to match all other adapters and provide denial context to agents.

- Removed lines 136-145 in `register()` that duplicated the callback invocation already happening in `_after_hook()` at line 286-291
- Changed `_deny()` return type from `bool` to `str` and updated return value from `False` to `f"DENIED: {reason}"`
- Updated `_before_hook()` return type annotation from `bool | None` to `str | None`
- All 5 test files updated with comprehensive behavior tests validating both fixes
- Adapter parity maintained across all 6 framework adapters

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested bug fixes with comprehensive test coverage
- Both bugs are clearly identified with root cause analysis, fixes are minimal and surgical, comprehensive behavior tests added (including test_crewai_register_wrapper_no_double_fire and TestCrewAIDenyReturnValue class), all existing tests updated, adapter parity maintained, and 922 tests passing
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/adapters/crewai.py | Fixed double callback invocation and changed `_deny()` to return reason string instead of boolean |
| tests/test_behavior/test_callback_behavior.py | Added comprehensive behavior tests for double-fire fix and deny return value changes |

</details>


</details>


<sub>Last reviewed commit: 2ce50ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->