### PR TITLE
fix: normalize paths in sandbox within/not_within checks

### DIFF
--- a/docs/concepts/sandbox-contracts.md
+++ b/docs/concepts/sandbox-contracts.md
@@ -116,7 +116,7 @@ When the pipeline encounters a sandbox contract, it runs through these steps in 
 
 **1. Tool match.** The pipeline checks whether the current tool name matches the sandbox's `tool` or `tools` patterns using `fnmatch`. If the tool does not match, the sandbox contract is skipped entirely.
 
-**2. Path check.** The pipeline extracts file paths from the envelope args -- keys named `path`, `file_path`, `directory`, any arg value starting with `/`, and tokens parsed from command strings. For each extracted path:
+**2. Path check.** The pipeline extracts file paths from the envelope args -- keys named `path`, `file_path`, `directory`, any arg value starting with `/`, and tokens parsed from command strings. Each extracted path is normalized with `os.path.normpath()` before comparison, which resolves `..` and `.` segments and collapses redundant slashes. For example, `/tmp/../etc/shadow` becomes `/etc/shadow`. The `within` and `not_within` boundaries are also normalized at compile time. For each normalized path:
 
 - Check `not_within` first. If the path matches any exclusion prefix, the call is denied (or sent for approval).
 - Check `within`. If the path matches any allowed prefix, it passes.
