### PR TITLE
feat: custom_operators parameter for domain-specific YAML operators

### DIFF
--- a/docs/contracts/operators.md
+++ b/docs/contracts/operators.md
@@ -425,3 +425,25 @@ When a selector references a field that does not exist:
 - All other operators return `false` (the contract does not fire).
 
 This means a contract like `args.path: { contains: ".env" }` will not fire if the tool call has no `path` argument. No error is raised.
+
+---
+
+## Custom Operators
+
+Beyond the 15 built-in operators, you can register domain-specific operators via the `custom_operators` parameter on `from_yaml()`, `from_yaml_string()`, and `from_template()`. Each operator is a callable receiving `(field_value, operator_value)` and returning `bool`.
+
+```python
+import ipaddress
+
+def ip_in_cidr(field_value: str, cidr: str) -> bool:
+    return ipaddress.ip_address(field_value) in ipaddress.ip_network(cidr)
+
+guard = Edictum.from_yaml(
+    "contracts.yaml",
+    custom_operators={"ip_in_cidr": ip_in_cidr},
+)
+```
+
+Custom operators follow the same missing-field and type-mismatch behavior as built-in operators. Names must not clash with the 15 built-in operators. Unknown operator names in YAML are caught at compile time.
+
+For a full guide with examples, see [Custom Operators](../guides/custom-operators.md).

