### PR TITLE
fix: sync repo-root schema, OTel ghost field, nanobot is_error, run() heuristic

### DIFF
--- a/schemas/edictum-v1.schema.json
+++ b/schemas/edictum-v1.schema.json
@@ -16,7 +16,9 @@
       "minItems": 1,
       "items": { "$ref": "#/$defs/Contract" }
     },
-    "tools": { "$ref": "#/$defs/Tools" }
+    "tools": { "$ref": "#/$defs/Tools" },
+    "observability": { "$ref": "#/$defs/Observability" },
+    "observe_alongside": { "type": "boolean", "default": false }
   },
 
   "$defs": {
@@ -57,6 +59,35 @@
       }
     },
 
+    "Observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "otel": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "endpoint": { "type": "string" },
+            "protocol": { "type": "string", "enum": ["grpc", "http"] },
+            "service_name": { "type": "string" },
+            "insecure": { "type": "boolean", "default": true },
+            "resource_attributes": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        "stdout": { "type": "boolean", "default": true },
+        "file": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+
     "Defaults": {
       "type": "object",
       "required": ["mode"],
@@ -75,7 +106,8 @@
       "oneOf": [
         { "$ref": "#/$defs/PreContract" },
         { "$ref": "#/$defs/PostContract" },
-        { "$ref": "#/$defs/SessionContract" }
+        { "$ref": "#/$defs/SessionContract" },
+        { "$ref": "#/$defs/SandboxContract" }
       ]
     },
 
@@ -95,10 +127,12 @@
           "required": ["effect", "message"],
           "additionalProperties": false,
           "properties": {
-            "effect": { "const": "deny" },
+            "effect": { "enum": ["deny", "approve"] },
             "message": { "$ref": "#/$defs/MessageString" },
             "tags": { "$ref": "#/$defs/Tags" },
-            "metadata": { "$ref": "#/$defs/ThenMetadata" }
+            "metadata": { "$ref": "#/$defs/ThenMetadata" },
+            "timeout": { "type": "integer", "minimum": 1, "default": 300 },
+            "timeout_effect": { "enum": ["deny", "allow"], "default": "deny" }
           }
         }
       }
@@ -153,6 +187,86 @@
       }
     },
 
