### PR TITLE
fix: correct Agno import path in adapter docs

### DIFF
--- a/docs/adapters/agno.md
+++ b/docs/adapters/agno.md
@@ -15,7 +15,7 @@ pip install edictum[agno]
 ```python
 from edictum import Edictum
 from edictum.adapters.agno import AgnoAdapter
-from agno import Agent
+from agno.agent import Agent
 
 guard = Edictum.from_yaml("contracts.yaml")
 adapter = AgnoAdapter(guard=guard)
@@ -88,7 +88,7 @@ hook = adapter.as_tool_hook(on_postcondition_warn=redact_pii)
 ```python
 from edictum import Edictum, Principal
 from edictum.adapters.agno import AgnoAdapter
-from agno import Agent
+from agno.agent import Agent
 
 # Load contracts
 guard = Edictum.from_yaml("contracts.yaml")


### PR DESCRIPTION
## Summary
- Fix `from agno import Agent` → `from agno.agent import Agent` in `docs/adapters/agno.md` (lines 18, 91) to match the agno package's public API and `docs/quickstart.md`
- Verified `sinks.md` RedactionPolicy `sensitive_keys` comment ("merged with defaults (union)") already matches code behavior after #23 — no update needed

## Root Cause
`docs/adapters/agno.md` used an incorrect top-level import path (`from agno import Agent`) while `docs/quickstart.md` had the correct submodule import (`from agno.agent import Agent`).

## Fix
Changed both occurrences in `docs/adapters/agno.md` to use `from agno.agent import Agent`.

## Test Plan
- [x] All three `from agno` imports across docs now use `from agno.agent import Agent`
- [x] Full test suite passes (929 passed; 6 pre-existing failures unrelated to this change)
- [x] Lint passes
- [x] Docs build passes (`mkdocs build --strict`)
- [x] Docs-code sync passes (`test_docs_sync.py`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed incorrect import path in Agno adapter documentation to match the agno package's public API structure.

- Changed `from agno import Agent` to `from agno.agent import Agent` at lines 18 and 91 in `docs/adapters/agno.md`
- All agno imports across documentation now use the correct submodule path
- Aligns with the pattern already used in `docs/quickstart.md`
- Test suite passes (929 passed), lint passes, docs build passes, docs-code sync passes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Documentation-only change that corrects an import path to match the agno package's actual API. The fix ensures consistency across all documentation and has been validated by passing test suite, lint, and docs build checks.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/adapters/agno.md | Corrected import path from `from agno import Agent` to `from agno.agent import Agent` in two locations |

</details>


</details>


<sub>Last reviewed commit: 3e36616</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->