### PR TITLE
feat: custom template directories and list_templates() API

### DIFF
--- a/tests/test_behavior/test_template_behavior.py
+++ b/tests/test_behavior/test_template_behavior.py
@@ -1,0 +1,194 @@
+"""Behavior tests for from_template(template_dirs=) and list_templates()."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError, EdictumDenied, TemplateInfo
+
+CUSTOM_TEMPLATE = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: support-agent
+  description: "Custom template for support agents."
+defaults:
+  mode: enforce
+contracts:
+  - id: block-ticket-leak
+    type: pre
+    tool: send_message
+    when:
+      args.body: { contains: "TICKET-" }
+    then:
+      effect: deny
+      message: "Ticket references must not be in customer messages."
+"""
+
+
+@pytest.fixture()
+def custom_dir(tmp_path):
+    """Create a temp directory with a custom template."""
+    tpl = tmp_path / "support-agent.yaml"
+    tpl.write_text(CUSTOM_TEMPLATE)
+    return tmp_path
+
+
+@pytest.fixture()
+def override_dir(tmp_path):
+    """Create a temp directory with a template that overrides a built-in."""
+    tpl = tmp_path / "file-agent.yaml"
+    tpl.write_text(CUSTOM_TEMPLATE.replace("support-agent", "file-agent-custom"))
+    return tmp_path
+
+
+class TestFromTemplateBackwardCompat:
+    """Existing from_template() calls still work without template_dirs."""
+
+    def test_builtin_loads_without_template_dirs(self):
+        guard = Edictum.from_template("file-agent")
+        assert guard is not None
+        assert len(guard._preconditions) > 0
+
+    def test_missing_template_raises(self):
+        with pytest.raises(EdictumConfigError, match="not found"):
+            Edictum.from_template("nonexistent")
+
+
+class TestFromTemplateCustomDirs:
+    """template_dirs parameter enables loading templates from user directories."""
+
+    def test_loads_from_custom_dir(self, custom_dir):
+        guard = Edictum.from_template("support-agent", template_dirs=[custom_dir])
+        assert guard is not None
+        assert len(guard._preconditions) == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_template_enforces(self, custom_dir):
+        guard = Edictum.from_template(
+            "support-agent",
+            template_dirs=[custom_dir],
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Ticket references"):
+            await guard.run("send_message", {"body": "See TICKET-123"}, _dummy_tool)
+
+
+class TestFromTemplateSearchOrder:
+    """User directories are searched before built-in templates."""
+
+    def test_user_dir_overrides_builtin(self, override_dir):
+        guard = Edictum.from_template("file-agent", template_dirs=[override_dir])
+        # The override template has 1 contract, the built-in has 3
+        assert len(guard._preconditions) == 1
+
+    def test_builtin_used_as_fallback(self, custom_dir):
+        # custom_dir only has support-agent, so file-agent falls through
+        guard = Edictum.from_template("file-agent", template_dirs=[custom_dir])
+        assert len(guard._preconditions) == 3  # built-in file-agent has 3
+
+    def test_first_user_dir_wins(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        dir_b = tmp_path / "b"
+        dir_b.mkdir()
+
+        # Same name in both dirs, different content
+        (dir_a / "my-agent.yaml").write_text(CUSTOM_TEMPLATE.replace("support-agent", "my-agent"))
+        alt_yaml = CUSTOM_TEMPLATE.replace("support-agent", "my-agent").replace("block-ticket-leak", "alt-contract")
+        (dir_b / "my-agent.yaml").write_text(alt_yaml)
+
+        guard = Edictum.from_template("my-agent", template_dirs=[dir_a, dir_b])
+        # Should load from dir_a (first in list)
+        contract_id = getattr(guard._preconditions[0], "_edictum_id", None)
+        assert contract_id == "block-ticket-leak"
+
+
+class TestFromTemplateErrorMessage:
+    """Error message lists templates from all searched directories."""
+
+    def test_error_includes_custom_templates(self, custom_dir):
+        with pytest.raises(EdictumConfigError, match="support-agent") as exc_info:
+            Edictum.from_template("nope", template_dirs=[custom_dir])
+        # Also includes built-in templates
+        assert "file-agent" in str(exc_info.value)
+
+    def test_nonexistent_dir_ignored(self, tmp_path):
+        fake = tmp_path / "does-not-exist"
+        # Should not raise on the dir itself, only on missing template
+        with pytest.raises(EdictumConfigError, match="not found"):
+            Edictum.from_template("nope", template_dirs=[fake])
+
+
+class TestListTemplatesBuiltins:
+    """list_templates() discovers built-in templates."""
+
+    def test_returns_builtin_templates(self):
+        templates = Edictum.list_templates()
+        names = [t.name for t in templates]
+        assert "file-agent" in names
+        assert "research-agent" in names
+        assert "devops-agent" in names
+
+    def test_builtin_flag_is_true(self):
+        templates = Edictum.list_templates()
+        assert all(t.builtin for t in templates)
+
+    def test_returns_template_info_type(self):
+        templates = Edictum.list_templates()
+        assert all(isinstance(t, TemplateInfo) for t in templates)
+
+
+class TestListTemplatesCustomDirs:
+    """list_templates(template_dirs=) discovers user templates."""
+
+    def test_includes_custom_templates(self, custom_dir):
+        templates = Edictum.list_templates(template_dirs=[custom_dir])
+        names = [t.name for t in templates]
+        assert "support-agent" in names
+        # Built-ins still present
+        assert "file-agent" in names
+
+    def test_custom_template_not_builtin(self, custom_dir):
+        templates = Edictum.list_templates(template_dirs=[custom_dir])
+        custom = [t for t in templates if t.name == "support-agent"]
+        assert len(custom) == 1
+        assert custom[0].builtin is False
+
+    def test_user_template_shadows_builtin(self, override_dir):
+        templates = Edictum.list_templates(template_dirs=[override_dir])
+        file_agents = [t for t in templates if t.name == "file-agent"]
+        assert len(file_agents) == 1
+        assert file_agents[0].builtin is False
+
+    def test_nonexistent_dir_ignored(self, tmp_path):
+        fake = tmp_path / "does-not-exist"
+        templates = Edictum.list_templates(template_dirs=[fake])
+        # Should still return built-in templates
+        assert len(templates) >= 3
+
+
+class TestListTemplatesOrder:
+    """list_templates() returns user templates before built-in templates."""
+
+    def test_user_templates_come_first(self, custom_dir):
+        templates = Edictum.list_templates(template_dirs=[custom_dir])
+        user_indices = [i for i, t in enumerate(templates) if not t.builtin]
+        builtin_indices = [i for i, t in enumerate(templates) if t.builtin]
+        if user_indices and builtin_indices:
+            assert max(user_indices) < min(builtin_indices)
+
+
+# -- Helpers --
+
+
+async def _dummy_tool(**kwargs):
+    return "ok"
+
+
+def _null_sink():
+    class _Sink:
+        async def emit(self, event):
+            pass
+
+    return _Sink()


### PR DESCRIPTION
## Summary

- Add `template_dirs` parameter to `Edictum.from_template()` — user directories are searched first, built-in templates serve as fallback
- Add `Edictum.list_templates(template_dirs=None)` to discover available templates across all directories
- Add `TemplateInfo` frozen dataclass (name, path, builtin) as the return type
- Full backward compatibility — existing `from_template("file-agent")` calls work unchanged

## Scenarios

**Team/org-specific contract libraries.** A platform team creates a `shared-contracts/` directory with templates like `support-agent`, `billing-agent`, `onboarding-agent`. Individual developers load them by name without knowing the YAML details — `from_template("support-agent", template_dirs=["shared-contracts/"])`.

**Override built-in defaults per project.** A team that needs a stricter `file-agent` (e.g., blocking additional patterns like `terraform.tfvars`) can drop their custom `file-agent.yaml` into a project directory. The override is automatic — same `from_template("file-agent")` call, different behavior.

**Template discovery for tooling and CI.** `list_templates()` lets CLI tools, dashboards, or CI scripts enumerate all available templates across directories. A CI job can validate all templates in a repo without hardcoding names.

**Multi-repo contract sharing.** A monorepo or shared package can publish templates as YAML files. Consumer repos point `template_dirs` at the shared package's template directory.

## Test plan

- [x] 17 behavior tests in `tests/test_behavior/test_template_behavior.py`
- [x] Backward compat: built-in templates load without `template_dirs`
- [x] Custom dir loading and enforcement
- [x] Search order: user dirs first, first user dir wins, built-in fallback
- [x] Error messages include templates from all searched dirs
- [x] `list_templates()` returns built-ins, custom, and shadows correctly
- [x] Nonexistent directories are gracefully ignored
- [x] Full test suite passes (990/992, 2 pre-existing OpenAI adapter failures)
- [x] Lint clean, docs build clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `template_dirs` parameter to `Edictum.from_template()` and new `Edictum.list_templates()` API for custom contract template directories.

**Key changes:**
- `from_template()` now searches user directories first, then falls back to built-in templates
- New `TemplateInfo` frozen dataclass captures template metadata (name, path, builtin flag)
- `list_templates()` discovers all available templates with proper shadowing behavior
- Full backward compatibility - existing calls work unchanged
- Comprehensive behavior tests (17 tests) covering search order, overrides, error messages, and discovery
- Documentation updated with use cases, examples, and template creation guidelines

**Implementation quality:**
- Search order correctly prioritizes user directories
- Nonexistent directories gracefully handled
- Error messages list all available templates across directories
- Consistent shadowing behavior between `from_template()` and `list_templates()`
- Follows project conventions: frozen dataclass, type hints, proper exports in `__all__`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- Clean implementation with excellent test coverage (17 behavior tests), proper error handling, full backward compatibility, and comprehensive documentation. Code follows all project conventions and API design principles from CLAUDE.md
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/__init__.py | Added `template_dirs` parameter to `from_template()` and new `list_templates()` API with `TemplateInfo` dataclass - clean implementation with proper search order |
| tests/test_behavior/test_template_behavior.py | Comprehensive behavior tests covering backward compatibility, custom directories, search order, error messages, and template discovery - 17 tests |
| docs/contracts/templates.md | Added documentation for custom template directories, template discovery, and creation guidelines with clear use cases and examples |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[from_template name, template_dirs] --> B{template_dirs provided?}
    B -->|Yes| C[Create search_dirs: user dirs + builtin]
    B -->|No| D[Create search_dirs: builtin only]
    C --> E[Iterate through search_dirs in order]
    D --> E
    E --> F{Check candidate path exists}
    F -->|Yes| G[Load with from_yaml and return]
    F -->|No| H{More directories?}
    H -->|Yes| E
    H -->|No| I[Gather all available templates]
    I --> J[Raise EdictumConfigError with list]
    
    K[list_templates template_dirs] --> L[Create empty seen set and results list]
    L --> M{template_dirs provided?}
    M -->|Yes| N[Iterate user directories]
    M -->|No| P[Skip to builtin]
    N --> O{Directory exists?}
    O -->|Yes| Q[Glob *.yaml files]
    O -->|No| R{More user dirs?}
    Q --> S{Name in seen?}
    S -->|No| T[Add TemplateInfo builtin=False]
    S -->|Yes| R
    T --> R
    R -->|Yes| N
    R -->|No| P[Iterate builtin directory]
    P --> U[Glob builtin *.yaml files]
    U --> V{Name in seen?}
    V -->|No| W[Add TemplateInfo builtin=True]
    V -->|Yes| X[Skip duplicate]
    W --> Y[Return results list]
    X --> Y
```

<sub>Last reviewed commit: 3235b1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->