### PR TITLE
feat: pipeline approval protocol + wildcard tool matching

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,8 @@ ToolEnvelope --> pre_execute(envelope, session)
                     |      Each returns Verdict.pass_() or .fail(msg).
                     |      In observe mode, failures are recorded but do not deny.
                     |      In enforce mode, first failure short-circuits.
+                    |      Contracts with effect=approve return "pending_approval"
+                    |      instead of deny, delegating to approval_backend.
                     |
                     +-- 4. Evaluate session contracts
                     |      Session contracts receive the Session object.
@@ -70,7 +72,7 @@ ToolEnvelope --> pre_execute(envelope, session)
                            real decision. Results emitted as audit events
                            with mode: "observe".
 
-                    --> PreDecision(action="allow"|"deny", shadow_results=[...], ...)
+                    --> PreDecision(action="allow"|"deny"|"pending_approval", shadow_results=[...], ...)
 ```
 
 If the `PreDecision.action` is `"allow"`, the adapter lets the tool execute.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -62,6 +62,28 @@ An `AuditEvent` with `action: CALL_DENIED` is written to all configured sinks (s
 
 The `.env` file was never read. The agent sees the denial and can try a different approach.
 
+## An Approval Gate: Step by Step
+
+An agent calls `delete_records` with `{"table": "users", "query": "WHERE inactive = true"}`. A precondition with `effect: approve` is configured.
+
+**1. Agent decides to call `delete_records`.**
+
+The adapter intercepts the call and builds a `ToolEnvelope`.
+
+**2. Edictum evaluates preconditions.**
+
+The pipeline finds a matching contract with `effect: approve`. Instead of denying immediately, it returns `PreDecision` with `action: "pending_approval"`.
+
+**3. The pipeline requests human approval.**
+
+The `approval_backend.request_approval()` method is called. A `CALL_APPROVAL_REQUESTED` audit event is emitted. The pipeline then calls `approval_backend.wait_for_decision()` and blocks until a decision arrives or the timeout expires.
+
+**4a. If approved:** The tool executes normally. A `CALL_APPROVAL_GRANTED` audit event is emitted and `on_allow` fires.
+
+**4b. If denied:** `EdictumDenied` is raised. A `CALL_APPROVAL_DENIED` audit event is emitted and `on_deny` fires.
+
+**4c. If timeout:** The `timeout_effect` determines the outcome. Default is `deny` (raises `EdictumDenied`). A `CALL_APPROVAL_TIMEOUT` audit event is emitted.
+
 ## An Allowed Call: Step by Step
 
 The same agent calls `read_file` with `{"path": "config.txt"}`.
@@ -105,6 +127,7 @@ After all real checks pass, the pipeline evaluates shadow preconditions and sess
 | Stage | When | Can Deny? | Output |
 |-------|------|-----------|--------|
 | Preconditions | Before tool executes | Yes | `CALL_DENIED` or pass |
+| Approval gate | When precondition has `effect: approve` | Yes (on denial/timeout) | `CALL_APPROVAL_REQUESTED`, then `GRANTED`/`DENIED`/`TIMEOUT` |
 | Session limits | Before tool executes | Yes | `CALL_DENIED` if limit exceeded |
 | Shadow contracts | After real checks pass | Never | Audit events with `mode: "observe"` |
 | Tool execution | Only if all preconditions pass | -- | Tool's return value |

--- a/docs/contracts/patterns/change-control.md
+++ b/docs/contracts/patterns/change-control.md
@@ -158,6 +158,72 @@ Restrict high-impact tools to senior roles. This pattern is the simplest form of
 
 ---
 
+## Human Approval Gate
+
+Pause high-impact tool calls and wait for a human to approve or deny them. Unlike role-based gates (which deny immediately if the role is wrong), approval gates pause the pipeline and request explicit human sign-off before proceeding.
+
+**When to use:** Destructive operations (database drops, production deploys, bulk deletes) where even authorized users should confirm intent before the tool executes.
+
+=== "YAML"
+
+    ```yaml
+    apiVersion: edictum/v1
+    kind: ContractBundle
+
+    metadata:
+      name: approval-gates
+
+    defaults:
+      mode: enforce
+
+    contracts:
+      - id: delete-requires-approval
+        type: pre
+        tool: "db_*"
+        when:
+          args.query:
+            matches: '\bDELETE\b'
+        then:
+          effect: approve
+          message: "DELETE query requires human approval: {args.query}"
+          timeout: 120
+          timeout_effect: deny
+    ```
+
+=== "Python"
+
+    ```python
+    from edictum import Edictum, LocalApprovalBackend
+
+    guard = Edictum.from_yaml(
+        "contracts.yaml",
+        approval_backend=LocalApprovalBackend(),
+    )
+
+    # When the contract fires, the pipeline:
+    # 1. Calls approval_backend.request_approval(...)
+    # 2. Waits up to `timeout` seconds for a decision
+    # 3. If approved -> tool executes normally
+    # 4. If denied -> EdictumDenied is raised
+    # 5. If timeout -> applies timeout_effect (deny or allow)
+    ```
+
+**Three outcomes:**
+
+| Outcome | What happens | Audit event |
+|---------|-------------|-------------|
+| Approved | Tool call proceeds, `on_allow` fires | `CALL_APPROVAL_GRANTED` |
+| Denied | `EdictumDenied` raised, `on_deny` fires | `CALL_APPROVAL_DENIED` |
+| Timeout | Applies `timeout_effect` (default: deny) | `CALL_APPROVAL_TIMEOUT` |
+
+**Gotchas:**
+- If no `approval_backend` is configured on the `Edictum` instance, `effect: approve` raises `EdictumDenied` immediately with the message "Approval required but no approval backend configured."
+- The `timeout` field is in seconds. The default (300s / 5 minutes) is generous for interactive workflows. Reduce it for automated pipelines.
+- `timeout_effect: allow` should only be used when the timeout indicates the operation is safe to proceed (e.g., a low-risk change that just needs acknowledgement).
+- The `tool: "db_*"` selector uses glob matching to cover all database tools. See [tool selectors](../../contracts/yaml-reference.md#precondition) in the YAML reference.
+
+---
+
 ## Blast Radius Limits
 
 Cap the scope of batch operations to prevent agents from making changes that are too large to review or roll back.

--- a/docs/contracts/yaml-reference.md
+++ b/docs/contracts/yaml-reference.md
@@ -158,14 +158,23 @@ Preconditions evaluate **before** tool execution. If the expression matches, the
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `tool` | string | yes | Tool name to target, or `"*"` for all tools. |
+| `tool` | string | yes | Tool name, glob pattern (e.g. `mcp_*`), or `"*"` for all tools. Patterns use Python's `fnmatch`. |
 | `when` | Expression | yes | Boolean expression tree. See [Expression Grammar](#expression-grammar). |
 
 **Constraints:**
 
-- `then.effect` must be `deny`. Preconditions block; they do not warn.
+- `then.effect` must be `deny` or `approve`. Preconditions deny or require human approval; they do not warn.
 - The `output.text` selector is invalid in preconditions because the tool has not run yet. Using it is a validation error.
 - When `mode: observe` is set (either on the contract or via `defaults.mode`), a matching precondition emits a `CALL_WOULD_DENY` audit event instead of denying. The tool call proceeds.
+
+**Approval effect:** When `effect: approve`, the pipeline pauses and requests human approval via the configured `approval_backend`. Two additional fields are available:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `timeout` | integer | `300` | Seconds to wait for an approval decision before applying `timeout_effect`. |
+| `timeout_effect` | `deny` or `allow` | `deny` | What happens when the approval times out. |
+
+If no `approval_backend` is configured on the `Edictum` instance, `effect: approve` raises `EdictumDenied` immediately.
 
 ```yaml
 - id: block-sensitive-reads