--- a/docs/guides/custom-operators.md
+++ b/docs/guides/custom-operators.md
@@ -1,0 +1,280 @@
+# Custom Operators
+
+Edictum ships with 15 built-in operators (`contains`, `matches`, `gt`, etc.). Custom operators let you extend the expression grammar with domain-specific checks — IBAN validation, CIDR matching, semver comparison — so contracts stay declarative YAML instead of falling back to Python hooks.
+
+```python
+import ipaddress
+
+def ip_in_cidr(field_value: str, cidr: str) -> bool:
+    """Check if an IP address is within a CIDR range."""
+    return ipaddress.ip_address(field_value) in ipaddress.ip_network(cidr)
+
+guard = Edictum.from_yaml(
+    "contracts.yaml",
+    custom_operators={"ip_in_cidr": ip_in_cidr},
+)
+```
+
+```yaml
+# contracts.yaml
+- id: internal-only
+  type: pre
+  tool: ssh_connect
+  when:
+    args.target_ip: { ip_in_cidr: "10.0.0.0/8" }
+  then:
+    effect: deny
+    message: "Only internal IPs allowed. Got {args.target_ip}."
+```
+
+---
+
+## When to use this
+
+### Financial validation
+
+Your fintech agent processes wire transfers. You need an operator like `is_invalid_iban: true` to validate IBAN numbers in YAML contracts instead of writing a Python precondition for every bank-related tool. The contract stays declarative: `when: args.destination_account: {is_invalid_iban: true}`.
+
+### Network security
+
+Your infrastructure agent manages firewall rules. You need `ip_in_cidr: "10.0.0.0/8"` to check if a target IP is in an allowed range. Without custom operators, you'd need a Python hook for what should be a one-line YAML condition.
+
+### Healthcare compliance
+
+Your patient-facing agent accesses medical records. You need `is_invalid_npi: true` to validate National Provider Identifier numbers before allowing record access. Domain-specific validation belongs in YAML, not scattered across Python hooks.
+
+### Semantic versioning
+
+Your deployment agent manages releases. You need `semver_lt: "2.0.0"` to ensure only packages above a minimum version get deployed. Custom operators keep deployment contracts readable.
+
+### Who benefits
+
+- **Domain teams** — express domain-specific validation in YAML instead of Python, keeping contracts readable by non-developers.
+- **Security teams** — audit YAML contracts without reading Python code to understand what's being validated.
+- **Platform teams** — distribute custom operators as a library alongside [templates](../contracts/templates.md).
+
+### Overlap with Python hooks
+
+Python `@precondition` hooks can do anything custom operators can. The difference is readability and auditability — YAML contracts with custom operators are reviewable by non-engineers, Python hooks are not. Use custom operators for domain-specific leaf checks, Python hooks for complex logic with branching. See [Python Hooks](python-hooks.md) for the hook approach.
+
+---
+
+## Operator contract
+
+Every custom operator is a callable with this signature:
+
+```python
+def my_operator(field_value: Any, operator_value: Any) -> bool:
+    ...
+```
+
+| Parameter | Description |
+|---|---|
+| `field_value` | The resolved value from the selector (e.g., the value of `args.target_ip`). |
+| `operator_value` | The value from the YAML operator (e.g., `"10.0.0.0/8"`). |
+| **Return** | `True` if the condition is met (contract fires), `False` otherwise. |
+
+The return value is coerced to `bool`. Truthy non-bool values (like `1` or `"yes"`) work but `True`/`False` is preferred.
+
+### Error handling
+
+- If the operator raises `TypeError`, Edictum treats it as a `policy_error` (fail-closed — the contract fires).
+- If the operator raises any other exception, Edictum treats it the same way (fail-closed).
+- Missing fields are never passed to custom operators. When a selector resolves to a missing or null field, the expression evaluates to `False` without calling the operator.
+
+---
+
+## Registering operators
+
+Pass `custom_operators` to any of the YAML loading methods:
+
+=== "from_yaml()"
+
+    ```python
+    guard = Edictum.from_yaml(
+        "contracts.yaml",
+        custom_operators={"ip_in_cidr": ip_in_cidr},
+    )
+    ```
+
+=== "from_yaml_string()"
+
+    ```python
+    guard = Edictum.from_yaml_string(
+        yaml_content,
+        custom_operators={"ip_in_cidr": ip_in_cidr},
+    )
+    ```
+
+=== "from_template()"
+
+    ```python
+    guard = Edictum.from_template(
+        "file-agent",
+        custom_operators={"ip_in_cidr": ip_in_cidr},
+    )
+    ```
+
+Multiple operators can be registered at once:
+
+```python
+guard = Edictum.from_yaml(
+    "contracts.yaml",
+    custom_operators={
+        "ip_in_cidr": ip_in_cidr,
+        "is_invalid_iban": is_invalid_iban,
+        "semver_lt": semver_lt,
+    },
+)
+```
+
+---
+
+## Name clash protection
+
+Custom operator names must not collide with the 15 built-in operators. Attempting to register a name like `contains` or `equals` raises `EdictumConfigError`:
+
+```python
+# This raises EdictumConfigError
+guard = Edictum.from_yaml_string(
+    yaml_content,
+    custom_operators={"contains": my_fn},  # clash!
+)
+```
+
+```
+EdictumConfigError: Custom operator names clash with built-in operators: ['contains']
+```
+
+---
+
+## Unknown operator detection
+
+If a YAML contract uses an operator name that is neither built-in nor registered as a custom operator, Edictum raises `EdictumConfigError` at compile time (when loading the bundle), not at evaluation time:
+
+```python
+# contracts.yaml uses `ip_in_cidr` but no custom_operators registered
+guard = Edictum.from_yaml_string(yaml_content)
+# EdictumConfigError: Contract 'internal-only': unknown operator 'ip_in_cidr'
+```
+
+This means typos and missing registrations are caught immediately, not when a tool call happens to trigger the contract.
+
+---
+
+## Composing with boolean expressions
+
+Custom operators compose with `all:`, `any:`, and `not:` the same way built-in operators do:
+
+```yaml
+- id: internal-approved-only
+  type: pre
+  tool: ssh_connect
+  when:
+    all:
+      - args.target_ip: { ip_in_cidr: "10.0.0.0/8" }
+      - principal.role: { not_in: [sre, admin] }
+  then:
+    effect: deny
+    message: "Internal access requires SRE or admin role."
+```
+
+Custom and built-in operators can be mixed freely within the same expression tree.
+
+---
+
+## Dry-run evaluation
+
+Custom operators work with the [dry-run evaluation API](../evaluation.md):
+
+```python
+result = guard.evaluate(
+    "ssh_connect",
+    {"target_ip": "192.168.1.1"},
+)
+print(result.verdict)  # "deny" or "allow"
+```
+
+---
+
+## Examples
+
+### IBAN validation
+
+```python
+import re
+
+IBAN_RE = re.compile(r'^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$')
+
+def is_invalid_iban(field_value: str, expected: bool) -> bool:
+    """Return True when the IBAN is invalid (deny condition)."""
+    valid = bool(IBAN_RE.match(str(field_value)))
+    return (not valid) == expected
+```
+
+```yaml
+- id: validate-iban
+  type: pre
+  tool: wire_transfer
+  when:
+    args.destination_account: { is_invalid_iban: true }
+  then:
+    effect: deny
+    message: "Invalid IBAN: {args.destination_account}"
+```
+
+### CIDR range check
+
+```python
+import ipaddress
+
+def ip_in_cidr(field_value: str, cidr: str) -> bool:
+    """Return True when the IP is within the CIDR range."""
+    try:
+        return ipaddress.ip_address(field_value) in ipaddress.ip_network(cidr)
+    except ValueError:
+        return False
+```
+
+```yaml
+# Deny connections to internal IPs
+- id: block-internal
+  type: pre
+  tool: ssh_connect
+  when:
+    args.target_ip: { ip_in_cidr: "10.0.0.0/8" }
+  then:
+    effect: deny
+    message: "Internal IP {args.target_ip} denied."
+```
+
+### Semver comparison
+
+```python
+from packaging.version import Version
+
+def semver_lt(field_value: str, threshold: str) -> bool:
+    """Return True when field version is below threshold."""
+    return Version(field_value) < Version(threshold)
+```
+
+```yaml
+# Deny deploying packages below minimum version
+- id: min-version
+  type: pre
+  tool: deploy_package
+  when:
+    args.version: { semver_lt: "2.0.0" }
+  then:
+    effect: deny
+    message: "Version {args.version} is below the minimum 2.0.0."
+```
+
+---
+
+## Next steps
+
+- [Operator Reference](../contracts/operators.md) — all 15 built-in operators
+- [Python Hooks](python-hooks.md) — for complex validation with branching logic
+- [Writing Contracts](writing-contracts.md) — YAML contract patterns
+- [Testing Contracts](testing-contracts.md) — verifying your contracts work

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - Guides:
     - Writing Contracts: guides/writing-contracts.md
     - Testing Contracts: guides/testing-contracts.md
