### PR TITLE
fix: ExprLeaf/ExprNot oneOf conflict in JSON Schema (#66)

### DIFF
--- a/schemas/edictum-v1.schema.json
+++ b/schemas/edictum-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://edictum.dev/schemas/edictum-v1-contractbundle.json",
   "title": "Edictum ContractBundle v1",
-  "description": "Schema for Edictum YAML contract bundles. Enforces structure, type-specific constraints, and effect rules.",
+  "description": "Schema for Edictum YAML contract bundles. Enforces structure, type-specific constraints, and effect constraints.",
   "type": "object",
   "required": ["apiVersion", "kind", "metadata", "defaults", "contracts"],
   "additionalProperties": false,
@@ -253,6 +253,11 @@
       "minProperties": 1,
       "maxProperties": 1,
       "description": "A single selector:operator pair. Selector validation done in Python validator.",
+      "properties": {
+        "all": false,
+        "any": false,
+        "not": false
+      },
       "additionalProperties": { "$ref": "#/$defs/Operator" }
     },
 

--- a/src/edictum/yaml_engine/edictum-v1.schema.json
+++ b/src/edictum/yaml_engine/edictum-v1.schema.json
@@ -367,6 +367,11 @@
       "minProperties": 1,
       "maxProperties": 1,
       "description": "A single selector:operator pair. Selector validation done in Python validator.",
+      "properties": {
+        "all": false,
+        "any": false,
+        "not": false
+      },
       "additionalProperties": { "$ref": "#/$defs/Operator" }
     },
 

--- a/tests/test_behavior/test_schema_expression_behavior.py
+++ b/tests/test_behavior/test_schema_expression_behavior.py
@@ -1,0 +1,126 @@
+"""Behavior tests for JSON Schema validation of boolean expressions (#66)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from edictum import Edictum
+
+_ROOT = Path(__file__).resolve().parents[2]
+YAML_ENGINE_SCHEMA_PATH = _ROOT / "src" / "edictum" / "yaml_engine" / "edictum-v1.schema.json"
+STANDALONE_SCHEMA_PATH = _ROOT / "schemas" / "edictum-v1.schema.json"
+
+_schema_cache: dict[str, dict] = {}
+
+
+def _load_schema(path: str) -> dict:
+    if path not in _schema_cache:
+        _schema_cache[path] = json.loads(Path(path).read_text())
+    return _schema_cache[path]
+
+
+def _make_bundle(when_expr: dict) -> dict:
+    return {
+        "apiVersion": "edictum/v1",
+        "kind": "ContractBundle",
+        "metadata": {"name": "test"},
+        "defaults": {"mode": "enforce"},
+        "contracts": [
+            {
+                "id": "test-contract",
+                "type": "pre",
+                "tool": "test_tool",
+                "when": when_expr,
+                "then": {"effect": "deny", "message": "denied"},
+            }
+        ],
+    }
+
+
+BOTH_SCHEMAS = [str(YAML_ENGINE_SCHEMA_PATH), str(STANDALONE_SCHEMA_PATH)]
+
+
+@pytest.mark.parametrize("schema_path", BOTH_SCHEMAS)
+class TestNotExpressionValidates:
+    """not: expressions pass schema validation after the ExprLeaf fix."""
+
+    def test_not_expression_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"not": {"args.to": {"ends_with": "@company.com"}}})
+        jsonschema.validate(doc, schema)
+
+    def test_nested_all_not_expression_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"all": [{"args.x": {"equals": 1}}, {"not": {"args.y": {"equals": 2}}}]})
+        jsonschema.validate(doc, schema)
+
+    def test_nested_any_not_expression_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"any": [{"args.x": {"equals": 1}}, {"not": {"args.y": {"equals": 2}}}]})
+        jsonschema.validate(doc, schema)
+
+    def test_double_nested_not_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"not": {"not": {"args.x": {"equals": 1}}}})
+        jsonschema.validate(doc, schema)
+
+
+@pytest.mark.parametrize("schema_path", BOTH_SCHEMAS)
+class TestExistingExpressionsStillValidate:
+    """Regression guards: leaf, all, any expressions still pass."""
+
+    def test_leaf_expression_still_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"args.command": {"contains": "rm"}})
+        jsonschema.validate(doc, schema)
+
+    def test_all_expression_still_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"all": [{"args.x": {"equals": 1}}]})
+        jsonschema.validate(doc, schema)
+
+    def test_any_expression_still_validates(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({"any": [{"args.x": {"equals": 1}}]})
+        jsonschema.validate(doc, schema)
+
+
+@pytest.mark.parametrize("schema_path", BOTH_SCHEMAS)
+class TestInvalidExpressionRejected:
+    """Malformed expressions are still rejected by schema validation."""
+
+    def test_invalid_expression_still_rejected(self, schema_path):
+        schema = _load_schema(schema_path)
+        doc = _make_bundle({})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+class TestNotExpressionIntegration:
+    """from_yaml_string() loads a not: contract end-to-end."""
+
+    def test_not_expression_loads_via_from_yaml_string(self):
+        yaml_content = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: not-test
+defaults:
+  mode: enforce
+contracts:
+  - id: no-external-email
+    type: pre
+    tool: send_email
+    when:
+      not:
+        args.to: { ends_with: "@company.com" }
+    then:
+      effect: deny
+      message: "External email denied"
+"""
+        guard = Edictum.from_yaml_string(yaml_content)
+        assert len(guard._preconditions) >= 1


