### PR TITLE
docs: document Claude Agent SDK intentional decoupling decision

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,24 @@ class StorageBackend(Protocol):
 
 `max_attempts` fires first because it counts denied calls too. An agent stuck in a denial loop hits the attempt cap without ever incrementing the execution counter. The denial message tells the agent to stop and reassess rather than keep retrying.
 
+### Claude Agent SDK: Intentional Decoupling
+
+`to_hook_callables()` returns callables using Edictum's own calling convention
+(snake_case keys, `(tool_name, tool_input, tool_use_id)` signature) rather than
+the SDK-native `HookCallback` signature (`(input_data, tool_use_id, context)`
+with PascalCase event keys and `HookMatcher` wrappers).
+
+This is intentional. The `claude-agent-sdk` package is pre-1.0 and its types
+(`HookMatcher`, `HookContext`, `HookCallback`) may change. Importing them would
+add a runtime dependency to Edictum's zero-dep core and couple releases to SDK
+breaking changes. The ~10-line bridge recipe in the
+[Claude SDK adapter docs](adapters/claude-sdk.md#using-with-claudesdkclient-bridge-recipe)
+lives in user-land where the `claude-agent-sdk` coupling already exists.
+
+If the SDK stabilizes at 1.0, a `to_native_hooks()` convenience method that
+returns `dict[HookEvent, list[HookMatcher]]` directly could be added without
+breaking `to_hook_callables()`.
+
 ### Error Handling: Fail-Closed
 
 Edictum follows a fail-closed default with explicit opt-in to permissive behavior:


### PR DESCRIPTION
## Summary
- Added ADR in `docs/architecture.md` documenting why `to_hook_callables()` intentionally does not return SDK-native hooks
- The audit flagged this as a gap, but it was a deliberate decision from PR #15 — only the reasoning was undocumented

## Root Cause
PR #15 renamed `to_sdk_hooks()` → `to_hook_callables()` and documented the bridge recipe, but the architectural rationale (pre-1.0 SDK, zero-dep core policy) lived only in the commit message. No durable ADR existed, so the audit re-flagged it.

## Fix
Added a "Claude Agent SDK: Intentional Decoupling" section under Design Decisions in `docs/architecture.md` explaining:
- What: Edictum's own calling convention vs SDK-native `HookCallback`
- Why: `claude-agent-sdk` is pre-1.0, zero runtime deps in core
- Where: bridge recipe lives in user-land
- When to revisit: if/when SDK reaches 1.0

## Test Plan
- [ ] Docs build passes (`mkdocs build --strict`)
- [ ] No code changes — documentation only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Architecture Decision Record (ADR) documenting why `to_hook_callables()` intentionally returns Edictum's own calling convention rather than SDK-native `HookCallback` types. The ADR addresses an audit gap from PR #15, which renamed the method and documented the bridge recipe but left the architectural rationale in the commit message. The new section explains the zero-dep core policy and pre-1.0 SDK stability concerns, references the bridge recipe location, and notes when to revisit (SDK 1.0 stabilization).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that adds missing ADR for an already-implemented design decision. No code changes, proper terminology usage, and correctly references existing adapter docs.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/architecture.md | Added ADR explaining intentional decoupling from `claude-agent-sdk` pre-1.0 types |

</details>


</details>


<sub>Last reviewed commit: cfc4d78</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->