### PR TITLE
chore: add scenarios & use cases step to implementation skills

### DIFF
--- a/.claude/skills/edictum-oss/SKILL.md
+++ b/.claude/skills/edictum-oss/SKILL.md
@@ -31,13 +31,19 @@ Everything under `src/edictum/` is OSS core (MIT). This includes:
 1. **Read CLAUDE.md** — understand boundaries and dropped features
 2. **Read the Linear ticket** or user description
 3. **Read relevant source files** before proposing changes
-4. **Scope with user** — confirm approach before writing code
-5. **Implement** — small, focused changes
-6. **Behavior test** — every new/changed API parameter gets a test in `tests/test_behavior/test_{module}_behavior.py`
-7. **Docs-code sync** — `pytest tests/test_docs_sync.py -v`
-8. **Adapter parity** — if touching adapters: `pytest tests/test_adapter_parity.py -v`
-9. **Test** — `pytest tests/ -v` then `ruff check src/ tests/`
-10. **Commit** — conventional commits, no Co-Authored-By
+4. **Scenarios & use cases** — before implementing, write down:
+   - What concrete scenarios does this feature enable? (e.g., "send Slack alert on denial", "build live deny-rate dashboard")
+   - What user personas benefit? (developer debugging locally vs. platform team in production)
+   - Does this overlap with existing features? (e.g., OTel already covers some observability use cases — explain when to use which)
+   - Does this naturally surface related features that should be designed separately? (e.g., on_deny surfaced HITL as a distinct future feature)
+   - Include this analysis in the PR body under a "## Scenarios" section
+5. **Scope with user** — confirm approach before writing code
+6. **Implement** — small, focused changes
+7. **Behavior test** — every new/changed API parameter gets a test in `tests/test_behavior/test_{module}_behavior.py`
+8. **Docs-code sync** — `pytest tests/test_docs_sync.py -v`
+9. **Adapter parity** — if touching adapters: `pytest tests/test_adapter_parity.py -v`
+10. **Test** — `pytest tests/ -v` then `ruff check src/ tests/`
+11. **Commit** — conventional commits, no Co-Authored-By
 
 ## Conventions
 

--- a/.claude/skills/fix-audit-issue/SKILL.md
+++ b/.claude/skills/fix-audit-issue/SKILL.md
@@ -16,7 +16,17 @@ git checkout -b fix/{short-description}
 
 Use a descriptive branch name based on the issue (e.g., `fix/redaction-policy-merge`, `fix/crewai-double-callback`).
 
-## Step 2: Follow fix-bug procedure
+## Step 2: Scenarios & use cases (for features/design changes)
+
+If the issue involves adding a new feature or changing API behavior (not just a simple bug fix), write down BEFORE implementing:
+- What concrete scenarios does this enable? (e.g., "send Slack alert on denial", "test env-specific contracts in CI")
+- What user personas benefit? (developer debugging vs. platform team in production)
+- Does this overlap with existing features? Explain when to use which.
+- Does this surface related features that should be designed separately? Note them for future work.
+
+Include this analysis in the PR body under a `## Scenarios` section.
+
+## Step 3: Follow fix-bug procedure
 
 Execute all 8 steps from the `fix-bug` skill:
 1. Understand the bug
@@ -42,6 +52,9 @@ git push -u origin fix/{short-description}
 gh pr create --title "fix: {short description}" --body "$(cat <<'EOF'
 ## Summary
 {one-line summary}
+
+## Scenarios
+{what concrete use cases does this enable — skip for trivial bug fixes}
 
 ## Root Cause
 {what the code did wrong and why tests didn't catch it}


### PR DESCRIPTION
## Summary
Adds a mandatory "Scenarios & Use Cases" step to edictum-oss and fix-audit-issue skills.

## Why
During the on_deny callback design (#11), thinking through scenarios before coding naturally surfaced:
- The HITL (on_before_deny) feature as a separate future item
- The OTel overlap question (when to use callbacks vs OTel)
- Clear user personas (dev debugging vs platform team in production)

This kind of design exploration should be standardized, not accidental.

## Changes
- `edictum-oss` skill: new step 4 between "Read source" and "Scope with user"
- `fix-audit-issue` skill: new step 2 between "Create branch" and "Follow fix-bug"
- PR template updated with `## Scenarios` section

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a mandatory "Scenarios & Use Cases" step to both `edictum-oss` and `fix-audit-issue` skills, requiring developers to think through concrete use cases, user personas, feature overlap, and related features before implementation.

**Key Changes:**
- `edictum-oss`: New step 4 inserted between "Read source" and "Scope with user", with steps 5-11 renumbered accordingly
- `fix-audit-issue`: New conditional step 2 for features/design changes (not trivial bug fixes), with PR template updated to include `## Scenarios` section

**Issue Found:**
- Step numbering error in `fix-audit-issue/SKILL.md`: both scenario analysis and fix-bug procedure labeled "Step 3", causing steps 3-4 to become 4-5

**Note on PR Description:**
The PR description claims "PR template updated with `## Scenarios` section" but no separate PR template file was modified. The update is embedded in the `fix-audit-issue` skill's PR creation command at line 56.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing step numbering errors in fix-audit-issue skill
- Documentation-only change with clear intent and proper structure. Two step numbering errors found that need correction to avoid confusion when following the skill workflow. Otherwise, the addition of scenario analysis aligns well with the project's design-first philosophy.
- `.claude/skills/fix-audit-issue/SKILL.md` requires step renumbering (steps 3 and 4 should become 4 and 5)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/skills/edictum-oss/SKILL.md | Added step 4 "Scenarios & use cases" between source reading and user scoping, renumbered subsequent steps 5-11 |
| .claude/skills/fix-audit-issue/SKILL.md | Added step 2 for scenarios analysis with conditional guidance, updated PR template with Scenarios section |

</details>


</details>


<sub>Last reviewed commit: 4def87b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->