### PR TITLE
fix: add author_association guard to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add `author_association` checks (MEMBER, OWNER, COLLABORATOR) to every branch of the Claude workflow `if` condition
- Prevents external GitHub users from triggering the bot by mentioning `@claude` in comments, reviews, or issues
- No changes to permissions, steps, or any other workflow logic

## Test plan
- [ ] Verify workflow YAML is valid (GitHub Actions syntax check on push)
- [ ] Confirm the workflow no longer triggers for users with `NONE` or `FIRST_TIME_CONTRIBUTOR` association
- [ ] Confirm repo members (MEMBER/OWNER/COLLABORATOR) can still trigger the bot as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Security hardening for the Claude workflow to prevent unauthorized bot access. Added `author_association` checks (MEMBER, OWNER, COLLABORATOR) to every trigger condition in `.github/workflows/claude.yml`, ensuring only repo members can invoke the bot via `@claude` mentions. Also adds `PROMPT-SERVER-GLUE.md` documentation for planned server integration features.

- Correctly implements `contains(fromJSON('[...]'), author_association)` pattern across all four event types
- Covers `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events
- Fail-secure: undefined or missing `author_association` values will not trigger the workflow
- No changes to permissions, steps, or other workflow logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Security-focused configuration change with straightforward logic, no code modification, and clear fail-secure behavior
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/claude.yml | Added `author_association` guards to all workflow trigger conditions to restrict bot access to repo members only |
| PROMPT-SERVER-GLUE.md | New documentation file describing implementation requirements for server integration features (`from_server()` and `reload()` methods) |

</details>


</details>


<sub>Last reviewed commit: 815eca7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->