### PR TITLE
docs: add Gate module to architecture source layout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -341,6 +341,16 @@ src/edictum/
     nanobot.py             Nanobot governed ToolRegistry
     google_adk.py          Google ADK plugin and agent callback adapter
 
+  gate/                    pip install edictum[gate]
+    __init__.py            Module entry point
+    __main__.py            CLI entry point (python -m edictum.gate)
+    check.py               stdin → ToolEnvelope → evaluate → stdout (core check)
+    config.py              GateConfig, ConsoleConfig, load_gate_config()
+    install.py             Hook install/uninstall for 5 assistants
+    audit_buffer.py        WAL write, redaction, batch flush to Console
+    cache.py               Contract cache (SHA256 + mtime validation)
+    formats/               Format handlers (claude_code, cursor, copilot, gemini, opencode, raw)
+
   server/                  pip install edictum[server]
     client.py              EdictumServerClient (async HTTP, auth, retries, env, bundle_name)
     approval_backend.py    ServerApprovalBackend (ApprovalBackend via HTTP)


### PR DESCRIPTION
## Summary
- Add `gate/` module listing to architecture.md source layout section
- Documents all 8 Gate source files and their responsibilities

## Context
Gate feature merged in PR #78. Architecture docs were missing the module listing.

## Test plan
- [x] `mkdocs build --strict` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR backfills the missing `gate/` module block in the source layout section of `docs/architecture.md`, documenting the 7 top-level source files and the `formats/` sub-directory introduced in PR #78. The change is documentation-only and fits naturally between the `adapters/` and `server/` blocks already present in the layout.

**Changes:**
- Adds `gate/` entry with `pip install edictum[gate]` install hint, matching the pattern used for the `server/` module
- Describes all 7 top-level files (`__init__.py`, `__main__.py`, `check.py`, `config.py`, `install.py`, `audit_buffer.py`, `cache.py`) with descriptions that match the actual source
- Lists `formats/` sub-directory with format handler names

**Issue found:**
- The `formats/` parenthetical lists `copilot` and `gemini`, but the actual Python module filenames are `copilot_cli.py` and `gemini_cli.py` — a minor but misleading mismatch for anyone cross-referencing the docs against the source tree

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with a minor documentation correction needed.
- The change is documentation-only with no runtime impact. All file entries and descriptions are accurate for the top-level gate files. One small naming discrepancy in the `formats/` listing (`copilot`/`gemini` vs. `copilot_cli`/`gemini_cli`) is trivially fixable.
- docs/architecture.md — one-line correction needed in the `formats/` sub-listing

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["edictum gate check\n(stdin)"] --> B["check.py\nparse ToolEnvelope"]
    B --> C["formats/\nget_format(name)"]
    C --> D["claude_code\n| cursor\n| copilot_cli\n| gemini_cli\n| opencode\n| raw"]
    B --> E["cache.py\nSHA256 + mtime lookup"]
    E --> F{"contract\ncached?"}
    F -- yes --> G["evaluate"]
    F -- no --> H["load + cache"]
    H --> G
    G --> I{"verdict"}
    I -- allow --> J["audit_buffer.py\nWAL write"]
    I -- deny --> J
    J --> K["stdout response\n(exit 0 / 2)"]
    B -.-> L["config.py\nGateConfig / load_gate_config()"]
```

<sub>Last reviewed commit: b4a5004</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->