@@ -186,7 +195,7 @@ Postconditions evaluate **after** tool execution. They inspect the tool's output
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `tool` | string | yes | Tool name to target, or `"*"` for all tools. |
+| `tool` | string | yes | Tool name, glob pattern (e.g. `mcp_*`), or `"*"` for all tools. Patterns use Python's `fnmatch`. |
 | `when` | Expression | yes | Boolean expression tree. |
 
 **Constraints:**
@@ -451,7 +460,7 @@ then:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `effect` | string | yes | `deny` (block execution), `warn` (log only), or `redact`/`deny` for postconditions. Constrained by contract type. |
+| `effect` | string | yes | `deny` (block execution), `approve` (pause for human approval, pre only), `warn` (log only), or `redact`/`deny` for postconditions. Constrained by contract type. |
 | `message` | string | yes | Human-readable message sent to the agent and recorded in audit. 1-500 characters. |
 | `tags` | array of strings | no | Classification labels. Appear in audit events and can be filtered downstream. |
 | `metadata` | object | no | Arbitrary key-value data stamped into the `Verdict` and audit event. |
@@ -462,7 +471,7 @@ The allowed effect depends on the contract type:
 
 | Contract Type | Allowed Effects | Rationale |
 |---|---|---|
-| `pre` | `deny` only | Preconditions exist to block dangerous calls. |
+| `pre` | `deny`, `approve` | Preconditions deny or pause for human approval. |
 | `post` | `warn`, `redact`, `deny` | `warn` produces findings. `redact` replaces matched patterns. `deny` suppresses output. See [Postcondition Effects](#postcondition-effects). |
 | `session` | `deny` only | Session limits gate further execution. |
 

--- a/docs/lifecycle-callbacks.md
+++ b/docs/lifecycle-callbacks.md
@@ -32,6 +32,8 @@ the pipeline continues normally.
 | Limit exceeded (max_attempts, max_tool_calls) | Fires | -- |
 | All checks pass | -- | Fires |
 | Observe mode converts deny to allow | -- | Fires |
+| Approval granted (`effect: approve`) | -- | Fires |
+| Approval denied or timed out (`effect: approve`) | Fires | -- |
 | Postcondition warns after execution | -- | -- |
 
 `on_deny` does **not** fire in observe mode. In observe mode, the call is allowed
@@ -142,6 +144,7 @@ functions work regardless of which framework you use.
 | **`on_deny`** | React to denials in real time | Pre-execution deny (enforce mode) |
 | **`on_allow`** | React to allowed calls in real time | Pre-execution allow |
 | **`on_postcondition_warn`** | Remediate bad tool output | Post-execution postcondition failure |
+| **`approval_backend`** | Human-in-the-loop approval for tool calls | Pre-execution when `effect: approve` fires |
 | **Audit sinks** | Persistent record of all decisions | Every decision (allow, deny, execute, fail) |
 | **OTel spans** | Production observability | Every decision (with full trace context) |
 
@@ -149,3 +152,32 @@ Lifecycle callbacks are the lightweight, zero-dependency option for users who ne
 real-time reactions without setting up audit sink parsing or OTel infrastructure.
 For production observability at scale, use [OTel](audit/telemetry.md).
 For persistent audit trails, use [audit sinks](audit/sinks.md).
+
+## Approval Backend
+
+The `approval_backend` parameter enables human-in-the-loop approval workflows. When a
+precondition with `effect: approve` fires, the pipeline pauses and delegates to the
+configured backend.
+
+```python
+from edictum import Edictum, LocalApprovalBackend
+
+guard = Edictum.from_yaml(
+    "contracts.yaml",
+    approval_backend=LocalApprovalBackend(),
+)
+```
+
+The `ApprovalBackend` protocol requires two async methods:
+
+| Method | Description |
+|--------|-------------|
+| `request_approval(tool_name, tool_args, message, *, timeout, timeout_effect, principal)` | Creates an approval request and returns an `ApprovalRequest` |
+| `wait_for_decision(approval_id, timeout)` | Blocks until the request is approved, denied, or times out. Returns an `ApprovalDecision` |
+
+`LocalApprovalBackend` prompts on stdout and reads from stdin -- suitable for local
+development and testing. For production use, implement `ApprovalBackend` with your
+own backend (Slack bot, web dashboard, approval queue).
+
+If `effect: approve` fires but no `approval_backend` is configured, the pipeline
+raises `EdictumDenied` immediately.

--- a/src/edictum/__init__.py
+++ b/src/edictum/__init__.py
@@ -15,6 +15,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -707,14 +708,14 @@ class Edictum:
 
     def get_hooks(self, phase: str, envelope: ToolEnvelope) -> list[HookRegistration]:
         hooks = self._before_hooks if phase == "before" else self._after_hooks
-        return [h for h in hooks if h.tool == "*" or h.tool == envelope.tool_name]
+        return [h for h in hooks if h.tool == "*" or fnmatch(envelope.tool_name, h.tool)]
 
     def get_preconditions(self, envelope: ToolEnvelope) -> list:
         result = []
         for p in self._preconditions:
             tool = getattr(p, "_edictum_tool", "*")
             when = getattr(p, "_edictum_when", None)
-            if tool != "*" and tool != envelope.tool_name:
+            if tool != "*" and not fnmatch(envelope.tool_name, tool):
                 continue
             if when and not when(envelope):
                 continue
@@ -726,7 +727,7 @@ class Edictum:
         for p in self._postconditions:
             tool = getattr(p, "_edictum_tool", "*")
             when = getattr(p, "_edictum_when", None)
-            if tool != "*" and tool != envelope.tool_name:
+            if tool != "*" and not fnmatch(envelope.tool_name, tool):
                 continue
             if when and not when(envelope):
                 continue
@@ -741,7 +742,7 @@ class Edictum:
         for p in self._shadow_preconditions:
             tool = getattr(p, "_edictum_tool", "*")
             when = getattr(p, "_edictum_when", None)
-            if tool != "*" and tool != envelope.tool_name:
+            if tool != "*" and not fnmatch(envelope.tool_name, tool):
                 continue
             if when and not when(envelope):
                 continue
@@ -753,7 +754,7 @@ class Edictum:
         for p in self._shadow_postconditions:
             tool = getattr(p, "_edictum_tool", "*")
             when = getattr(p, "_edictum_when", None)
-            if tool != "*" and tool != envelope.tool_name:
+            if tool != "*" and not fnmatch(envelope.tool_name, tool):
                 continue
             if when and not when(envelope):
                 continue
@@ -961,10 +962,73 @@ class Edictum:
         # Pre-execute
         pre = await pipeline.pre_execute(envelope, session)
 
+        # Handle pending_approval: request approval from backend
+        if pre.action == "pending_approval":
+            if self._approval_backend is None:
+                span.end()
+                raise EdictumDenied(
+                    reason=f"Approval required but no approval backend configured: {pre.reason}",
+                    decision_source=pre.decision_source,
+                    decision_name=pre.decision_name,
+                )
+            principal_dict = asdict(envelope.principal) if envelope.principal else None
+            approval_request = await self._approval_backend.request_approval(
+                tool_name=envelope.tool_name,
+                tool_args=envelope.args,
+                message=pre.approval_message or pre.reason or "",
+                timeout=pre.approval_timeout,
+                timeout_effect=pre.approval_timeout_effect,
+                principal=principal_dict,
+            )
+            await self._emit_run_pre_audit(envelope, session, AuditAction.CALL_APPROVAL_REQUESTED, pre)
+            decision = await self._approval_backend.wait_for_decision(
+                approval_id=approval_request.approval_id,
+                timeout=pre.approval_timeout,
+            )
+            # Resolve approval: approved, denied, or timeout (with timeout_effect)
+            approved = decision.approved
+            if not approved and decision.status == ApprovalStatus.TIMEOUT:
+                await self._emit_run_pre_audit(envelope, session, AuditAction.CALL_APPROVAL_TIMEOUT, pre)
+                if pre.approval_timeout_effect == "allow":
+                    approved = True
+            elif decision.approved:
+                await self._emit_run_pre_audit(envelope, session, AuditAction.CALL_APPROVAL_GRANTED, pre)
+            else:
+                await self._emit_run_pre_audit(envelope, session, AuditAction.CALL_APPROVAL_DENIED, pre)
+
+            if approved:
+                self.telemetry.record_allowed(envelope)
+                if self._on_allow:
+                    try:
+                        self._on_allow(envelope)
+                    except Exception:
+                        logger.exception("on_allow callback raised")
+                span.set_attribute("governance.action", "approved")
+                # Skip the normal pre-execution audit/callback logic below —
+                # approval-granted path handles its own audit and callbacks.
+            else:
+                self.telemetry.record_denial(envelope, decision.reason or pre.reason)
+                if self._on_deny:
+                    try:
+                        self._on_deny(envelope, decision.reason or pre.reason or "", pre.decision_name)
+                    except Exception:
+                        logger.exception("on_deny callback raised")
+                span.set_attribute("governance.action", "denied")
+                span.set_attribute("governance.reason", decision.reason or pre.reason or "")
+                span.end()
+                raise EdictumDenied(
+                    reason=decision.reason or pre.reason,
+                    decision_source=pre.decision_source,
+                    decision_name=pre.decision_name,
+                )
+
         # Determine if this is a real deny or just per-contract observed denials
         real_deny = pre.action == "deny" and not pre.observed
 
-        if real_deny:
+        # Skip pre-execution audit for approval-granted path (already handled above)
+        if pre.action == "pending_approval":
+            pass  # Fall through directly to tool execution
+        elif real_deny:
             audit_action = AuditAction.CALL_WOULD_DENY if self.mode == "observe" else AuditAction.CALL_DENIED
             await self._emit_run_pre_audit(envelope, session, audit_action, pre)
             self.telemetry.record_denial(envelope, pre.reason)

--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class PreDecision:
     """Result of pre-execution governance evaluation."""
 
-    action: str  # "allow" | "deny"
+    action: str  # "allow" | "deny" | "pending_approval"
     reason: str | None = None
     decision_source: str | None = None
     decision_name: str | None = None
@@ -31,6 +31,9 @@ class PreDecision:
     observed: bool = False
     policy_error: bool = False
     shadow_results: list[dict] = field(default_factory=list)
+    approval_timeout: int = 300
+    approval_timeout_effect: str = "deny"
+    approval_message: str | None = None
 
 
 @dataclass
@@ -140,6 +143,22 @@ class GovernancePipeline:
 
                 source = getattr(contract, "_edictum_source", "precondition")
                 pe = any(c.get("metadata", {}).get("policy_error") for c in contracts_evaluated)
+
+                effect = getattr(contract, "_edictum_effect", "deny")
+                if effect == "approve":
+                    return PreDecision(
+                        action="pending_approval",
+                        reason=verdict.message,
+                        decision_source=source,
+                        decision_name=contract_record["name"],
+                        hooks_evaluated=hooks_evaluated,
+                        contracts_evaluated=contracts_evaluated,
+                        policy_error=pe,
+                        approval_timeout=getattr(contract, "_edictum_timeout", 300),
+                        approval_timeout_effect=getattr(contract, "_edictum_timeout_effect", "deny"),
+                        approval_message=verdict.message,
+                    )
+
                 return PreDecision(
                     action="deny",
                     reason=verdict.message,

--- a/src/edictum/yaml_engine/compiler.py
+++ b/src/edictum/yaml_engine/compiler.py
@@ -207,6 +207,9 @@ def _compile_pre(
     precondition_fn._edictum_mode = mode
     precondition_fn._edictum_id = contract_id
     precondition_fn._edictum_source = "yaml_precondition"
+    precondition_fn._edictum_effect = then.get("effect", "deny")
+    precondition_fn._edictum_timeout = then.get("timeout", 300)
+    precondition_fn._edictum_timeout_effect = then.get("timeout_effect", "deny")
     if contract.get("_shadow"):
         precondition_fn._edictum_shadow = True
 

--- a/src/edictum/yaml_engine/edictum-v1.schema.json
+++ b/src/edictum/yaml_engine/edictum-v1.schema.json
@@ -126,10 +126,12 @@
           "required": ["effect", "message"],
           "additionalProperties": false,
           "properties": {
-            "effect": { "const": "deny" },
+            "effect": { "enum": ["deny", "approve"] },
             "message": { "$ref": "#/$defs/MessageString" },
             "tags": { "$ref": "#/$defs/Tags" },
-            "metadata": { "$ref": "#/$defs/ThenMetadata" }
+            "metadata": { "$ref": "#/$defs/ThenMetadata" },
+            "timeout": { "type": "integer", "minimum": 1, "default": 300 },
+            "timeout_effect": { "enum": ["deny", "allow"], "default": "deny" }
           }
         }
       }
@@ -194,7 +196,7 @@
     "ToolSelector": {
       "type": "string",
       "minLength": 1,
-      "description": "Tool name or '*' for all tools."
+      "description": "Tool name, glob pattern (e.g. 'mcp_*'), or '*' for all tools."
     },
 
     "MessageString": {

--- a/tests/test_behavior/test_wildcard_behavior.py
+++ b/tests/test_behavior/test_wildcard_behavior.py
@@ -1,0 +1,79 @@
+"""Behavior tests for wildcard (glob) tool matching.
+
+Verifies that tool selectors support glob patterns via fnmatch,
+preserving exact-match and '*' semantics.
+"""
+
+from __future__ import annotations
+
+from edictum import Edictum, Verdict, precondition
+from edictum.envelope import create_envelope
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+
+class TestWildcardBehavior:
+    """Glob pattern tool matching through the public API."""
+
+    def test_glob_pattern_matches_tool(self):
+        """tool: 'mcp_*' in YAML matches mcp_anything."""
+        yaml_content = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-wildcard
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-mcp
+    type: pre
+    tool: "mcp_*"
+    when:
+      args.query:
+        exists: true
+    then:
+      effect: deny
+      message: "MCP tools denied"
+"""
+        guard = Edictum.from_yaml_string(yaml_content, audit_sink=NullAuditSink())
+
+        envelope = create_envelope("mcp_postgres_query", {"query": "SELECT 1"})
+        preconditions = guard.get_preconditions(envelope)
+        assert len(preconditions) == 1
+
+    def test_exact_match_preserved(self):
+        """tool: 'run' still matches only 'run'."""
+
+        @precondition("run")
+        def deny_run(envelope):
+            return Verdict.fail("run denied")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[deny_run],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+
+        # Matches
+        assert len(guard.get_preconditions(create_envelope("run", {}))) == 1
+        # Does not match
+        assert len(guard.get_preconditions(create_envelope("runner", {}))) == 0
+        assert len(guard.get_preconditions(create_envelope("run_tool", {}))) == 0
+
+    def test_star_matches_everything(self):
+        """tool: '*' matches all tools (existing behavior preserved)."""
+
+        @precondition("*")
+        def deny_all(envelope):
+            return Verdict.fail("all denied")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[deny_all],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+
+        assert len(guard.get_preconditions(create_envelope("any_tool", {}))) == 1
+        assert len(guard.get_preconditions(create_envelope("another_tool", {}))) == 1

--- a/tests/test_pipeline_approve.py
+++ b/tests/test_pipeline_approve.py
@@ -1,0 +1,366 @@
+"""Tests for pipeline approval protocol and wildcard tool matching."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from edictum import (
+    Edictum,
+    EdictumDenied,
+    Verdict,
+    precondition,
+)
+from edictum.approval import (
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalStatus,
+    LocalApprovalBackend,
+)
+from edictum.envelope import create_envelope
+from edictum.pipeline import GovernancePipeline
+from edictum.session import Session
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+
+def _make_approval_precondition(tool: str = "*"):
+    """Create a precondition with effect=approve."""
+
+    @precondition(tool)
+    def requires_approval(envelope):
+        return Verdict.fail("Requires human approval")
+
+    requires_approval._edictum_effect = "approve"
+    requires_approval._edictum_timeout = 60
+    requires_approval._edictum_timeout_effect = "deny"
+    return requires_approval
+
+
+class TestPreDecisionApproval:
+    """Pre contract with effect=approve returns pending_approval."""
+
+    async def test_approve_effect_returns_pending_approval(self):
+        backend = MemoryBackend()
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=backend,
+        )
+        session = Session("test", backend)
+        await session.increment_attempts()
+        pipeline = GovernancePipeline(guard)
+        envelope = create_envelope("TestTool", {})
+
+        decision = await pipeline.pre_execute(envelope, session)
+
+        assert decision.action == "pending_approval"
+        assert decision.reason == "Requires human approval"
+
+    async def test_approval_timeout_propagated(self):
+        contract = _make_approval_precondition()
+        contract._edictum_timeout = 120
+        contract._edictum_timeout_effect = "allow"
+
+        backend = MemoryBackend()
+        guard = Edictum(
+            environment="test",
+            contracts=[contract],
+            audit_sink=NullAuditSink(),
+            backend=backend,
+        )
+        session = Session("test", backend)
+        await session.increment_attempts()
+        pipeline = GovernancePipeline(guard)
+        envelope = create_envelope("TestTool", {})
+
+        decision = await pipeline.pre_execute(envelope, session)
+
+        assert decision.action == "pending_approval"
+        assert decision.approval_timeout == 120
+        assert decision.approval_timeout_effect == "allow"
+        assert decision.approval_message == "Requires human approval"
+
+
+class TestRunApprovalBackend:
+    """run() approval backend integration."""
+
+    async def test_no_backend_raises_denied(self):
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+
+        with pytest.raises(EdictumDenied, match="no approval backend configured"):
+            await guard.run("TestTool", {}, lambda: "result")
+
+    async def test_backend_approves_executes_tool(self):
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="deny",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=True,
+            status=ApprovalStatus.APPROVED,
+        )
+
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+        )
+
+        result = await guard.run("TestTool", {}, lambda: "tool-result")
+
+        assert result == "tool-result"
+        mock_backend.request_approval.assert_awaited_once()
+        mock_backend.wait_for_decision.assert_awaited_once()
+
+    async def test_backend_denies_raises_denied(self):
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="deny",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=False,
+            status=ApprovalStatus.DENIED,
+            reason="Reviewer rejected",
+        )
+
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+        )
+
+        with pytest.raises(EdictumDenied, match="Reviewer rejected"):
+            await guard.run("TestTool", {}, lambda: "result")
+
+    async def test_backend_timeout_raises_denied(self):
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="deny",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=False,
+            status=ApprovalStatus.TIMEOUT,
+            reason="Approval timed out",
+        )
+
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+        )
+
+        with pytest.raises(EdictumDenied, match="Approval timed out"):
+            await guard.run("TestTool", {}, lambda: "result")
+
+    async def test_approval_emits_correct_audit_actions(self):
+        """Approval flow emits CALL_APPROVAL_REQUESTED then CALL_APPROVAL_GRANTED."""
+        from edictum.audit import AuditAction
+
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="deny",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=True,
+            status=ApprovalStatus.APPROVED,
+        )
+
+        sink = NullAuditSink()
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=sink,
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+        )
+
+        await guard.run("TestTool", {}, lambda: "result")
+
+        actions = [e.action for e in sink.events]
+        assert AuditAction.CALL_APPROVAL_REQUESTED in actions
+        assert AuditAction.CALL_APPROVAL_GRANTED in actions
+
+    async def test_on_allow_fires_exactly_once_on_approval(self):
+        """on_allow must fire exactly once when approval is granted (not twice)."""
+        from unittest.mock import MagicMock
+
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="deny",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=True,
+            status=ApprovalStatus.APPROVED,
+        )
+
+        on_allow = MagicMock()
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+            on_allow=on_allow,
+        )
+
+        await guard.run("TestTool", {}, lambda: "result")
+        assert on_allow.call_count == 1, f"on_allow fired {on_allow.call_count} times, expected 1"
+
+    async def test_timeout_effect_allow_executes_tool(self):
+        """When timeout_effect is 'allow', a timed-out approval should execute the tool."""
+        contract = _make_approval_precondition()
+        contract._edictum_timeout_effect = "allow"
+
+        mock_backend = AsyncMock()
+        mock_backend.request_approval.return_value = ApprovalRequest(
+            approval_id="req-1",
+            tool_name="TestTool",
+            tool_args={},
+            message="Requires human approval",
+            timeout=60,
+            timeout_effect="allow",
+        )
+        mock_backend.wait_for_decision.return_value = ApprovalDecision(
+            approved=False,
+            status=ApprovalStatus.TIMEOUT,
+            reason="Approval timed out",
+        )
+
+        guard = Edictum(
+            environment="test",
+            contracts=[contract],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=mock_backend,
+        )
+
+        result = await guard.run("TestTool", {}, lambda: "tool-result")
+        assert result == "tool-result"
+
+    async def test_local_approval_backend_via_run(self):
+        """LocalApprovalBackend auto-approves via stdin mock."""
+        from unittest.mock import patch
+
+        backend = LocalApprovalBackend()
+        guard = Edictum(
+            environment="test",
+            contracts=[_make_approval_precondition()],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+            approval_backend=backend,
+        )
+
+        with patch.object(backend, "_read_stdin", return_value="y"):
+            result = await guard.run("TestTool", {}, lambda: "tool-result")
+
+        assert result == "tool-result"
+        assert len(backend._pending) == 1
+
+
+class TestYamlApproveEffect:
+    """YAML contract with effect: approve compiles correctly."""
+
+    def test_yaml_approve_compiles(self):
+        yaml_content = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-approve
+defaults:
+  mode: enforce
+contracts:
+  - id: require-approval
+    type: pre
+    tool: dangerous_tool
+    when:
+      args.action:
+        equals: delete
+    then:
+      effect: approve
+      message: "Deletion requires approval"
+      timeout: 120
+      timeout_effect: allow
+"""
+        guard = Edictum.from_yaml_string(yaml_content, audit_sink=NullAuditSink())
+
+        envelope = create_envelope("dangerous_tool", {"action": "delete"})
+        preconditions = guard.get_preconditions(envelope)
+        assert len(preconditions) == 1
+
+        fn = preconditions[0]
+        assert fn._edictum_effect == "approve"
+        assert fn._edictum_timeout == 120
+        assert fn._edictum_timeout_effect == "allow"
+
+
+class TestWildcardToolMatching:
+    """Wildcard glob patterns in tool selectors."""
+
+    def test_glob_pattern_matches(self):
+        @precondition("mcp_*")
+        def deny_mcp(envelope):
+            return Verdict.fail("MCP denied")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[deny_mcp],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+
+        envelope = create_envelope("mcp_postgres_query", {})
+        assert len(guard.get_preconditions(envelope)) == 1
+
+    def test_glob_pattern_no_match(self):
+        @precondition("read_*")
+        def deny_reads(envelope):
+            return Verdict.fail("Read denied")
+
+        guard = Edictum(
+            environment="test",
+            contracts=[deny_reads],
+            audit_sink=NullAuditSink(),
+            backend=MemoryBackend(),
+        )
+
+        envelope = create_envelope("write_file", {})
+        assert len(guard.get_preconditions(envelope)) == 0


### PR DESCRIPTION
## Summary

Builds on #50 (ApprovalBackend protocol + HITL audit events). Wires the approval protocol into the governance pipeline and adds wildcard tool matching.

- **Approval gates**: Preconditions with `effect: approve` pause the pipeline, request human approval via the configured `ApprovalBackend`, and emit the four HITL audit actions (`CALL_APPROVAL_REQUESTED`, `CALL_APPROVAL_GRANTED`, `CALL_APPROVAL_DENIED`, `CALL_APPROVAL_TIMEOUT`)
- **Wildcard tool matching**: Tool selectors upgraded from exact-match to glob patterns via `fnmatch`, enabling `tool: "mcp_*"` in YAML contracts
- **Docs**: YAML reference, change-control patterns (new Human Approval Gate section), lifecycle callbacks, how-it-works, and architecture updated

## Changes

| File | What |
|------|------|
| `src/edictum/pipeline.py` | `PreDecision` gains 3 approval fields; `pre_execute()` returns `pending_approval` for `effect: approve` |
| `src/edictum/yaml_engine/compiler.py` | Stamps `_edictum_effect`, `_edictum_timeout`, `_edictum_timeout_effect` on pre-contracts |
| `src/edictum/yaml_engine/edictum-v1.schema.json` | PreContract `effect` enum expanded, `timeout`/`timeout_effect` added, ToolSelector updated |
| `src/edictum/__init__.py` | `pending_approval` handling in `run()` using #50's types + audit actions, `fnmatch` in all 6 tool filters |
| `tests/test_pipeline_approve.py` | 14 tests: approval flow, audit events, YAML compile, wildcard matching |
| `tests/test_behavior/test_wildcard_behavior.py` | 3 behavior tests: glob, exact, star matching |
| `docs/contracts/yaml-reference.md` | `effect: approve`, `timeout`, `timeout_effect`, glob tool patterns |
| `docs/contracts/patterns/change-control.md` | New "Human Approval Gate" pattern section |
| `docs/lifecycle-callbacks.md` | `approval_backend` section, updated tables |
| `docs/concepts/how-it-works.md` | Approval gate stage + step-by-step walkthrough |
| `docs/architecture.md` | Pre-execution detail updated for approval protocol |

## Test plan

- [x] `pytest tests/test_pipeline_approve.py -v` — 14 pass
- [x] `pytest tests/test_behavior/test_wildcard_behavior.py -v` — 3 pass
- [x] `pytest tests/ -v` — 1182 pass, 0 regressions
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/test_docs_sync.py -v` — pass
- [x] `python -m mkdocs build --strict` — pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the approval protocol and wildcard tool matching. The wildcard matching feature (`fnmatch` for glob patterns like `mcp_*`) is cleanly implemented across all 6 tool filters in `__init__.py` and properly tested. The schema, compiler, and documentation updates are solid.

However, `src/edictum/__init__.py` has two **critical logic bugs** in the approval flow that violate API contracts:

- **Double callback/audit bug**: When approval is granted (line 988-996), the code emits `CALL_APPROVAL_GRANTED`, calls `record_allowed()`, and fires `on_allow()`. Execution then continues to the `else` branch (line 1043-1072) which emits `CALL_ALLOWED` again, calls `record_allowed()` again, and fires `on_allow()` a second time. The CLAUDE.md API checklist explicitly requires "Callbacks fire exactly once" — this path fires callbacks twice.

- **`timeout_effect: allow` never honored**: When the backend returns timeout with `approved=False` (line 997-1017), the code always raises `EdictumDenied` regardless of `pre.approval_timeout_effect`. A contract declaring `timeout_effect: allow` will deny on timeout instead of allowing, contradicting the declared intent.

These issues were already identified in previous review threads but remain unresolved. The test suite passes because it doesn't verify callback invocation counts or `timeout_effect: allow` execution paths.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — contains two critical logic bugs that violate API contracts
- The wildcard matching feature is well-implemented and the documentation is comprehensive, but the approval flow in `src/edictum/__init__.py` has two showstopper bugs: (1) callbacks fire twice on approval-granted path, violating the "callbacks fire exactly once" contract from CLAUDE.md, and (2) `timeout_effect: allow` is completely ignored, always denying on timeout. These are not edge cases — they're core paths that break the declared API contract.
- `src/edictum/__init__.py` requires fixes to approval logic (lines 988-1017). The approval-granted path must skip the subsequent pre-execution audit/callback logic, and the timeout handling must check `pre.approval_timeout_effect` before raising.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/__init__.py | Adds approval protocol integration and wildcard matching with `fnmatch`. Has two critical logic bugs: approved path fires callbacks twice (violates API contract), and `timeout_effect: allow` is never honored (always denies on timeout). |
| src/edictum/pipeline.py | Extends `PreDecision` with approval fields and adds `pending_approval` action. Returns correct decision structure when `effect: approve` fires. Clean implementation. |
| src/edictum/yaml_engine/compiler.py | Stamps approval metadata onto precondition functions. Correctly extracts `effect`, `timeout`, and `timeout_effect` from YAML `then` block. |
| tests/test_pipeline_approve.py | Comprehensive approval flow tests covering granted/denied/timeout scenarios and audit events. Missing test case: `timeout_effect: allow` allowing execution (only tests deny). |

</details>


</details>


<sub>Last reviewed commit: bc5216d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e37a8046-77ec-4289-8d92-6c2e2896a820))

<!-- /greptile_comment -->