+    "SandboxContract": {
+      "type": "object",
+      "required": ["id", "type", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/ContractId" },
+        "type": { "const": "sandbox" },
+        "enabled": { "type": "boolean", "default": true },
+        "mode": { "$ref": "#/$defs/Mode" },
+        "tool": { "$ref": "#/$defs/ToolSelector" },
+        "tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ToolSelector" },
+          "minItems": 1
+        },
+        "within": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "not_within": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "allows": { "$ref": "#/$defs/SandboxAllows" },
+        "not_allows": { "$ref": "#/$defs/SandboxNotAllows" },
+        "outside": {
+          "type": "string",
+          "enum": ["deny", "approve"],
+          "default": "deny"
+        },
+        "message": { "$ref": "#/$defs/MessageString" },
+        "timeout": { "type": "integer", "minimum": 1, "default": 300 },
+        "timeout_effect": { "enum": ["deny", "allow"], "default": "deny" }
+      },
+      "allOf": [
+        {
+          "oneOf": [
+            { "required": ["tool"] },
+            { "required": ["tools"] }
+          ]
+        },
+        {
+          "anyOf": [
+            { "required": ["within"] },
+            { "required": ["allows"] }
+          ]
+        }
+      ]
+    },
+
+    "SandboxAllows": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "domains": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
+      }
+    },
+
+    "SandboxNotAllows": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "domains": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
+      }
+    },
+
     "ContractId": {
       "type": "string",
       "minLength": 1,
@@ -163,7 +277,7 @@
     "ToolSelector": {
       "type": "string",
       "minLength": 1,
-      "description": "Tool name or '*' for all tools."
+      "description": "Tool name, glob pattern (e.g. 'mcp_*'), or '*' for all tools."
     },
 
     "MessageString": {
@@ -265,7 +379,7 @@
       "type": "object",
       "minProperties": 1,
       "maxProperties": 1,
-      "additionalProperties": false,
+      "additionalProperties": {},
       "properties": {
         "exists": { "type": "boolean" },
         "equals": { "description": "Strict equality. Any scalar type." },

--- a/src/edictum/__init__.py
+++ b/src/edictum/__init__.py
@@ -1511,7 +1511,7 @@ class Edictum:
                 if self._success_check:
                     tool_success = self._success_check(tool_name, result)
                 else:
-                    tool_success = True
+                    tool_success = _default_success_check(tool_name, result)
             except Exception as e:
                 result = str(e)
                 tool_success = False
@@ -1607,7 +1607,7 @@ class Edictum:
             span.set_attribute("edictum.tool.args", tool_args_str)
 
             if audit_event.principal:
-                for key in ("role", "team", "ticket_ref", "user_id", "org_id"):
+                for key in ("role", "ticket_ref", "user_id", "org_id"):
                     val = audit_event.principal.get(key)
                     if val:
                         span.set_attribute(f"edictum.principal.{key}", val)
@@ -1621,6 +1621,24 @@ class Edictum:
                 span.set_status(StatusCode.ERROR, audit_event.reason or "denied")
             else:
                 span.set_status(StatusCode.OK)
+
+
+def _default_success_check(tool_name: str, result: Any) -> bool:
+    """Default heuristic for tool success detection.
+
+    Matches the heuristic used by all framework adapters: None is success,
+    dict with is_error is failure, string starting with error:/fatal: is failure.
+    """
+    if result is None:
+        return True
+    if isinstance(result, dict):
+        if result.get("is_error"):
+            return False
+    if isinstance(result, str):
+        lower = result[:7].lower()
+        if lower.startswith("error:") or lower.startswith("fatal:"):
+            return False
+    return True
 
 
 def _validate_custom_operators(custom_operators: dict[str, Any]) -> None:

--- a/src/edictum/adapters/nanobot.py
+++ b/src/edictum/adapters/nanobot.py
@@ -298,6 +298,9 @@ class GovernedToolRegistry:
             return self._guard._success_check(tool_name, result)
         if result is None:
             return True
+        if isinstance(result, dict):
+            if result.get("is_error"):
+                return False
         if isinstance(result, str):
             lower = result[:7].lower()
             if lower.startswith("error:") or lower.startswith("fatal:"):


### PR DESCRIPTION
## Summary

Fixes 4 issues found during a cross-repo docs audit. The original audit identified 5 fix groups, but investigation showed Fix Group 1 (JSON Schema gaps) was a false positive for the runtime schema — the package schema was already correct. Only the repo-root copy was stale.

### Changes

- **Sync `schemas/edictum-v1.schema.json`** — the repo-root copy was missing SandboxContract, approve effect, observability section, and observe_alongside. The runtime schema (in `src/edictum/yaml_engine/`) was already correct, which is why sandbox contracts work fine. Copied package schema to repo root.

- **Remove OTel `team` ghost** — `__init__.py:1610` iterated over `("role", "team", ...)` but `Principal` has no `team` field. `audit_event.principal.get("team")` always returned `None`, making it a silent no-op that misleads OTel span readers. Removed `"team"` from the loop.

- **Nanobot `is_error` check** — `nanobot.py:_check_tool_success()` was missing the `isinstance(result, dict) / result.get("is_error")` check that all 7 other adapters have. Dict results with `{"is_error": true}` were incorrectly treated as successful.

- **`run()` default success heuristic** — `Edictum.run()` defaulted to `tool_success = True` when no `success_check` was provided, while all 8 adapters apply a heuristic (None/dict/str checks). Added `_default_success_check()` so `run()` behavior matches adapters.

### What was NOT done (and why)

- **Fix Group 1 (schema rewrite)** — false positive. The runtime schema already has all features. Only the repo-root copy needed syncing.
- **Fix Group 5 (observe mode callback gap)** — intentional by design. In global observe mode, the tool executes as if governance didn't exist, so neither `on_deny` nor `on_allow` fires. This is correct semantics.
- **Adapter refactor** — did not extract adapters' `_check_tool_success` into a shared function. LangChain, Google ADK, and Semantic Kernel have adapter-specific extensions (ToolMessage content, `error` key, FunctionResult metadata), so a shared base would still need per-adapter overrides. Not worth the churn.

## Test plan

- [x] `pytest tests/` — 1800 passed, 3 skipped
- [x] `edictum validate src/edictum/yaml_engine/templates/*.yaml` — all 4 templates valid
- [x] `ruff check` — clean
- [x] Pre-commit hooks pass (ruff, ruff-format, check-terminology)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four correctness issues found during a cross-repo audit: syncing the stale repo-root JSON Schema, removing a ghost OTel span attribute, adding a missing `is_error` dict check in the nanobot adapter, and aligning `Edictum.run()`'s default success heuristic with all framework adapters.

- **Schema sync** (`schemas/edictum-v1.schema.json`): Verified identical to `src/edictum/yaml_engine/edictum-v1.schema.json` post-PR via diff. Adds `SandboxContract`, `Observability`, `observe_alongside`, `approve` effect, `timeout`/`timeout_effect` on `Then`, and relaxes `Operator.additionalProperties` to `{}` to allow custom operators — all already present and working in the runtime schema.
- **OTel ghost field** (`__init__.py:1610`): `"team"` correctly removed from the principal attribute loop. `Principal` has fields `user_id`, `service_id`, `org_id`, `role`, `ticket_ref`, `claims` — no `team` field, confirming the prior iteration was a silent no-op.
- **Nanobot `is_error`** (`nanobot.py:_check_tool_success`): The `isinstance(result, dict) / result.get("is_error")` guard is now in place, correctly positioned before the string heuristic, matching all other adapters.
- **`run()` success heuristic** (`__init__.py:_default_success_check`): The new module-level `_default_success_check()` correctly replicates the adapter heuristic — `None → True`, dict with truthy `is_error → False`, string prefixed `error:`/`fatal: → False`, everything else `→ True`. Logic is consistent with `nanobot._check_tool_success()` and the `tool_name` parameter is carried for API signature parity with user-provided `_success_check` callables.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all four fixes are narrow, well-reasoned, and backed by 1800 passing tests.
- Each change is a clear bug fix with no new logic complexity: the schema sync is verified identical to the already-working runtime schema; the OTel removal is confirmed by inspecting the Principal dataclass; the nanobot dict guard matches the pattern across all other adapters; and _default_success_check mirrors the same logic already battle-tested in every adapter. No regressions are expected.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| schemas/edictum-v1.schema.json | Syncs repo-root schema to runtime schema: adds SandboxContract, Observability, observe_alongside, approve effect, timeout/timeout_effect to Then, and relaxes Operator additionalProperties from false to {} to support custom operators. Verified identical to src/edictum/yaml_engine/edictum-v1.schema.json post-PR. |
| src/edictum/__init__.py | Two targeted fixes: (1) removes the ghost "team" key from the OTel principal attribute loop (Principal has no team field), (2) adds _default_success_check() module-level function so Edictum.run() applies the same None/dict/str heuristic as all 8 adapters instead of defaulting to True. |
| src/edictum/adapters/nanobot.py | Adds the missing isinstance(result, dict)/result.get("is_error") check to GovernedToolRegistry._check_tool_success(), aligning it with all 7 other adapters. The fix is placed correctly before the string heuristic check. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Edictum.run(tool_name, result)"] --> B{_success_check provided?}
    B -- Yes --> C["user _success_check(tool_name, result)"]
    B -- No --> D["_default_success_check(tool_name, result)  ← NEW"]

    D --> E{result is None?}
    E -- Yes --> F["return True ✓"]
    E -- No --> G{isinstance result dict?}
    G -- Yes --> H{"result.get('is_error') truthy?"}
    H -- Yes --> I["return False ✗"]
    H -- No --> J{isinstance result str?}
    G -- No --> J
    J -- Yes --> K{"starts with 'error:' or 'fatal:'?"}
    K -- Yes --> L["return False ✗"]
    K -- No --> M["return True ✓"]
    J -- No --> M

    subgraph "nanobot._check_tool_success (same heuristic)"
        N["result is None?"] --> O["True ✓"]
        N --> P["dict is_error?"] --> Q["False ✗"]
        N --> R["str error:/fatal:?"] --> S["False ✗"]
        N --> T["else True ✓"]
    end
```

<sub>Last reviewed commit: cd67bf0</sub>

<!-- /greptile_comment -->