### PR TITLE
fix: docs-audit workflow posts visible PR comments

### DIFF
--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -25,6 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
           prompt: |
             You are a docs-code sync auditor for the Edictum Python library. Your job is to find mismatches between documentation and actual source code in this PR.
 


### PR DESCRIPTION
## Summary
Add `use_sticky_comment: true` to docs-audit workflow so findings are posted as a visible PR comment instead of only appearing in workflow logs.

## Test Plan
- [ ] Next PR triggers docs-audit and posts comment on the PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Configured the docs-audit workflow to post sticky PR comments by adding the `use_sticky_comment: true` parameter to the `claude-code-action`.

- Added `use_sticky_comment: true` to make audit findings visible as PR comments instead of only in workflow logs
- The workflow already has `pull-requests: write` permission, which is required for posting comments

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line addition of a configuration parameter to enable sticky comments in the workflow. The workflow already has the necessary `pull-requests: write` permission to post comments, and the parameter is properly formatted.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/docs-audit.yml | Added `use_sticky_comment: true` parameter to enable visible PR comments |

</details>


</details>


<sub>Last reviewed commit: 9ee662a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->