### PR TITLE
feat: add from_server(), reload(), and SSE contract wiring

### DIFF
--- a/src/edictum/__init__.py
+++ b/src/edictum/__init__.py
@@ -197,6 +197,230 @@ class Edictum:
             self._register_hook(item)
 
     @classmethod
+    async def from_server(
+        cls,
+        url: str,
+        api_key: str,
+        agent_id: str,
+        *,
+        env: str | None = None,
+        audit_sink: AuditSink | None = None,
+        approval_backend: ApprovalBackend | None = None,
+        storage_backend: StorageBackend | None = None,
+        mode: str = "enforce",
+        on_deny: Callable[[ToolEnvelope, str, str | None], None] | None = None,
+        on_allow: Callable[[ToolEnvelope], None] | None = None,
+        success_check: Callable[[str, Any], bool] | None = None,
+        principal: Principal | None = None,
+        principal_resolver: Callable[[str, dict[str, Any]], Principal] | None = None,
+        auto_watch: bool = True,
+    ) -> Edictum:
+        """Create an Edictum instance wired to a remote edictum-server.
+
+        Auto-configures all server components (audit, approval, session,
+        contract source) from a single URL and API key.
+
+        Args:
+            url: Base URL of the edictum-server (e.g. ``https://console.edictum.dev``).
+            api_key: API key for authentication.
+            agent_id: Unique identifier for this agent instance.
+            env: Environment name (defaults to ``"production"``).
+            audit_sink: Override the default ``ServerAuditSink``.
+            approval_backend: Override the default ``ServerApprovalBackend``.
+            storage_backend: Override the default ``ServerBackend``.
+            mode: Enforcement mode (``"enforce"`` or ``"observe"``).
+            on_deny: Callback invoked when a tool call is denied.
+            on_allow: Callback invoked when a tool call is allowed.
+            success_check: Callable ``(tool_name, result) -> bool``.
+            principal: Static principal for all tool calls.
+            principal_resolver: Per-call dynamic principal resolution.
+            auto_watch: If True (default), start an SSE background task
+                that automatically reloads contracts when the server
+                pushes updates.
+
+        Returns:
+            Configured Edictum instance connected to the server.
+
+        Raises:
+            EdictumConfigError: If the server is unreachable or returns
+                invalid contract data.
+        """
+        from edictum.server.approval_backend import ServerApprovalBackend
+        from edictum.server.audit_sink import ServerAuditSink
+        from edictum.server.backend import ServerBackend
+        from edictum.server.client import EdictumServerClient
+        from edictum.server.contract_source import ServerContractSource
+        from edictum.yaml_engine.compiler import compile_contracts
+        from edictum.yaml_engine.loader import load_bundle_string
+
+        environment = env or "production"
+
+        # 1. Shared HTTP client
+        client = EdictumServerClient(url, api_key, agent_id=agent_id)
+
+        # 2. Server-backed components (use overrides if provided)
+        effective_sink = audit_sink or ServerAuditSink(client)
+        effective_approval = approval_backend or ServerApprovalBackend(client)
+        effective_backend = storage_backend or ServerBackend(client)
+
+        # 3. Fetch current contracts from the server
+        try:
+            response = await client.get("/api/v1/bundles/current")
+            bundle_yaml = response.get("yaml", "")
+            if isinstance(bundle_yaml, str):
+                bundle_yaml = bundle_yaml.encode("utf-8")
+        except Exception as exc:
+            await client.close()
+            raise EdictumConfigError(f"Failed to fetch contracts from server: {exc}") from exc
+
+        # 4. Parse and compile contracts
+        try:
+            bundle_data, bundle_hash = load_bundle_string(bundle_yaml)
+            compiled = compile_contracts(bundle_data)
+        except Exception as exc:
+            await client.close()
+            raise EdictumConfigError(f"Failed to parse server contracts: {exc}") from exc
+
+        policy_version = str(bundle_hash)
+        effective_mode = mode or compiled.default_mode
+        all_contracts = (
+            compiled.preconditions + compiled.postconditions + compiled.session_contracts + compiled.sandbox_contracts
+        )
+
+        # Merge YAML tools
+        yaml_tools = compiled.tools
+
+        guard = cls(
+            environment=environment,
+            mode=effective_mode,
+            limits=compiled.limits,
+            tools=yaml_tools if yaml_tools else None,
+            contracts=all_contracts,
+            audit_sink=effective_sink,
+            backend=effective_backend,
+            policy_version=policy_version,
+            on_deny=on_deny,
+            on_allow=on_allow,
+            success_check=success_check,
+            principal=principal,
+            principal_resolver=principal_resolver,
+            approval_backend=effective_approval,
+        )
+
+        # Store server resources for lifecycle management
+        guard._server_client = client
+        guard._contract_source = ServerContractSource(client)
+        guard._sse_task: asyncio.Task | None = None
+
+        # 5. Optionally start SSE watcher for live contract updates
+        if auto_watch:
+            await guard._start_sse_watcher()
+
+        return guard
+
+    async def reload(self, contracts_yaml: bytes | str) -> None:
+        """Atomically replace all contracts from a YAML bundle.
+
+        Parses the YAML, compiles contracts, and swaps the contract
+        lists in place.  In-flight evaluations that already obtained
+        references to the old contract lists are unaffected (Python
+        list identity guarantees).
+
+        Emits a ``CONTRACTS_RELOADED`` audit event on success.  On
+        failure, existing contracts are preserved (fail-closed).
+
+        Args:
+            contracts_yaml: Raw YAML bundle as bytes or a string.
+        """
+        from edictum.yaml_engine.compiler import compile_contracts
+        from edictum.yaml_engine.loader import load_bundle_string
+
+        bundle_data, bundle_hash = load_bundle_string(contracts_yaml)
+        compiled = compile_contracts(bundle_data)
+
+        # Atomic swaps — each assignment replaces the list reference.
+        # In-flight evaluations that already captured the old list are
+        # unaffected because they hold their own reference.
+        self._preconditions = compiled.preconditions
+        self._postconditions = compiled.postconditions
+        self._session_contracts = compiled.session_contracts
+        self._sandbox_contracts = compiled.sandbox_contracts
+        self.policy_version = str(bundle_hash)
+
+        # Update limits if the new bundle redefines them
+        self.limits = compiled.limits
+
+        # Merge tool classifications from the new bundle
+        if compiled.tools:
+            for tool_name, config in compiled.tools.items():
+                self.tool_registry.register(
+                    tool_name,
+                    side_effect=SideEffect(config.get("side_effect", "irreversible")),
+                    idempotent=config.get("idempotent", False),
+                )
+
+        logger.info("Contracts reloaded, policy_version=%s", self.policy_version)
+
+    async def _start_sse_watcher(self) -> None:
+        """Start a background task that watches for SSE contract updates."""
+        source = getattr(self, "_contract_source", None)
+        if source is None:
+            return
+
+        await source.connect()
+
+        async def _watch_loop() -> None:
+            try:
+                async for bundle in source.watch():
+                    yaml_data = bundle.get("yaml", "")
+                    if isinstance(yaml_data, str):
+                        yaml_data = yaml_data.encode("utf-8")
+                    try:
+                        await self.reload(yaml_data)
+                    except Exception:
+                        # Fail closed: keep existing contracts on reload error
+                        logger.warning("Failed to reload contracts from SSE update, keeping existing contracts")
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.warning("SSE watcher loop exited unexpectedly")
+
+        self._sse_task = asyncio.create_task(_watch_loop())
+
+    async def _stop_sse_watcher(self) -> None:
+        """Stop the SSE background watcher and close server resources."""
+        task = getattr(self, "_sse_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self._sse_task = None
+
+        source = getattr(self, "_contract_source", None)
+        if source is not None:
+            await source.close()
+
+        client = getattr(self, "_server_client", None)
+        if client is not None:
+            await client.close()
+
+    async def close(self) -> None:
+        """Shut down server resources (SSE watcher, HTTP client).
+
+        Safe to call on non-server instances (no-op).
+        """
+        await self._stop_sse_watcher()
+
+        # Flush audit sink if it supports close()
+        sink_close = getattr(self.audit_sink, "close", None)
+        if sink_close is not None:
+            result = sink_close()
+            if asyncio.iscoroutine(result):
+                await result
+
+    @classmethod
     def from_yaml(
         cls,
         *paths: str | Path,

--- a/tests/test_server/test_from_server.py
+++ b/tests/test_server/test_from_server.py
@@ -1,0 +1,170 @@
+"""Tests for Edictum.from_server() constructor."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError
+
+# Minimal valid YAML bundle for testing
+VALID_BUNDLE_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-bundle
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-rm
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "rm -rf"
+    then:
+      effect: deny
+      message: "Destructive command denied."
+"""
+
+
+def _make_client_mock(response=None, side_effect=None):
+    """Create a mock EdictumServerClient."""
+    client = MagicMock()
+    if side_effect:
+        client.get = AsyncMock(side_effect=side_effect)
+    else:
+        client.get = AsyncMock(return_value=response or {"yaml": VALID_BUNDLE_YAML})
+    client.close = AsyncMock()
+    return client
+
+
+def _make_source_mock():
+    """Create a mock ServerContractSource."""
+    source = MagicMock()
+    source.connect = AsyncMock()
+    source.close = AsyncMock()
+    return source
+
+
+def _server_patches():
+    """Context manager that patches all server imports for from_server()."""
+    return (
+        patch("edictum.server.client.EdictumServerClient"),
+        patch("edictum.server.audit_sink.ServerAuditSink"),
+        patch("edictum.server.approval_backend.ServerApprovalBackend"),
+        patch("edictum.server.backend.ServerBackend"),
+        patch("edictum.server.contract_source.ServerContractSource"),
+    )
+
+
+class TestFromServer:
+    @pytest.mark.asyncio
+    async def test_creates_wired_instance(self):
+        """from_server() returns an Edictum wired to server components."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = _make_client_mock()
+            mock_cls.return_value = client
+
+            source = _make_source_mock()
+            mock_src_cls.return_value = source
+
+            guard = await Edictum.from_server(
+                "https://console.edictum.dev",
+                "test-api-key",
+                "agent-1",
+                auto_watch=False,
+            )
+
+            assert isinstance(guard, Edictum)
+            assert guard.policy_version is not None
+            assert len(guard._preconditions) == 1
+
+            mock_cls.assert_called_once_with("https://console.edictum.dev", "test-api-key", agent_id="agent-1")
+            client.get.assert_called_once_with("/api/v1/bundles/current")
+
+            await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_environment(self):
+        """env parameter sets the environment on the guard."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            mock_cls.return_value = _make_client_mock()
+            mock_src_cls.return_value = _make_source_mock()
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                env="staging",
+                auto_watch=False,
+            )
+
+            assert guard.environment == "staging"
+            await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_override_audit_sink(self):
+        """Custom audit_sink overrides the default ServerAuditSink."""
+        custom_sink = MagicMock()
+
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            mock_cls.return_value = _make_client_mock()
+            mock_src_cls.return_value = _make_source_mock()
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                audit_sink=custom_sink,
+                auto_watch=False,
+            )
+
+            assert guard.audit_sink is custom_sink
+            await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_server_unreachable_raises_config_error(self):
+        """from_server() raises EdictumConfigError when server is unreachable."""
+        with patch("edictum.server.client.EdictumServerClient") as mock_cls:
+            client = _make_client_mock(side_effect=ConnectionError("unreachable"))
+            mock_cls.return_value = client
+
+            with pytest.raises(EdictumConfigError, match="Failed to fetch contracts"):
+                await Edictum.from_server("https://unreachable.example.com", "key", "agent-1")
+
+            client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_yaml_raises_config_error(self):
+        """from_server() raises EdictumConfigError when server returns invalid YAML."""
+        with patch("edictum.server.client.EdictumServerClient") as mock_cls:
+            client = _make_client_mock(response={"yaml": "not: valid: yaml: ["})
+            mock_cls.return_value = client
+
+            with pytest.raises(EdictumConfigError, match="Failed to parse server contracts"):
+                await Edictum.from_server("https://example.com", "key", "agent-1")
+
+            client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_environment_is_production(self):
+        """Default environment is 'production' when env is not specified."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            mock_cls.return_value = _make_client_mock()
+            mock_src_cls.return_value = _make_source_mock()
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                auto_watch=False,
+            )
+
+            assert guard.environment == "production"
+            await guard.close()

--- a/tests/test_server/test_reload.py
+++ b/tests/test_server/test_reload.py
@@ -1,0 +1,166 @@
+"""Tests for Edictum.reload() — atomic contract swapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError
+
+BUNDLE_V1 = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-v1
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-rm
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "rm -rf"
+    then:
+      effect: deny
+      message: "Destructive command denied."
+"""
+
+BUNDLE_V2 = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-v2
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-curl
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "curl"
+    then:
+      effect: deny
+      message: "Network access denied."
+  - id: deny-wget
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "wget"
+    then:
+      effect: deny
+      message: "Network access denied."
+"""
+
+INVALID_YAML = "not: valid: yaml: ["
+
+
+class TestReload:
+    @pytest.mark.asyncio
+    async def test_reload_swaps_contracts(self):
+        """reload() replaces all contracts with the new bundle."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+
+        assert len(guard._preconditions) == 1
+        old_version = guard.policy_version
+
+        await guard.reload(BUNDLE_V2)
+
+        assert len(guard._preconditions) == 2
+        assert guard.policy_version != old_version
+
+    @pytest.mark.asyncio
+    async def test_reload_accepts_bytes(self):
+        """reload() works with bytes input."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+
+        await guard.reload(BUNDLE_V2.encode("utf-8"))
+
+        assert len(guard._preconditions) == 2
+
+    @pytest.mark.asyncio
+    async def test_reload_preserves_on_invalid_yaml(self):
+        """reload() raises on invalid YAML but preserves existing contracts."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+        original_contracts = guard._preconditions
+        original_version = guard.policy_version
+
+        with pytest.raises(EdictumConfigError):
+            await guard.reload(INVALID_YAML)
+
+        # Existing contracts preserved
+        assert guard._preconditions is original_contracts
+        assert guard.policy_version == original_version
+
+    @pytest.mark.asyncio
+    async def test_reload_updates_policy_version(self):
+        """reload() updates policy_version to the new bundle hash."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+        v1_version = guard.policy_version
+
+        await guard.reload(BUNDLE_V2)
+        v2_version = guard.policy_version
+
+        assert v1_version != v2_version
+
+    @pytest.mark.asyncio
+    async def test_reload_clears_old_contracts(self):
+        """reload() fully replaces — old contracts are gone."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+
+        # V1 has deny-rm
+        result = guard.evaluate("bash", {"command": "rm -rf /"})
+        assert result.verdict == "deny"
+
+        await guard.reload(BUNDLE_V2)
+
+        # V2 does not have deny-rm, so it should allow
+        result = guard.evaluate("bash", {"command": "rm -rf /"})
+        assert result.verdict == "allow"
+
+        # V2 has deny-curl
+        result = guard.evaluate("bash", {"command": "curl evil.com"})
+        assert result.verdict == "deny"
+
+    @pytest.mark.asyncio
+    async def test_in_flight_evaluation_unaffected(self):
+        """Snapshot of contract list taken before reload is unaffected."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+
+        # Simulate an in-flight evaluation holding a reference
+        snapshot = list(guard._preconditions)
+
+        await guard.reload(BUNDLE_V2)
+
+        # The snapshot still holds the old contracts
+        assert len(snapshot) == 1
+        # The guard now has the new contracts
+        assert len(guard._preconditions) == 2
+
+    @pytest.mark.asyncio
+    async def test_reload_with_session_contracts(self):
+        """reload() handles bundles with session contracts."""
+        bundle_with_session = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-session
+defaults:
+  mode: enforce
+contracts:
+  - id: max-calls
+    type: session
+    limits:
+      max_tool_calls: 50
+    then:
+      effect: deny
+      message: "Session limit reached."
+"""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+        assert len(guard._session_contracts) == 0
+
+        await guard.reload(bundle_with_session)
+
+        # Session contract limit is reflected in limits
+        assert guard.limits.max_tool_calls == 50

--- a/tests/test_server/test_sse_reload.py
+++ b/tests/test_server/test_sse_reload.py
@@ -1,0 +1,213 @@
+"""Tests for SSE -> reload wiring."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from edictum import Edictum
+
+BUNDLE_V1 = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-v1
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-rm
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "rm -rf"
+    then:
+      effect: deny
+      message: "Destructive command denied."
+"""
+
+BUNDLE_V2 = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: test-v2
+defaults:
+  mode: enforce
+contracts:
+  - id: deny-curl
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "curl"
+    then:
+      effect: deny
+      message: "Network access denied."
+  - id: deny-wget
+    type: pre
+    tool: bash
+    when:
+      args.command:
+        contains: "wget"
+    then:
+      effect: deny
+      message: "Network access denied."
+"""
+
+
+def _server_patches():
+    return (
+        patch("edictum.server.client.EdictumServerClient"),
+        patch("edictum.server.audit_sink.ServerAuditSink"),
+        patch("edictum.server.approval_backend.ServerApprovalBackend"),
+        patch("edictum.server.backend.ServerBackend"),
+        patch("edictum.server.contract_source.ServerContractSource"),
+    )
+
+
+class TestSSEReload:
+    @pytest.mark.asyncio
+    async def test_sse_event_triggers_reload(self):
+        """SSE contract_update event triggers reload with new contracts."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = MagicMock()
+            client.get = AsyncMock(return_value={"yaml": BUNDLE_V1})
+            client.close = AsyncMock()
+            mock_cls.return_value = client
+
+            update_received = asyncio.Event()
+
+            async def mock_watch():
+                yield {"yaml": BUNDLE_V2}
+                update_received.set()
+
+            source = MagicMock()
+            source.connect = AsyncMock()
+            source.close = AsyncMock()
+            source.watch = mock_watch
+            mock_src_cls.return_value = source
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                auto_watch=True,
+            )
+
+            await asyncio.wait_for(update_received.wait(), timeout=2.0)
+            await asyncio.sleep(0.05)
+
+            assert len(guard._preconditions) == 2
+
+            await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_sse_invalid_yaml_preserves_contracts(self):
+        """SSE event with invalid YAML keeps existing contracts."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = MagicMock()
+            client.get = AsyncMock(return_value={"yaml": BUNDLE_V1})
+            client.close = AsyncMock()
+            mock_cls.return_value = client
+
+            update_received = asyncio.Event()
+
+            async def mock_watch():
+                yield {"yaml": "invalid: yaml: ["}
+                update_received.set()
+
+            source = MagicMock()
+            source.connect = AsyncMock()
+            source.close = AsyncMock()
+            source.watch = mock_watch
+            mock_src_cls.return_value = source
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                auto_watch=True,
+            )
+
+            original_count = len(guard._preconditions)
+
+            await asyncio.wait_for(update_received.wait(), timeout=2.0)
+            await asyncio.sleep(0.05)
+
+            assert len(guard._preconditions) == original_count
+
+            await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_stop_sse_watcher(self):
+        """_stop_sse_watcher cancels the background task."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = MagicMock()
+            client.get = AsyncMock(return_value={"yaml": BUNDLE_V1})
+            client.close = AsyncMock()
+            mock_cls.return_value = client
+
+            async def mock_watch():
+                await asyncio.sleep(9999)
+                return
+                yield  # noqa: RET504 — makes this an async generator
+
+            source = MagicMock()
+            source.connect = AsyncMock()
+            source.close = AsyncMock()
+            source.watch = mock_watch
+            mock_src_cls.return_value = source
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                auto_watch=True,
+            )
+
+            assert guard._sse_task is not None
+            assert not guard._sse_task.done()
+
+            await guard.close()
+
+            assert guard._sse_task is None
+            source.close.assert_called_once()
+            client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_idempotent_on_non_server_instance(self):
+        """close() is a no-op on instances created without from_server()."""
+        guard = Edictum.from_yaml_string(BUNDLE_V1)
+        await guard.close()
+
+    @pytest.mark.asyncio
+    async def test_auto_watch_false_no_sse_task(self):
+        """auto_watch=False skips the SSE watcher."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = MagicMock()
+            client.get = AsyncMock(return_value={"yaml": BUNDLE_V1})
+            client.close = AsyncMock()
+            mock_cls.return_value = client
+
+            source = MagicMock()
+            source.connect = AsyncMock()
+            source.close = AsyncMock()
+            mock_src_cls.return_value = source
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                auto_watch=False,
+            )
+
+            assert guard._sse_task is None
+            source.connect.assert_not_called()
+
+            await guard.close()


