### PR TITLE
fix: docs-audit posts findings as visible PR comments

### DIFF
--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -26,8 +26,12 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
+          claude_args: '--allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(find:*),Bash(grep:*),Read,Glob,Grep"'
           prompt: |
             You are a docs-code sync auditor for the Edictum Python library. Your job is to find mismatches between documentation and actual source code in this PR.
+
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
             ## Setup
 
@@ -75,24 +79,20 @@ jobs:
                - "alert" when meaning finding
             2. **Adapter docs parity**: If an adapter's source changed, verify its docs page reflects the change. If a new feature was added to one adapter, check if the adapter comparison guide (guides/adapter-comparison.md) needs updating.
 
-            ## Output Format
+            ## Posting Results
 
-            If you find issues, comment on the PR with this format:
+            You MUST post your findings as a PR comment using `gh pr comment`. Do not just output text.
 
-            ### Docs-Code Sync Audit
+            If you find issues, run:
 
+            gh pr comment ${{ github.event.pull_request.number }} --body "### Docs-Code Sync Audit
             **Issues found: N**
+            [for each issue: **[MISMATCH]**/**[MISSING]**/**[STALE]**/**[TERMINOLOGY]** prefix, file path and line number, what docs say vs what code does, suggested fix]"
 
-            For each issue:
-            - **[MISMATCH]** or **[MISSING]** or **[STALE]** or **[TERMINOLOGY]** prefix
-            - File path and line number
-            - What the docs say vs what the code does
-            - Suggested fix
+            If no issues found, run:
 
-            If no issues found, comment:
-
-            ### Docs-Code Sync Audit
-            No docs-code mismatches found.
+            gh pr comment ${{ github.event.pull_request.number }} --body "### Docs-Code Sync Audit
+            No docs-code mismatches found."
 
             ## Important
 
@@ -100,6 +100,7 @@ jobs:
             - Check the ACTUAL source code, not your assumptions about what it does.
             - Read the full function signatures, not just the first few parameters.
             - Be specific: include file paths and line numbers for both the docs and the code.
+            - You MUST use `gh pr comment` to post results. Only post GitHub comments — don't submit review text as messages.
         env:
           ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `claude_args` with `--allowedTools` granting access to `gh pr comment`
- Add PR context (REPO, PR NUMBER) to the prompt
- Replace "Output Format" section with explicit `gh pr comment` instructions

Without this, the action runs and finds mismatches but only writes to workflow logs — nobody sees them.

## Test Plan
- [ ] Next PR triggers docs-audit and posts a visible comment on the PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the fix started in #29 by granting the Claude agent explicit permission to post PR comments via `gh pr comment`. Previously, the workflow only added `use_sticky_comment: true` but didn't grant the agent the necessary tool access, so findings only appeared in workflow logs. The changes add `claude_args` with `--allowedTools` including `gh pr comment`, inject PR context variables (REPO, PR NUMBER) into the prompt, and replace passive output format instructions with explicit `gh pr comment` command examples.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - it fixes visibility of audit findings by granting necessary tool permissions
- The changes correctly address the root cause (missing tool permissions) and follow proper GitHub Actions syntax. The workflow structure is sound, though there's a minor syntax consideration with the multiline --body argument in the prompt instructions that could be made more explicit with heredoc syntax for clarity
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/docs-audit.yml | Grants Claude agent access to `gh pr comment` tool and adds explicit PR context, replacing passive instructions with actionable `gh pr comment` commands |

</details>


</details>


<sub>Last reviewed commit: baecc38</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->