### PR TITLE
feat: add CompositeSink for multi-destination audit logging

### DIFF
--- a/src/edictum/__init__.py
+++ b/src/edictum/__init__.py
@@ -22,6 +22,7 @@ from edictum.audit import (
     AuditAction,
     AuditEvent,
     AuditSink,
+    CompositeSink,
     FileAuditSink,
     RedactionPolicy,
     StdoutAuditSink,
@@ -76,6 +77,7 @@ __all__ = [
     "AuditAction",
     "AuditEvent",
     "AuditSink",
+    "CompositeSink",
     "StdoutAuditSink",
     "FileAuditSink",
     "RedactionPolicy",
@@ -111,7 +113,7 @@ class Edictum:
         tools: dict[str, dict] | None = None,
         contracts: list | None = None,
         hooks: list | None = None,
-        audit_sink: AuditSink | None = None,
+        audit_sink: AuditSink | list[AuditSink] | None = None,
         redaction: RedactionPolicy | None = None,
         backend: StorageBackend | None = None,
         policy_version: str | None = None,
@@ -121,7 +123,10 @@ class Edictum:
         self.limits = limits or OperationLimits()
         self.backend = backend or MemoryBackend()
         self.redaction = redaction or RedactionPolicy()
-        self.audit_sink = audit_sink or StdoutAuditSink(self.redaction)
+        if isinstance(audit_sink, list):
+            self.audit_sink: AuditSink = CompositeSink(audit_sink)
+        else:
+            self.audit_sink = audit_sink or StdoutAuditSink(self.redaction)
         self.telemetry = GovernanceTelemetry()
         self._gov_tracer = get_tracer("edictum.governance")
         self.policy_version = policy_version
@@ -160,7 +165,7 @@ class Edictum:
         *paths: str | Path,
         tools: dict[str, dict] | None = None,
         mode: str | None = None,
-        audit_sink: AuditSink | None = None,
+        audit_sink: AuditSink | list[AuditSink] | None = None,
         redaction: RedactionPolicy | None = None,
         backend: StorageBackend | None = None,
         environment: str = "production",
@@ -175,7 +180,8 @@ class Edictum:
             tools: Tool side-effect classifications. Merged with any ``tools:``
                 section in the YAML bundle (parameter wins on conflict).
             mode: Override the bundle's default mode (enforce/observe).
-            audit_sink: Custom audit sink.
+            audit_sink: Custom audit sink, or a list of sinks (auto-wrapped
+                in CompositeSink).
             redaction: Custom redaction policy.
             backend: Custom storage backend.
             environment: Environment name for envelope context.
@@ -277,7 +283,7 @@ class Edictum:
         *,
         tools: dict[str, dict] | None = None,
         mode: str | None = None,
-        audit_sink: AuditSink | None = None,
+        audit_sink: AuditSink | list[AuditSink] | None = None,
         redaction: RedactionPolicy | None = None,
         backend: StorageBackend | None = None,
         environment: str = "production",
@@ -292,7 +298,8 @@ class Edictum:
             tools: Tool side-effect classifications. Merged with any ``tools:``
                 section in the YAML bundle (parameter wins on conflict).
             mode: Override the bundle's default mode (enforce/observe).
-            audit_sink: Custom audit sink.
+            audit_sink: Custom audit sink, or a list of sinks (auto-wrapped
+                in CompositeSink).
             redaction: Custom redaction policy.
             backend: Custom storage backend.
             environment: Environment name for envelope context.
@@ -365,7 +372,7 @@ class Edictum:
         *,
         tools: dict[str, dict] | None = None,
         mode: str | None = None,
-        audit_sink: AuditSink | None = None,
+        audit_sink: AuditSink | list[AuditSink] | None = None,
         redaction: RedactionPolicy | None = None,
         backend: StorageBackend | None = None,
         environment: str = "production",

--- a/tests/test_behavior/test_audit_behavior.py
+++ b/tests/test_behavior/test_audit_behavior.py
@@ -1,0 +1,101 @@
+"""Behavior tests for audit sinks — CompositeSink and list auto-wrapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum
+from edictum.audit import (
+    AuditAction,
+    AuditEvent,
+    AuditSink,
+    CompositeSink,
+    StdoutAuditSink,
+)
+
+
+class _CaptureSink:
+    """Minimal AuditSink that records emitted events."""
+
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    async def emit(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+class TestCompositeSinkBehavior:
+    """CompositeSink fans out events to every wrapped sink."""
+
+    async def test_events_reach_all_sinks(self):
+        sink_a = _CaptureSink()
+        sink_b = _CaptureSink()
+        composite = CompositeSink([sink_a, sink_b])
+
+        event = AuditEvent(action=AuditAction.CALL_ALLOWED, tool_name="Read")
+        await composite.emit(event)
+
+        assert len(sink_a.events) == 1
+        assert len(sink_b.events) == 1
+        assert sink_a.events[0] is event
+        assert sink_b.events[0] is event
+
+    async def test_multiple_events_accumulate_in_all_sinks(self):
+        sink_a = _CaptureSink()
+        sink_b = _CaptureSink()
+        composite = CompositeSink([sink_a, sink_b])
+
+        for i in range(3):
+            await composite.emit(AuditEvent(action=AuditAction.CALL_ALLOWED, tool_name=f"tool_{i}"))
+
+        assert len(sink_a.events) == 3
+        assert len(sink_b.events) == 3
+
+    async def test_sinks_property_returns_copy(self):
+        sink_a = _CaptureSink()
+        composite = CompositeSink([sink_a])
+        returned = composite.sinks
+        returned.append(_CaptureSink())
+        assert len(composite.sinks) == 1
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="at least one sink"):
+            CompositeSink([])
+
+    async def test_conforms_to_audit_sink_protocol(self):
+        composite = CompositeSink([_CaptureSink()])
+        assert isinstance(composite, AuditSink)
+
+
+class TestEdictumListAutoWrap:
+    """Passing a list of sinks to Edictum auto-wraps in CompositeSink."""
+
+    async def test_list_wraps_in_composite(self):
+        sink_a = _CaptureSink()
+        sink_b = _CaptureSink()
+        guard = Edictum(audit_sink=[sink_a, sink_b])
+
+        assert isinstance(guard.audit_sink, CompositeSink)
+        assert guard.audit_sink.sinks == [sink_a, sink_b]
+
+    async def test_single_sink_still_works(self):
+        sink = _CaptureSink()
+        guard = Edictum(audit_sink=sink)
+
+        assert guard.audit_sink is sink
+        assert not isinstance(guard.audit_sink, CompositeSink)
+
+    async def test_none_defaults_to_stdout(self):
+        guard = Edictum()
+        assert isinstance(guard.audit_sink, StdoutAuditSink)
+
+    async def test_list_sinks_receive_events_through_run(self):
+        sink_a = _CaptureSink()
+        sink_b = _CaptureSink()
+        guard = Edictum(audit_sink=[sink_a, sink_b])
+
+        await guard.run("read_file", {"path": "/tmp/test"}, lambda **kw: "ok")
+
+        assert len(sink_a.events) >= 2  # pre + post audit events
+        assert len(sink_b.events) >= 2
+        assert len(sink_a.events) == len(sink_b.events)


### PR DESCRIPTION
## Summary

- Add `CompositeSink` class in `audit.py` that fans out events to multiple sinks sequentially
- `Edictum` constructor now accepts `audit_sink` as `AuditSink | list[AuditSink] | None` — lists are auto-wrapped in `CompositeSink`
- Backward compatible: single sink and `None` default still work unchanged
- Type hint updates on `from_yaml`, `from_yaml_string`, and `from_template`

## Scenarios

| Scenario | Sinks | Who benefits |
|----------|-------|--------------|
| **Dev debugging + persistent audit trail** | `StdoutAuditSink` + `FileAuditSink` | Developer debugging locally — real-time terminal output plus a `.jsonl` file for later analysis |
| **Multi-destination compliance** | `FileAuditSink` + custom sink | Platform team — file for regulatory retention plus a custom sink pushing to an internal dashboard |
| **Gradual migration** | `StdoutAuditSink` + new sink | Anyone migrating — keep existing stdout while adding a new destination, without changing constructor code |
| **Custom sink stacking** | `FileAuditSink` + `KafkaAuditSink` | Compliance — redundant audit trails from a one-liner, each sink independently processes the same events |

CompositeSink is about the structured event log, not observability traces. OTel spans operate independently and are complementary — use both in production.

## Test plan

- [x] 9 behavior tests in `tests/test_behavior/test_audit_behavior.py`
- [x] Events reach all sinks (direct + through `guard.run()`)
- [x] List auto-wraps in `CompositeSink`, single sink unchanged
- [x] Empty list raises `ValueError`
- [x] `CompositeSink` conforms to `AuditSink` protocol
- [x] Full test suite passes (982/984 — 2 pre-existing OpenAI callback failures)
- [x] Lint clean, docs build strict, docs-code sync passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `CompositeSink` for multi-destination audit logging. The `Edictum` constructor now accepts `audit_sink` as `AuditSink | list[AuditSink] | None` with automatic list-to-CompositeSink wrapping. All type hints updated across `from_yaml`, `from_yaml_string`, and `from_template`. Implementation is clean, well-tested (9 behavior tests), and fully backward compatible.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- Clean implementation following all project conventions: frozen dataclass pattern avoided (sink mutability needed), protocol conformance verified, comprehensive behavior tests (9 tests covering all edge cases), proper error handling for empty lists, backward compatibility preserved, type hints consistent across all methods, documentation complete with examples and use-case table
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/audit.py | Added `CompositeSink` class that fans out events to multiple sinks sequentially with proper error handling and protocol conformance |
| src/edictum/__init__.py | Updated type hints for `audit_sink` parameter to accept `AuditSink | list[AuditSink] | None`, with auto-wrapping logic in constructor |
| tests/test_behavior/test_audit_behavior.py | Comprehensive behavior tests covering CompositeSink emission, list auto-wrapping, empty list validation, and end-to-end integration |
| docs/audit/sinks.md | Added documentation for CompositeSink with usage examples, parameter table, and scenario comparison table |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Edictum Constructor] --> B{audit_sink type?}
    B -->|list| C[Create CompositeSink]
    B -->|AuditSink| D[Use sink directly]
    B -->|None| E[Default StdoutAuditSink]
    
    C --> F[CompositeSink.__init__]
    F --> G{List empty?}
    G -->|Yes| H[Raise ValueError]
    G -->|No| I[Store sinks in order]
    
    I --> J[Event Emission]
    D --> J
    E --> J
    
    J --> K[CompositeSink.emit]
    K --> L[Iterate sinks sequentially]
    L --> M{Sink raises?}
    M -->|Yes| N[Propagate exception]
    M -->|No| O[Continue to next sink]
    O --> P{More sinks?}
    P -->|Yes| L
    P -->|No| Q[Complete]
```

<sub>Last reviewed commit: 8366e41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->