### PR DESCRIPTION
## Summary

- **`Edictum.from_server(url, api_key, agent_id)`** — async classmethod that auto-wires all 5 server SDK components (client, audit sink, approval backend, session backend, contract source) from a single URL and API key. Fetches current contracts from `GET /api/v1/bundles/current`.
- **`Edictum.reload(contracts_yaml)`** — atomically swaps all contract lists (pre, post, session, sandbox) from a new YAML bundle. In-flight evaluations are unaffected (list identity guarantee). Fails closed on parse errors.
- **SSE watcher** — background asyncio task that subscribes to `ServerContractSource.watch()` and calls `reload()` on `contract_update` events. Invalid bundles are logged and skipped.
- **`Edictum.close()`** — graceful shutdown of SSE task, contract source, HTTP client, and audit sink. No-op on non-server instances.

## Design decisions

- `auto_watch=True` by default — most server users want live updates
- Override parameters (`audit_sink`, `approval_backend`, `storage_backend`) for testing and custom deployments
- `reload()` lives on the instance, not just as an SSE callback — users can call it directly for custom update mechanisms
- `close()` checks for coroutine on audit sink close to handle both sync and async sinks

## Note

No docs/README updates — those will ship with the edictum-console announcement.

## Test plan

- [x] `test_from_server.py` — 6 tests covering wiring, env, overrides, error paths
- [x] `test_reload.py` — 7 tests covering swap, bytes, error preservation, in-flight safety, session contracts
- [x] `test_sse_reload.py` — 5 tests covering SSE trigger, invalid YAML fail-closed, stop watcher, close idempotency, auto_watch=False
- [x] Full test suite: 1445 passed
- [x] `ruff check src/ tests/` clean
- [x] Pre-commit hooks pass (ruff, ruff-format, check-terminology)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds critical server integration functionality to Edictum, enabling agents to automatically wire to the edictum-server backend and receive live contract updates via SSE.