### PR DESCRIPTION
## Summary

- **ExprLeaf now excludes boolean operator keywords** (`all`, `any`, `not`) via `"properties": {"all": false, "any": false, "not": false}`, preventing `oneOf` ambiguity with ExprNot/ExprAll/ExprAny
- **Terminology fix** in standalone schema description: "effect rules" -> "effect constraints"
- **17 behavior tests** covering `not:` expressions (simple, nested, double-nested), regression guards for leaf/all/any, invalid expression rejection, and `from_yaml_string()` integration

## Root Cause

`{"not": {...}}` matched both ExprNot (correct) and ExprLeaf (incorrect — `additionalProperties: {}` in Operator accepted any key). Two matches violated `oneOf`, rejecting all `not:` contracts.

## Fix

`"property_name": false` in JSON Schema means that key is never valid. Adding it to ExprLeaf prevents it from matching objects whose sole key is a boolean operator.

Applied to both schemas:
- `src/edictum/yaml_engine/edictum-v1.schema.json` (runtime — the bug)
- `schemas/edictum-v1.schema.json` (standalone — defense-in-depth)

## Test Plan

- [x] `pytest tests/test_behavior/test_schema_expression_behavior.py -v` — 17 passed
- [x] `pytest tests/test_yaml_engine/ -v` — 222 passed (no regressions)
- [x] `ruff check src/ tests/` — clean
- [x] Inline `jsonschema.validate()` verification against both schemas

Closes #66

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes a `oneOf` ambiguity in the JSON Schema where `{"not": {...}}` matched both `ExprNot` (correct) and `ExprLeaf` (incorrect), causing all `not:` expressions to be rejected. The fix adds `"properties": {"all": false, "any": false, "not": false}` to the `ExprLeaf` definition in both schemas.

**Key changes:**
- **`schemas/edictum-v1.schema.json`** and **`src/edictum/yaml_engine/edictum-v1.schema.json`**: Both receive identical `ExprLeaf` property exclusion to prevent `oneOf` conflicts; the standalone schema also fixes the description ("effect rules" → "effect constraints").
- **`tests/test_behavior/test_schema_expression_behavior.py`**: 17 new parametrized tests validate `not:` expressions, nested combinations, and regression guards for existing leaf/all/any expressions.

The fix leverages standard JSON Schema Draft 2020-12 semantics where `"property_name": false` unconditionally fails validation when that key is present, allowing `additionalProperties` to correctly route valid selectors to the `Operator` ref. All changes are minimal, well-tested (17 new + 222 existing tests passing), and introduce no regressions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it applies a minimal, well-understood JSON Schema fix with comprehensive test coverage and no regressions.
- The fix is targeted and correct: it adds property exclusions to `ExprLeaf` to prevent `oneOf` ambiguity. Both runtime and standalone schemas receive the identical fix. Test coverage is comprehensive (17 new parametrized tests + 222 existing tests, all passing), and the change is minimal with no side effects or behavioral regressions.
- No files require special attention

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Expression (oneOf)"] --> B["ExprLeaf\n(single selector:operator pair)"]
    A --> C["ExprNot\n(not: Expression)"]
    A --> D["ExprAll\n(all: [Expression…])"]
    A --> E["ExprAny\n(any: [Expression…])"]

    B --> F{"Key in properties?\n(all / any / not)"}
    F -- "Yes → schema=false" --> G["❌ Validation fails\n(not a leaf)"]
    F -- "No → additionalProperties" --> H["Operator ref\n(contains/equals/…)"]
    H --> I["✅ Valid ExprLeaf"]

    C --> J["'not' key required\nadditionalProperties: false"]
    J --> K["✅ Valid ExprNot"]

    style G fill:#f88,color:#000
    style I fill:#8f8,color:#000
    style K fill:#8f8,color:#000
```

<sub>Last reviewed commit: 2c226bc</sub>

**Context used:**

- Rule used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e37a8046-77ec-4289-8d92-6c2e2896a820))
- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=968d838b-d461-4ad8-9519-8768714add88))

<!-- /greptile_comment -->