+    - Custom Operators: guides/custom-operators.md
     - Python Hooks: guides/python-hooks.md
     - Adapter Comparison: guides/adapter-comparison.md
     - Observability: guides/observability.md

--- a/src/edictum/yaml_engine/__init__.py
+++ b/src/edictum/yaml_engine/__init__.py
@@ -30,11 +30,11 @@ def load_bundle_string(content: str | bytes) -> tuple[dict, BundleHash]:
     return _load_string(content)
 
 
-def compile_contracts(bundle: dict) -> CompiledBundle:
+def compile_contracts(bundle: dict, *, custom_operators: dict | None = None) -> CompiledBundle:
     """Compile a parsed bundle into contract objects. See :func:`compiler.compile_contracts`."""
     from edictum.yaml_engine.compiler import compile_contracts as _compile
 
-    return _compile(bundle)
+    return _compile(bundle, custom_operators=custom_operators)
 
 
 __all__ = [

--- a/src/edictum/yaml_engine/edictum-v1.schema.json
+++ b/src/edictum/yaml_engine/edictum-v1.schema.json
@@ -291,7 +291,7 @@
       "type": "object",
       "minProperties": 1,
       "maxProperties": 1,
-      "additionalProperties": false,
+      "additionalProperties": {},
       "properties": {
         "exists": { "type": "boolean" },
         "equals": { "description": "Strict equality. Any scalar type." },

--- a/tests/test_behavior/test_custom_operators_behavior.py
+++ b/tests/test_behavior/test_custom_operators_behavior.py
@@ -1,0 +1,675 @@
+"""Behavior tests for custom_operators parameter."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError, EdictumDenied
+
+# ---------------------------------------------------------------------------
+# YAML templates
+# ---------------------------------------------------------------------------
+
+YAML_IBAN_CHECK = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: iban-check
+defaults:
+  mode: enforce
+contracts:
+  - id: reject-invalid-iban
+    type: pre
+    tool: wire_transfer
+    when:
+      args.destination_account: { is_invalid_iban: true }
+    then:
+      effect: deny
+      message: "Invalid IBAN: {args.destination_account}"
+"""
+
+YAML_POST_PII = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: pii-check
+defaults:
+  mode: enforce
+contracts:
+  - id: detect-pii
+    type: post
+    tool: lookup_customer
+    when:
+      output.text: { has_pii_pattern: true }
+    then:
+      effect: warn
+      message: "PII detected in output"
+"""
+
+YAML_UNKNOWN_OP = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: unknown-op
+defaults:
+  mode: enforce
+contracts:
+  - id: uses-unknown
+    type: pre
+    tool: some_tool
+    when:
+      args.value: { totally_unknown_op: true }
+    then:
+      effect: deny
+      message: "Should not compile"
+"""
+
+YAML_ALL_COMBINATOR = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: combinator-test
+defaults:
+  mode: enforce
+contracts:
+  - id: all-combined
+    type: pre
+    tool: deploy
+    when:
+      all:
+        - args.region: { is_restricted_region: true }
+        - args.service: { contains: "prod" }
+    then:
+      effect: deny
+      message: "Cannot deploy to restricted region in prod"
+"""
+
+YAML_ANY_COMBINATOR = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: any-combinator
+defaults:
+  mode: enforce
+contracts:
+  - id: any-combined
+    type: pre
+    tool: execute
+    when:
+      any:
+        - args.cmd: { is_dangerous_command: true }
+        - args.cmd: { contains: "rm -rf" }
+    then:
+      effect: deny
+      message: "Dangerous command denied"
+"""
+
+YAML_DISALLOWED_HOST = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: host-check
+defaults:
+  mode: enforce
+contracts:
+  - id: disallowed-host
+    type: pre
+    tool: api_call
+    when:
+      args.url: { is_disallowed_host: true }
+    then:
+      effect: deny
+      message: "Host not allowed"
+"""
+
+YAML_MISSING_FIELD = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: missing-field
+defaults:
+  mode: enforce
+contracts:
+  - id: check-missing
+    type: pre
+    tool: some_tool
+    when:
+      args.nonexistent_field: { custom_check: true }
+    then:
+      effect: deny
+      message: "Should not fire for missing fields"
+"""
+
+YAML_MULTI_CUSTOM = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: multi-custom
+defaults:
+  mode: enforce
+contracts:
+  - id: check-cidr
+    type: pre
+    tool: connect
+    when:
+      args.ip: { is_private_cidr: true }
+    then:
+      effect: deny
+      message: "Private CIDR denied"
+  - id: check-semver
+    type: pre
+    tool: install
+    when:
+      args.version: { is_prerelease: true }
+    then:
+      effect: deny
+      message: "Pre-release version denied"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Operator implementations for tests
+# ---------------------------------------------------------------------------
+
+_IBAN_RE = re.compile(r"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$")
+
+
+def _is_invalid_iban(field_value: str, op_value: bool) -> bool:
+    """Returns True when the IBAN is invalid (the deny condition)."""
+    valid = bool(_IBAN_RE.match(field_value))
+    return (not valid) == op_value
+
+
+def _has_pii_pattern(field_value: str, op_value: bool) -> bool:
+    """Returns True when SSN-like patterns are found."""
+    found = bool(re.search(r"\d{3}-\d{2}-\d{4}", field_value))
+    return found == op_value
+
+
+def _is_restricted_region(field_value: str, op_value: bool) -> bool:
+    restricted = field_value in {"cn-north-1", "ru-central-1"}
+    return restricted == op_value
+
+
+def _is_dangerous_command(field_value: str, op_value: bool) -> bool:
+    dangerous = any(k in field_value for k in ["shutdown", "format"])
+    return dangerous == op_value
+
+
+def _is_disallowed_host(field_value: str, op_value: bool) -> bool:
+    disallowed = not field_value.startswith("https://api.example.com")
+    return disallowed == op_value
+
+
+def _custom_check(field_value, op_value) -> bool:
+    return True  # pragma: no cover — should never be called for missing fields
+
+
+def _is_private_cidr(field_value: str, op_value: bool) -> bool:
+    private = field_value.startswith("10.") or field_value.startswith("192.168.")
+    return private == op_value
+
+
+def _is_prerelease(field_value: str, op_value: bool) -> bool:
+    pre = "-" in field_value  # e.g. "1.0.0-beta"
+    return pre == op_value
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+class TestCustomOperatorDeniesMatching:
+    """Custom operator returns True for the deny condition and the call is denied."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_iban_denied(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _is_invalid_iban},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Invalid IBAN"):
+            await guard.run("wire_transfer", {"destination_account": "BOGUS"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_valid_iban_allowed(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _is_invalid_iban},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run(
+            "wire_transfer",
+            {"destination_account": "DE89370400440532013000"},
+            _dummy_tool,
+        )
+        assert result == "ok"
+
+
+class TestCustomOperatorPostcondition:
+    """Custom operator works in postcondition contracts."""
+
+    @pytest.mark.asyncio
+    async def test_pii_in_output_warns(self):
+        guard = Edictum.from_yaml_string(
+            YAML_POST_PII,
+            custom_operators={"has_pii_pattern": _has_pii_pattern},
+            audit_sink=_null_sink(),
+        )
+
+        async def _tool_with_pii(**kwargs):
+            return "Customer SSN: 123-45-6789"
+
+        result = await guard.run("lookup_customer", {}, _tool_with_pii)
+        # Warn effect does not raise, but postcondition fires
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_no_pii_clean(self):
+        guard = Edictum.from_yaml_string(
+            YAML_POST_PII,
+            custom_operators={"has_pii_pattern": _has_pii_pattern},
+            audit_sink=_null_sink(),
+        )
+
+        async def _clean_tool(**kwargs):
+            return "Customer name: Alice"
+
+        result = await guard.run("lookup_customer", {}, _clean_tool)
+        assert result == "Customer name: Alice"
+
+
+class TestFromYamlFilePath:
+    """Custom operators work with from_yaml() loading from a file path."""
+
+    @pytest.mark.asyncio
+    async def test_from_yaml_with_custom_operators(self, tmp_path):
+        yaml_file = tmp_path / "contracts.yaml"
+        yaml_file.write_text(YAML_IBAN_CHECK)
+
+        guard = Edictum.from_yaml(
+            yaml_file,
+            custom_operators={"is_invalid_iban": _is_invalid_iban},
+            audit_sink=_null_sink(),
+        )
+
+        with pytest.raises(EdictumDenied, match="Invalid IBAN"):
+            await guard.run("wire_transfer", {"destination_account": "BAD"}, _dummy_tool)
+
+
+class TestFromTemplate:
+    """from_template() accepts the custom_operators parameter."""
+
+    def test_from_template_accepts_custom_operators(self):
+        guard = Edictum.from_template(
+            "file-agent",
+            custom_operators={"my_noop": lambda fv, ov: False},
+        )
+        assert guard is not None
+
+
+class TestCustomOperatorNameClash:
+    """Passing a built-in operator name raises EdictumConfigError."""
+
+    @pytest.mark.parametrize(
+        "builtin_name",
+        [
+            "exists",
+            "equals",
+            "not_equals",
+            "in",
+            "not_in",
+            "contains",
+            "contains_any",
+            "starts_with",
+            "ends_with",
+            "matches",
+            "matches_any",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+        ],
+    )
+    def test_each_builtin_clashes(self, builtin_name):
+        with pytest.raises(EdictumConfigError, match="clash with built-in operators"):
+            Edictum.from_yaml_string(
+                YAML_IBAN_CHECK,
+                custom_operators={builtin_name: lambda fv, ov: False},
+            )
+
+
+class TestNonCallableValidation:
+    """Non-callable values in custom_operators raise EdictumConfigError."""
+
+    def test_string_value_rejected(self):
+        with pytest.raises(EdictumConfigError, match="not callable"):
+            Edictum.from_yaml_string(
+                YAML_IBAN_CHECK,
+                custom_operators={"my_op": "not_a_function"},
+            )
+
+    def test_int_value_rejected(self):
+        with pytest.raises(EdictumConfigError, match="not callable"):
+            Edictum.from_yaml_string(
+                YAML_IBAN_CHECK,
+                custom_operators={"my_op": 42},
+            )
+
+
+class TestUnknownOperatorAtCompileTime:
+    """Unknown operators in YAML raise EdictumConfigError at compile time."""
+
+    def test_unknown_op_raises(self):
+        with pytest.raises(EdictumConfigError, match="unknown operator 'totally_unknown_op'"):
+            Edictum.from_yaml_string(YAML_UNKNOWN_OP)
+
+    def test_registering_makes_it_compile(self):
+        guard = Edictum.from_yaml_string(
+            YAML_UNKNOWN_OP,
+            custom_operators={"totally_unknown_op": lambda fv, ov: False},
+        )
+        assert guard is not None
+
+
+class TestCustomOperatorArguments:
+    """Custom operator receives the correct (field_value, operator_value) pair."""
+
+    @pytest.mark.asyncio
+    async def test_receives_correct_args(self):
+        spy = MagicMock(return_value=True)
+
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": spy},
+            audit_sink=_null_sink(),
+        )
+
+        with pytest.raises(EdictumDenied):
+            await guard.run(
+                "wire_transfer",
+                {"destination_account": "TEST123"},
+                _dummy_tool,
+            )
+
+        spy.assert_called_once_with("TEST123", True)
+
+
+class TestReturnValueCoercion:
+    """Truthy non-bool returns are coerced to bool via bool()."""
+
+    @pytest.mark.asyncio
+    async def test_integer_one_treated_as_true(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": lambda fv, ov: 1},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied):
+            await guard.run("wire_transfer", {"destination_account": "X"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_zero_treated_as_false(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": lambda fv, ov: 0},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run("wire_transfer", {"destination_account": "X"}, _dummy_tool)
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_nonempty_string_treated_as_true(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": lambda fv, ov: "yes"},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied):
+            await guard.run("wire_transfer", {"destination_account": "X"}, _dummy_tool)
+
+
+class TestBooleanCombinators:
+    """Custom operators compose correctly inside all/any/not expressions."""
+
+    @pytest.mark.asyncio
+    async def test_all_both_true_denies(self):
+        guard = Edictum.from_yaml_string(
+            YAML_ALL_COMBINATOR,
+            custom_operators={"is_restricted_region": _is_restricted_region},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="restricted region"):
+            await guard.run(
+                "deploy",
+                {"region": "cn-north-1", "service": "prod-api"},
+                _dummy_tool,
+            )
+
+    @pytest.mark.asyncio
+    async def test_all_one_false_allows(self):
+        guard = Edictum.from_yaml_string(
+            YAML_ALL_COMBINATOR,
+            custom_operators={"is_restricted_region": _is_restricted_region},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run(
+            "deploy",
+            {"region": "us-east-1", "service": "prod-api"},
+            _dummy_tool,
+        )
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_any_first_true_denies(self):
+        guard = Edictum.from_yaml_string(
+            YAML_ANY_COMBINATOR,
+            custom_operators={"is_dangerous_command": _is_dangerous_command},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Dangerous command"):
+            await guard.run("execute", {"cmd": "shutdown -h now"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_any_second_true_denies(self):
+        guard = Edictum.from_yaml_string(
+            YAML_ANY_COMBINATOR,
+            custom_operators={"is_dangerous_command": _is_dangerous_command},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Dangerous command"):
+            await guard.run("execute", {"cmd": "rm -rf /"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_any_neither_true_allows(self):
+        guard = Edictum.from_yaml_string(
+            YAML_ANY_COMBINATOR,
+            custom_operators={"is_dangerous_command": _is_dangerous_command},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run("execute", {"cmd": "echo hello"}, _dummy_tool)
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_disallowed_host_denied(self):
+        guard = Edictum.from_yaml_string(
+            YAML_DISALLOWED_HOST,
+            custom_operators={"is_disallowed_host": _is_disallowed_host},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Host not allowed"):
+            await guard.run(
+                "api_call",
+                {"url": "https://evil.example.com/steal"},
+                _dummy_tool,
+            )
+
+    @pytest.mark.asyncio
+    async def test_allowed_host_passes(self):
+        guard = Edictum.from_yaml_string(
+            YAML_DISALLOWED_HOST,
+            custom_operators={"is_disallowed_host": _is_disallowed_host},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run(
+            "api_call",
+            {"url": "https://api.example.com/data"},
+            _dummy_tool,
+        )
+        assert result == "ok"
+
+    def test_not_combinator_via_evaluator(self):
+        """Verify not: combinator works with custom operators at the evaluator level."""
+        from edictum.envelope import create_envelope
+        from edictum.yaml_engine.evaluator import evaluate_expression
+
+        env = create_envelope("api_call", {"url": "https://evil.example.com"})
+        custom_ops = {"is_safe_url": lambda fv, ov: fv.startswith("https://api.example.com") == ov}
+
+        # not(is_safe_url: true) on unsafe URL -> not(False) -> True
+        expr = {"not": {"args.url": {"is_safe_url": True}}}
+        assert evaluate_expression(expr, env, custom_operators=custom_ops) is True
+
+        # not(is_safe_url: true) on safe URL -> not(True) -> False
+        safe_env = create_envelope("api_call", {"url": "https://api.example.com/data"})
+        assert evaluate_expression(expr, safe_env, custom_operators=custom_ops) is False
+
+
+class TestMissingFieldSkipsCustomOperator:
+    """When the selector field is missing, the custom operator is NOT called."""
+
+    @pytest.mark.asyncio
+    async def test_missing_field_allows(self):
+        spy = MagicMock(return_value=True)
+        guard = Edictum.from_yaml_string(
+            YAML_MISSING_FIELD,
+            custom_operators={"custom_check": spy},
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run("some_tool", {}, _dummy_tool)
+        assert result == "ok"
+        spy.assert_not_called()
+
+
+class TestCustomOperatorTypeError:
+    """TypeError from a custom operator is treated as a policy_error (fail-closed)."""
+
+    @pytest.mark.asyncio
+    async def test_type_error_causes_deny(self):
+        def _bad_op(field_value, op_value):
+            raise TypeError("cannot compare")
+
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _bad_op},
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied):
+            await guard.run("wire_transfer", {"destination_account": "X"}, _dummy_tool)
+
+    def test_type_error_sets_policy_error_in_evaluate(self):
+        def _bad_op(field_value, op_value):
+            raise TypeError("cannot compare")
+
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _bad_op},
+        )
+        result = guard.evaluate("wire_transfer", {"destination_account": "X"})
+        assert result.verdict == "deny"
+        assert result.policy_error is True
+
+
+class TestDryRunEvaluation:
+    """guard.evaluate() (dry-run API) works with custom operators."""
+
+    def test_evaluate_denies_with_custom_op(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _is_invalid_iban},
+        )
+        result = guard.evaluate("wire_transfer", {"destination_account": "INVALID"})
+        assert result.verdict == "deny"
+
+    def test_evaluate_allows_with_custom_op(self):
+        guard = Edictum.from_yaml_string(
+            YAML_IBAN_CHECK,
+            custom_operators={"is_invalid_iban": _is_invalid_iban},
+        )
+        result = guard.evaluate("wire_transfer", {"destination_account": "DE89370400440532013000"})
+        assert result.verdict == "allow"
+
+    def test_evaluate_post_with_custom_op(self):
+        guard = Edictum.from_yaml_string(
+            YAML_POST_PII,
+            custom_operators={"has_pii_pattern": _has_pii_pattern},
+        )
+        result = guard.evaluate("lookup_customer", {}, output="SSN: 123-45-6789")
+        assert result.verdict == "warn"
+
+
+class TestMultipleCustomOperators:
+    """Multiple custom operators registered simultaneously all work."""
+
+    @pytest.mark.asyncio
+    async def test_first_operator_denies(self):
+        guard = Edictum.from_yaml_string(
+            YAML_MULTI_CUSTOM,
+            custom_operators={
+                "is_private_cidr": _is_private_cidr,
+                "is_prerelease": _is_prerelease,
+            },
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Private CIDR"):
+            await guard.run("connect", {"ip": "10.0.0.1"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_second_operator_denies(self):
+        guard = Edictum.from_yaml_string(
+            YAML_MULTI_CUSTOM,
+            custom_operators={
+                "is_private_cidr": _is_private_cidr,
+                "is_prerelease": _is_prerelease,
+            },
+            audit_sink=_null_sink(),
+        )
+        with pytest.raises(EdictumDenied, match="Pre-release version"):
+            await guard.run("install", {"version": "1.0.0-beta"}, _dummy_tool)
+
+    @pytest.mark.asyncio
+    async def test_both_pass_allows(self):
+        guard = Edictum.from_yaml_string(
+            YAML_MULTI_CUSTOM,
+            custom_operators={
+                "is_private_cidr": _is_private_cidr,
+                "is_prerelease": _is_prerelease,
+            },
+            audit_sink=_null_sink(),
+        )
+        result = await guard.run("connect", {"ip": "8.8.8.8"}, _dummy_tool)
+        assert result == "ok"
+        result2 = await guard.run("install", {"version": "1.0.0"}, _dummy_tool)
+        assert result2 == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _dummy_tool(**kwargs):
+    return "ok"
+
+
+def _null_sink():
+    class _Sink:
+        async def emit(self, event):
+            pass
+
+    return _Sink()


### PR DESCRIPTION
## Summary

- Add `custom_operators` parameter to `from_yaml()`, `from_yaml_string()`, and `from_template()` — a dict mapping operator names to `(field_value, operator_value) -> bool` callables
- Validate custom operator names don't clash with the 15 built-in operators at registration time
- Detect unknown operator names in YAML at compile time (fail-fast, not at evaluation time)
- Relax JSON schema `Operator` definition to allow additional properties (custom operator names validated in Python)
- Thread `custom_operators` through evaluator → compiler → closures so they're available at evaluation time

## Scenarios

1. **Financial validation** — Fintech agents need `is_invalid_iban: true` to validate IBAN numbers in YAML contracts instead of writing a Python precondition for every bank-related tool
2. **Network security** — Infrastructure agents need `ip_in_cidr: "10.0.0.0/8"` to check if a target IP is in an allowed range, expressible as a one-line YAML condition
3. **Healthcare compliance** — Patient-facing agents need `is_invalid_npi: true` to validate National Provider Identifier numbers before allowing record access
4. **Semantic versioning** — Deployment agents need `semver_lt: "2.0.0"` to ensure only packages above a minimum version get deployed

## Test plan

- [x] 46 behavior tests covering: precondition/postcondition custom ops, from_yaml/from_yaml_string/from_template paths, name-clash validation for all 15 built-ins, non-callable rejection, unknown operator compile-time detection, argument verification via mock, return value coercion, boolean combinators (all/any/not), missing field handling, TypeError policy_error, dry-run evaluation, multiple simultaneous operators
- [x] All 1019 existing tests pass (2 pre-existing OpenAI callback failures unrelated)
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/test_docs_sync.py -v` passes
- [x] `mkdocs build --strict` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds domain-specific operator extensibility to Edictum's YAML contract system. The `custom_operators` parameter accepts callables `(field_value, operator_value) -> bool` that integrate seamlessly with the 15 built-in operators.

**Key changes:**
- Validation at registration time prevents name clashes with built-in operators (all 15 tested)
- Compile-time detection of unknown operator names (fail-fast before evaluation)
- Custom operators thread through `from_yaml()` → `compile_contracts()` → closures → `evaluate_expression()` → `_apply_operator()`
- JSON schema relaxed from `additionalProperties: false` to `additionalProperties: {}` for custom operator names
- Missing fields never reach custom operators (evaluated to `False` early)
- `TypeError` from custom operators treated as `policy_error` (fail-closed)
- Return values coerced to `bool` (tested with `1`, `0`, `"yes"`)
- Works with all combinators (`all`, `any`, `not`) and dry-run evaluation API

**Test coverage:**
46 behavior tests covering preconditions, postconditions, name clashes for all 15 built-ins, non-callable rejection, unknown operator compile-time detection, argument verification, return value coercion, boolean combinators, missing field handling, `TypeError` policy error, and dry-run evaluation.

**Documentation:**
280-line guide with 4 real-world scenarios (financial IBAN validation, network CIDR matching, healthcare NPI validation, semver comparison), operator contract signature, error handling semantics, and working examples.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects excellent implementation quality: comprehensive 46-test behavior suite covering all edge cases (name clashes for all 15 built-ins, non-callable rejection, unknown operator detection, type errors, missing fields, combinators), proper fail-fast validation at compile time, fail-closed error handling, clean parameter threading through 4 layers (from_yaml → compiler → closures → evaluator), well-structured 280-line documentation with real-world use cases, and alignment with project conventions (frozen dataclasses, type hints, async patterns, behavior test requirement, terminology enforcement)
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/__init__.py | Adds `custom_operators` parameter to `from_yaml()`, `from_yaml_string()`, and `from_template()` with proper validation and threading through to compiler |
| src/edictum/yaml_engine/compiler.py | Implements compile-time operator validation, threads `custom_operators` through precondition/postcondition compilation to evaluator |
| src/edictum/yaml_engine/evaluator.py | Adds custom operator evaluation logic in `_apply_operator()`, threads parameter through expression tree evaluation, exports `BUILTIN_OPERATOR_NAMES` |
| tests/test_behavior/test_custom_operators_behavior.py | Comprehensive 675-line test suite covering 46 scenarios: preconditions, postconditions, name clashes, unknown operators, combinators, missing fields, type errors, dry-run evaluation |
| docs/guides/custom-operators.md | New 280-line guide documenting custom operators with use cases, operator contract signature, registration, error handling, and examples (IBAN, CIDR, semver) |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User calls from_yaml/from_yaml_string/from_template] --> B[_validate_custom_operators checks]
    B --> C{Names clash with<br/>15 built-ins?}
    C -->|Yes| D[Raise EdictumConfigError]
    C -->|No| E{All values callable?}
    E -->|No| D
    E -->|Yes| F[load_bundle loads YAML]
    F --> G[compile_contracts receives custom_operators]
    G --> H[_validate_operators scans YAML]
    H --> I{Unknown operator<br/>in YAML?}
    I -->|Yes| D
    I -->|No| J[_compile_pre/_compile_post create closures]
    J --> K[Closures capture custom_operators]
    K --> L[Runtime: evaluate_expression called]
    L --> M[_eval_all/_eval_any/_eval_not thread parameter]
    M --> N[_eval_leaf reaches operator]
    N --> O[_apply_operator checks built-ins first]
    O --> P{Operator in<br/>built-ins?}
    P -->|Yes| Q[Call built-in operator]
    P -->|No| R{Operator in<br/>custom_operators?}
    R -->|Yes| S[Call custom operator with bool coercion]
    R -->|No| T[Return _PolicyError]
    S --> U{TypeError raised?}
    U -->|Yes| V[Return _PolicyError fail-closed]
    U -->|No| W[Return bool result]
```

<sub>Last reviewed commit: 9beb9a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->