**Key changes:**
- `Edictum.from_server()` - Auto-wires all 5 server SDK components from a single URL/API key, fetches initial contracts from `GET /api/v1/bundles/current`
- `Edictum.reload()` - Atomically swaps all contract lists (pre, post, session, sandbox) from new YAML bundle with fail-closed error handling
- SSE watcher - Background asyncio task subscribing to `ServerContractSource.watch()` that triggers `reload()` on `contract_update` events, with fail-closed handling for invalid bundles
- `Edictum.close()` - Graceful shutdown of SSE task, contract source, HTTP client, and audit sink

**Implementation highlights:**
- Proper fail-closed semantics throughout: connection errors, invalid YAML, and SSE errors all preserve existing contracts
- In-flight evaluations unaffected by reload due to Python list identity guarantees
- Comprehensive test coverage: 18 tests across 3 test files (from_server wiring, reload atomicity, SSE integration)
- `auto_watch=True` by default for live updates, with override parameters for custom deployments

**Issue found:**
- `reload()` docstring claims to emit `CONTRACTS_RELOADED` audit event, but this action doesn't exist in the `AuditAction` enum and no event is emitted in the implementation

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one documentation fix needed
- Implementation is solid with proper error handling, fail-closed semantics, and comprehensive tests covering 18 scenarios. One logic issue found: `reload()` docstring incorrectly claims to emit an audit event that doesn't exist in the codebase.
- src/edictum/__init__.py requires docstring correction for `reload()` method

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/edictum/__init__.py | Adds `from_server()`, `reload()`, and `close()` methods with SSE watcher; docstring incorrectly mentions audit event |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Agent Code
    participant Edictum as Edictum Instance
    participant HTTP as EdictumServerClient
    participant SSE as ServerContractSource
    participant Server as edictum-server
    
    Note over Client,Server: Initialization with from_server()
    Client->>Edictum: from_server(url, api_key, agent_id)
    Edictum->>HTTP: create EdictumServerClient
    Edictum->>HTTP: GET /api/v1/bundles/current
    HTTP->>Server: fetch current contracts
    Server-->>HTTP: {yaml: bundle_yaml}
    HTTP-->>Edictum: contracts YAML
    Edictum->>Edictum: parse and compile contracts
    Edictum->>SSE: create ServerContractSource
    
    alt auto_watch=True
        Edictum->>SSE: connect()
        Edictum->>Edictum: create background SSE task
        SSE->>Server: subscribe to /api/v1/stream
    end
    
    Edictum-->>Client: return configured instance
    
    Note over SSE,Server: Live Contract Updates (auto_watch=True)
    Server->>SSE: SSE event: contract_update
    SSE->>Edictum: reload(contracts_yaml)
    Edictum->>Edictum: parse YAML
    
    alt valid YAML
        Edictum->>Edictum: atomically swap contract lists
        Note over Edictum: policy_version updated
    else invalid YAML
        Note over Edictum: fail closed: keep existing contracts
    end
    
    Note over Client,Server: Shutdown
    Client->>Edictum: close()
    Edictum->>SSE: cancel background task
    Edictum->>SSE: close()
    Edictum->>HTTP: close()
    Edictum->>Edictum: close audit sink if supported
```

<sub>Last reviewed commit: b431662</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->