### PR TITLE
feat: add from_yaml_string() for string/bytes YAML input

### DIFF
--- a/docs/contracts/yaml-reference.md
+++ b/docs/contracts/yaml-reference.md
@@ -56,6 +56,34 @@ Multiple bundles can be composed by passing multiple paths. Later bundles overri
 guard = Edictum.from_yaml("contracts/base.yaml", "contracts/overrides.yaml")
 ```
 
+### Loading from a String or Bytes {#from-yaml-string}
+
+When YAML is generated programmatically or fetched from an API, use `from_yaml_string()` to skip the file system. Follows the `json.load()` / `json.loads()` convention:
+
+```python
+yaml_content = """
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: dynamic-policy
+defaults:
+  mode: enforce
+contracts:
+  - id: block-dotenv
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".env" }
+    then:
+      effect: deny
+      message: "Denied: {args.path}"
+"""
+
+guard = Edictum.from_yaml_string(yaml_content)
+```
+
+`from_yaml_string()` accepts `str` or `bytes` and supports the same keyword arguments as `from_yaml()` (`tools`, `mode`, `audit_sink`, `redaction`, `backend`, `environment`). The low-level equivalent is `load_bundle_string()` from `edictum.yaml_engine`.
+
 See [Bundle Composition](#bundle-composition) for full details.
 
 A SHA256 hash of the raw YAML bytes is computed at load time and stamped as `policy_version` on every `AuditEvent` and OpenTelemetry span. This gives you an immutable link between any audit record and the exact contract bundle that produced it. When multiple bundles are composed, the combined hash is derived from all individual bundle hashes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -138,6 +138,14 @@ DENIED: Destructive command denied: rm -rf /tmp
 
 The `.env` file was never read. The `rm -rf` command never executed. Both calls were denied by contracts evaluated in Python, outside the LLM. The agent cannot talk its way past these checks.
 
+**Tip:** If your YAML is generated programmatically or fetched from an API, use `from_yaml_string()` instead:
+
+```python
+guard = Edictum.from_yaml_string(yaml_content)  # str or bytes
+```
+
+See the [YAML reference](contracts/yaml-reference.md#from-yaml-string) for details.
+
 ## 4. Add to Your Framework
 
 Create the guard from the same YAML, then use the adapter for your framework.

--- a/src/edictum/yaml_engine/__init__.py
+++ b/src/edictum/yaml_engine/__init__.py
@@ -23,6 +23,13 @@ def load_bundle(source: str) -> tuple[dict, BundleHash]:
     return _load(source)
 
 
+def load_bundle_string(content: str | bytes) -> tuple[dict, BundleHash]:
+    """Load and validate a YAML contract bundle from a string or bytes. See :func:`loader.load_bundle_string`."""
+    from edictum.yaml_engine.loader import load_bundle_string as _load_string
+
+    return _load_string(content)
+
+
 def compile_contracts(bundle: dict) -> CompiledBundle:
     """Compile a parsed bundle into contract objects. See :func:`compiler.compile_contracts`."""
     from edictum.yaml_engine.compiler import compile_contracts as _compile
@@ -40,4 +47,5 @@ __all__ = [
     "compile_contracts",
     "compose_bundles",
     "load_bundle",
+    "load_bundle_string",
 ]

--- a/tests/test_behavior/test_yaml_string_behavior.py
+++ b/tests/test_behavior/test_yaml_string_behavior.py
@@ -1,0 +1,192 @@
+"""Behavior tests for from_yaml_string() and load_bundle_string()."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError, EdictumDenied
+
+VALID_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-string-bundle
+defaults:
+  mode: enforce
+contracts:
+  - id: block-dotenv
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".env" }
+    then:
+      effect: deny
+      message: "Denied: {args.path}"
+"""
+
+VALID_YAML_OBSERVE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-observe
+defaults:
+  mode: observe
+contracts:
+  - id: block-dotenv
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".env" }
+    then:
+      effect: deny
+      message: "Denied: {args.path}"
+"""
+
+
+class TestFromYamlStringCreatesGuard:
+    """from_yaml_string() creates a working Edictum instance from YAML content."""
+
+    def test_string_input_creates_guard(self):
+        guard = Edictum.from_yaml_string(VALID_YAML)
+        assert guard is not None
+        assert guard.mode == "enforce"
+        assert len(guard._preconditions) == 1
+
+    def test_bytes_input_creates_guard(self):
+        guard = Edictum.from_yaml_string(VALID_YAML.encode("utf-8"))
+        assert guard is not None
+        assert guard.mode == "enforce"
+        assert len(guard._preconditions) == 1
+
+
+class TestFromYamlStringEnforcesContracts:
+    """Contracts loaded via from_yaml_string() evaluate correctly."""
+
+    @pytest.mark.asyncio
+    async def test_denies_matching_call(self):
+        guard = Edictum.from_yaml_string(VALID_YAML, audit_sink=_null_sink())
+
+        with pytest.raises(EdictumDenied, match="Denied: .env"):
+            await guard.run("read_file", {"path": ".env"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_allows_non_matching_call(self):
+        guard = Edictum.from_yaml_string(VALID_YAML, audit_sink=_null_sink())
+
+        result = await guard.run("read_file", {"path": "readme.txt"}, _dummy_tool)
+        assert result == "ok"
+
+
+class TestFromYamlStringModeOverride:
+    """The mode parameter overrides the YAML default mode."""
+
+    def test_mode_override_changes_guard_mode(self):
+        guard = Edictum.from_yaml_string(VALID_YAML, mode="observe")
+        assert guard.mode == "observe"
+
+    def test_yaml_mode_used_when_no_override(self):
+        guard = Edictum.from_yaml_string(VALID_YAML_OBSERVE)
+        assert guard.mode == "observe"
+
+
+class TestFromYamlStringPolicyVersion:
+    """from_yaml_string() computes a policy_version hash."""
+
+    def test_policy_version_set(self):
+        guard = Edictum.from_yaml_string(VALID_YAML)
+        assert guard.policy_version is not None
+        assert len(guard.policy_version) == 64  # SHA256 hex digest
+
+    def test_same_content_same_hash(self):
+        guard1 = Edictum.from_yaml_string(VALID_YAML)
+        guard2 = Edictum.from_yaml_string(VALID_YAML)
+        assert guard1.policy_version == guard2.policy_version
+
+    def test_bytes_and_string_same_hash(self):
+        guard_str = Edictum.from_yaml_string(VALID_YAML)
+        guard_bytes = Edictum.from_yaml_string(VALID_YAML.encode("utf-8"))
+        assert guard_str.policy_version == guard_bytes.policy_version
+
+
+class TestFromYamlStringErrors:
+    """from_yaml_string() raises EdictumConfigError on invalid input."""
+
+    def test_invalid_yaml_raises(self):
+        with pytest.raises(EdictumConfigError, match="YAML parse error"):
+            Edictum.from_yaml_string("not: valid: yaml: {{{{")
+
+    def test_non_mapping_raises(self):
+        with pytest.raises(EdictumConfigError, match="must be a mapping"):
+            Edictum.from_yaml_string("- just a list")
+
+    def test_schema_violation_raises(self):
+        bad_yaml = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: bad
+defaults:
+  mode: enforce
+contracts: []
+"""
+        with pytest.raises(EdictumConfigError, match="Schema validation failed"):
+            Edictum.from_yaml_string(bad_yaml)
+
+
+class TestLoadBundleString:
+    """load_bundle_string() in yaml_engine is importable and functional."""
+
+    def test_importable(self):
+        from edictum.yaml_engine import load_bundle_string
+
+        data, bundle_hash = load_bundle_string(VALID_YAML)
+        assert data["metadata"]["name"] == "test-string-bundle"
+        assert len(str(bundle_hash)) == 64
+
+
+class TestFromYamlStringToolsMerge:
+    """The tools parameter merges with YAML tools (parameter wins)."""
+
+    def test_tools_parameter_applied(self):
+        yaml_with_tools = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: tools-test
+defaults:
+  mode: enforce
+tools:
+  read_file:
+    side_effect: read
+contracts:
+  - id: block-dotenv
+    type: pre
+    tool: read_file
+    when:
+      args.path: { contains: ".env" }
+    then:
+      effect: deny
+      message: "Denied"
+"""
+        guard = Edictum.from_yaml_string(
+            yaml_with_tools,
+            tools={"custom_tool": {"side_effect": "pure"}},
+        )
+        # Both YAML tools and parameter tools should be registered
+        assert "read_file" in guard.tool_registry._tools
+        assert "custom_tool" in guard.tool_registry._tools
+
+
+# -- Helpers --
+
+
+async def _dummy_tool(**kwargs):
+    return "ok"
+
+
+def _null_sink():
+    class _Sink:
+        async def emit(self, event):
+            pass
+
+    return _Sink()


### PR DESCRIPTION
## Summary

- Add `Edictum.from_yaml_string(content)` classmethod that accepts `str` or `bytes` YAML content directly, following the `json.load()`/`json.loads()` convention
- Add `load_bundle_string(content)` to `edictum.yaml_engine` for low-level string-based bundle loading
- 14 behavior tests covering string/bytes input, contract enforcement, mode override, policy version hashing, error handling, and tools merge

## Test plan

- [x] `pytest tests/test_behavior/test_yaml_string_behavior.py -v` — 14/14 pass
- [x] `pytest tests/ -v` — 947/949 pass (2 pre-existing OpenAI callback failures)
- [x] `ruff check src/ tests/` — clean
- [x] `python -m mkdocs build --strict` — pass
- [x] `pytest tests/test_docs_sync.py -v` — pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `Edictum.from_yaml_string(content)` and `load_bundle_string(content)` for loading YAML contracts from strings or bytes, following the `json.load()` / `json.loads()` convention. The implementation mirrors the existing `from_yaml()` logic exactly, with proper string/bytes handling, SHA256 hashing, and all validation steps. Documentation updated in quickstart and YAML reference with clear examples. All 14 behavior tests pass, covering string/bytes input, contract enforcement, mode override, policy version hashing, error handling, and tools merge semantics.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation is clean, consistent with existing patterns, and thoroughly tested. The new `from_yaml_string()` method is an exact mirror of `from_yaml()` logic (duplicated intentionally for clarity). All 14 behavior tests pass, covering edge cases and parameter effects. Documentation is complete and accurate. No security, logic, or syntax issues identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/__init__.py | Added `from_yaml_string()` classmethod that mirrors `from_yaml()` logic, properly handles string/bytes input, and maintains consistency with existing patterns |
| src/edictum/yaml_engine/loader.py | Implemented `load_bundle_string()` with same validation logic as `load_bundle()`, handles str/bytes correctly, computes hash consistently |
| tests/test_behavior/test_yaml_string_behavior.py | Comprehensive behavior tests covering all parameters and edge cases: string/bytes input, enforcement, mode override, hashing, error handling, tools merge |

</details>


</details>


<sub>Last reviewed commit: f31c540</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e37a8046-77ec-4289-8d92-6c2e2896a820))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=968d838b-d461-4ad8-9519-8768714add88))

<!-- /greptile_comment -->