@@ -223,14 +223,15 @@ Most sandbox features work with just `pip install edictum`. The server (`edictum
 
 ## Known Limitations
 
-Sandbox contracts match against the literal strings in the tool call envelope. They do not resolve or expand values at the OS level. This means several patterns can bypass path-based sandbox enforcement:
+Sandbox contracts normalize path traversal sequences (`..`, `.`, `//`) before evaluation using `os.path.normpath()`. This means `/tmp/../etc/shadow` is correctly resolved to `/etc/shadow` and denied by a `within: [/tmp]` boundary. However, `normpath` is a pure string operation -- it does not access the filesystem. Several patterns remain outside its reach:
 
+- **Symlinks:** `ln -s /etc/shadow /tmp/evil && cat /tmp/evil` -- the sandbox sees `/tmp/evil`, which passes `within: [/tmp]`, but the file resolves to `/etc/shadow`. Symlink attacks require write access to an allowed directory (which the sandbox itself restricts) and a command that follows symlinks.
 - **Tilde expansion:** `cat ~/secrets` -- the sandbox sees `~/secrets`, not `/home/user/secrets`.
 - **Environment variables:** `cat "$HOME/.ssh/id_rsa"` -- the sandbox sees `$HOME/.ssh/id_rsa`, not the resolved path.
 - **Variable interpolation:** `x=/etc; cat $x/shadow` -- the sandbox sees `$x/shadow`.
-- **Relative paths:** `cat ../../etc/shadow` from a working directory inside `/workspace` -- the sandbox sees the relative path, not the resolved absolute path.
+- **Relative paths without leading `/`:** `cat ../../etc/shadow` from a working directory inside `/workspace` -- the sandbox sees the relative path, not the resolved absolute path.
 
-These are inherent to string-level enforcement. For full path resolution, you need OS-level sandboxing (containers, seccomp, AppArmor) as a complementary layer. Edictum's sandbox contracts provide application-level defense -- they catch the common case and raise the bar, but they are not a substitute for OS-level isolation when the threat model requires it.
+These are inherent to string-level enforcement. For full path resolution (including symlinks), you need OS-level sandboxing (containers, seccomp, AppArmor) as a complementary layer. Edictum's sandbox contracts provide application-level defense -- they catch the common case and raise the bar, but they are not a substitute for OS-level isolation when the threat model requires it.
 
 ## Next Steps
 

--- a/docs/contracts/yaml-reference.md
+++ b/docs/contracts/yaml-reference.md
@@ -324,9 +324,9 @@ Sandbox contracts define allowlists -- what agents are permitted to do. Instead 
 
 #### Path Matching
 
-Paths are extracted from the envelope args: keys named `path`, `file_path`, `directory`, or any arg value starting with `/`, plus tokens parsed from command strings.
+Paths are extracted from the envelope args: keys named `path`, `file_path`, `directory`, or any arg value starting with `/`, plus tokens parsed from command strings. All extracted paths are normalized with `os.path.normpath()` before evaluation -- this resolves `..` and `.` segments and collapses redundant slashes (`//`). For example, `/tmp/../etc/shadow` becomes `/etc/shadow`. The `within` and `not_within` boundaries are also normalized at compile time.
 
-Matching uses string prefix logic: `path == allowed OR path.startswith(allowed.rstrip("/") + "/")`. This means `/workspace` allows `/workspace` itself and all children like `/workspace/src/main.py`.
+After normalization, matching uses string prefix logic: `path == allowed OR path.startswith(allowed.rstrip("/") + "/")`. This means `/workspace` allows `/workspace` itself and all children like `/workspace/src/main.py`.
 
 `not_within` overrides `within` -- if a path matches an exclusion, it is denied even if it falls inside an allowed directory.
 

--- a/src/edictum/yaml_engine/compiler.py
+++ b/src/edictum/yaml_engine/compiler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -422,9 +423,11 @@ def _extract_paths(envelope: ToolEnvelope) -> list[str]:
     seen: set[str] = set()
 
     def _add(p: str) -> None:
-        if p and p not in seen:
-            seen.add(p)
-            paths.append(p)
+        if p:
+            p = os.path.normpath(p)
+            if p not in seen:
+                seen.add(p)
+                paths.append(p)
 
     # 1. Envelope convenience field
     if envelope.file_path:
@@ -498,8 +501,8 @@ def _compile_sandbox(contract: dict, mode: str) -> Any:
     else:
         tool_patterns = [contract["tool"]]
 
-    within = contract.get("within", [])
-    not_within = contract.get("not_within", [])
+    within = [os.path.normpath(p) for p in contract.get("within", [])]
+    not_within = [os.path.normpath(p) for p in contract.get("not_within", [])]
     allows = contract.get("allows", {})
     not_allows = contract.get("not_allows", {})
     allowed_commands = allows.get("commands", [])

--- a/tests/test_behavior/test_sandbox_path_traversal.py
+++ b/tests/test_behavior/test_sandbox_path_traversal.py
@@ -1,0 +1,251 @@
+"""Behavior tests for sandbox path traversal normalization.
+
+Every test proves that path traversal sequences (.. / . / //) are
+normalized before sandbox within/not_within evaluation, closing the
+bypass demonstrated in red team session 2026-02-24.
+"""
+
+from __future__ import annotations
+
+import os
+
+from edictum import Edictum, create_envelope
+from edictum.storage import MemoryBackend
+from edictum.yaml_engine.compiler import _extract_paths
+
+
+class NullSink:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event):
+        self.events.append(event)
+
+
+def _guard(yaml: str) -> Edictum:
+    return Edictum.from_yaml_string(yaml, audit_sink=NullSink(), backend=MemoryBackend())
+
+
+# --- _extract_paths normalization ---
+
+
+class TestExtractPathsNormalization:
+    """Paths extracted from envelopes are normalized via os.path.normpath."""
+
+    def test_traversal_resolved(self):
+        """Paths with .. segments are normalized before extraction."""
+        envelope = create_envelope("read_file", {"path": "/tmp/../etc/shadow"})
+        paths = _extract_paths(envelope)
+        assert paths == ["/etc/shadow"]
+
+    def test_dot_segments_collapsed(self):
+        """Redundant . segments are collapsed."""
+        envelope = create_envelope("read_file", {"path": "/tmp/./foo/../bar"})
+        paths = _extract_paths(envelope)
+        assert paths == ["/tmp/bar"]
+
+    def test_double_slash_collapsed(self):
+        """Double slashes are collapsed."""
+        envelope = create_envelope("read_file", {"path": "/tmp//foo//bar"})
+        paths = _extract_paths(envelope)
+        assert paths == ["/tmp/foo/bar"]
+
+    def test_workspace_breakout_resolved(self):
+        """Workspace-rooted traversal is resolved."""
+        envelope = create_envelope("read_file", {"path": "/root/.nanobot/workspace/../../.ssh/id_rsa"})
+        paths = _extract_paths(envelope)
+        assert paths == ["/root/.ssh/id_rsa"]
+
+    def test_command_path_tokens_normalized(self):
+        """Path tokens in commands are also normalized."""
+        envelope = create_envelope("exec", {"command": "cat /tmp/../etc/shadow"})
+        paths = _extract_paths(envelope)
+        assert "/etc/shadow" in paths
+
+    def test_clean_paths_unchanged(self):
+        """normpath on already-clean paths is identity."""
+        assert os.path.normpath("/tmp/foo/bar") == "/tmp/foo/bar"
+        assert os.path.normpath("/root/.nanobot/workspace") == "/root/.nanobot/workspace"
+
+
+# --- Sandbox within bypass ---
+
+
+WITHIN_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: traversal-test
+defaults:
+  mode: enforce
+contracts:
+  - id: file-sandbox
+    type: sandbox
+    tools: [read_file]
+    within: [/tmp]
+    outside: deny
+    message: "Denied"
+"""
+
+
+class TestSandboxWithinTraversal:
+    """Path traversal that escapes within boundary is denied."""
+
+    def test_traversal_tmp_to_etc(self):
+        """/tmp/../etc/shadow resolves to /etc/shadow -- must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/../etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_traversal_double_dotdot(self):
+        """/tmp/./../../etc/passwd -- multiple traversal segments."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/./../../etc/passwd"})
+        assert result.verdict == "deny"
+
+    def test_clean_path_still_allowed(self):
+        """Normal path within boundary still passes."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/myfile.txt"})
+        assert result.verdict == "allow"
+
+    def test_direct_outside_path_still_denied(self):
+        """Direct /etc/shadow (no traversal) is still denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/etc/shadow"})
+        assert result.verdict == "deny"
+
+
+# --- Sandbox not_within bypass ---
+
+
+NOT_WITHIN_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: not-within-traversal
+defaults:
+  mode: enforce
+contracts:
+  - id: file-sandbox
+    type: sandbox
+    tools: [read_file]
+    within: [/workspace]
+    not_within: [/workspace/.git]
+    outside: deny
+    message: "Denied"
+"""
+
+
+class TestSandboxNotWithinTraversal:
+    """Path traversal that lands in not_within target is denied."""
+
+    def test_traversal_into_excluded_dir(self):
+        """Traversal that resolves into .git is denied."""
+        guard = _guard(NOT_WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/workspace/foo/../../workspace/.git/config"})
+        assert result.verdict == "deny"
+
+    def test_direct_excluded_still_denied(self):
+        """Direct access to .git is still denied."""
+        guard = _guard(NOT_WITHIN_YAML)
+        result = guard.evaluate("read_file", {"path": "/workspace/.git/config"})
+        assert result.verdict == "deny"
+
+
+# --- Exec sandbox path traversal ---
+
+
+EXEC_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: exec-traversal
+defaults:
+  mode: enforce
+contracts:
+  - id: exec-sandbox
+    type: sandbox
+    tools: [exec]
+    allows:
+      commands: [cat]
+    within: [/tmp]
+    outside: deny
+    message: "Denied"
+"""
+
+
+class TestExecSandboxTraversal:
+    """Path tokens in exec commands are normalized."""
+
+    def test_exec_command_traversal_denied(self):
+        """cat /tmp/../etc/shadow -- path escapes within via traversal."""
+        guard = _guard(EXEC_YAML)
+        result = guard.evaluate("exec", {"command": "cat /tmp/../etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_exec_clean_path_allowed(self):
+        """cat /tmp/ok.txt -- clean path within boundary."""
+        guard = _guard(EXEC_YAML)
+        result = guard.evaluate("exec", {"command": "cat /tmp/ok.txt"})
+        assert result.verdict == "allow"
+
+
+# --- Red team fixture traversal vectors ---
+
+
+class TestRedTeamTraversalVectors:
+    """All 7 vectors from the red team session spec."""
+
+    YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: red-team-vectors
+defaults:
+  mode: enforce
+contracts:
+  - id: file-sandbox
+    type: sandbox
+    tools: [read_file]
+    within:
+      - /root/.nanobot/workspace
+      - /tmp
+    outside: deny
+    message: "Denied"
+"""
+
+    def test_tmp_etc_shadow(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/../etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_workspace_ssh_breakout(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/root/.nanobot/workspace/../../.ssh/id_rsa"})
+        assert result.verdict == "deny"
+
+    def test_tmp_proc_environ(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/../proc/1/environ"})
+        assert result.verdict == "deny"
+
+    def test_double_traversal_etc_passwd(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/tmp/./../../etc/passwd"})
+        assert result.verdict == "deny"
+
+    def test_workspace_config_breakout(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/root/.nanobot/workspace/../config.json"})
+        assert result.verdict == "deny"
+
+    def test_direct_etc_shadow_still_denied(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_clean_workspace_path_still_allowed(self):
+        guard = _guard(self.YAML)
+        result = guard.evaluate("read_file", {"path": "/root/.nanobot/workspace/README.md"})
+        assert result.verdict == "allow"


### PR DESCRIPTION
## Summary

- Fix path traversal bypass in sandbox `within`/`not_within` checks — `/tmp/../etc/shadow` passed `within:[/tmp]` because path matching used raw string prefix comparison without normalization
- Add `os.path.normpath()` to `_extract_paths()` and `_compile_sandbox()` compile-time boundaries (3 lines of production code)
- Update docs: sandbox-contracts.md (evaluation algorithm + known limitations) and yaml-reference.md (path matching section)

## Root Cause

`_extract_paths()` stored paths as-is from envelope args. The `within` check did `path.startswith(allowed.rstrip("/") + "/")` — pure string comparison. `/tmp/../etc/shadow` starts with `/tmp/` so it passed, but resolves to `/etc/shadow`.

6 of 7 red team traversal vectors bypassed the sandbox. Only direct paths (no `..`) were caught.

## The Fix

`os.path.normpath()` — resolves `..`, `.`, and `//` as a pure string operation. No filesystem I/O, no symlink resolution, works in test harnesses and remote evaluation. Applied in two places:

1. `_extract_paths()._add()` — normalizes all extracted paths before dedup and comparison
2. `_compile_sandbox()` — normalizes `within` and `not_within` lists at compile time

## Test plan

- [ ] 21 new behavior tests in `test_sandbox_path_traversal.py` (all 7 red team vectors, `_extract_paths` normalization, within/not_within traversal, exec command tokens)
- [ ] Full suite: 1342 tests pass, zero regressions
- [ ] `ruff check src/ tests/` clean
- [ ] `mkdocs build --strict` clean
- [ ] `pytest tests/test_docs_sync.py` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed path traversal bypass in sandbox `within`/`not_within` checks by normalizing paths with `os.path.normpath()` before evaluation. Previously, paths like `/tmp/../etc/shadow` passed `within:[/tmp]` boundaries due to raw string prefix comparison, allowing 6 of 7 red team traversal vectors to bypass the sandbox.

The fix adds normalization in two places:
- `_extract_paths()._add()` — normalizes all extracted paths (from args, command tokens) before deduplication
- `_compile_sandbox()` — normalizes `within`/`not_within` boundaries at compile time

All 21 new behavior tests pass, covering the 7 red team vectors, `_extract_paths` normalization, and traversal in `within`/`not_within`/exec contexts. Full suite: 1342 tests pass with zero regressions. Documentation updated to explain normalization behavior and remaining limitations (symlinks, tilde expansion, env vars).

<h3>Confidence Score: 5/5</h3>

- Critical security fix with comprehensive test coverage and zero regressions
- This PR fixes a path traversal vulnerability with a minimal, correct implementation using Python's standard `os.path.normpath()`. The fix is applied in exactly the right places (extraction and boundary compilation), test coverage is exhaustive (21 new tests covering all attack vectors), and the full test suite passes without regressions. Documentation accurately reflects the fix and its limitations.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/yaml_engine/compiler.py | Added `os.path.normpath()` to `_extract_paths()` and `_compile_sandbox()` to resolve path traversal sequences, closing security bypass |
| tests/test_behavior/test_sandbox_path_traversal.py | Added 21 behavior tests covering all 7 red team traversal vectors and normalization in `_extract_paths()`, `within`, and `not_within` checks |

</details>


</details>


<sub>Last reviewed commit: 9761efa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->