### PR TITLE
chore: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review for workflow and CI configuration changes
+.github/ @acartag7
+CLAUDE.md @acartag7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev,yaml,sinks,cli]"
@@ -28,8 +28,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - run: pip install ruff
@@ -38,8 +38,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - run: pip install bandit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,20 +26,20 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           # Pass GLM token as anthropic_api_key to satisfy action validation.
           # Actual auth is handled by ANTHROPIC_AUTH_TOKEN (Bearer) below.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
-          claude_args: '--model glm-5 --max-turns 10'
+          claude_args: '--model glm-5 --max-turns 10 --allowedTools "Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr comment:*),Bash(gh api:*),Bash(pytest:*),Bash(python:*),Bash(ruff:*),Read,Glob,Grep,Write,Edit"'
         env:
           # Redirect all API calls to GLM endpoint
           ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         with:
           types: |
             feat

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - run: uv build
       - run: uv publish

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,19 +16,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Code Review
         id: review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Hardens CI/CD workflows against the attack patterns described in the [hackerbot-claw campaign](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation) (Feb 2026), which achieved RCE in 5/7 targeted OSS repos including Microsoft and DataDog.

- **Pin all actions to commit SHAs** — replaces mutable tags (`@v4`, `@v5`, `@v1`) with immutable commit hashes across all 5 workflows, preventing tag-hijacking supply chain attacks
- **Restrict `claude.yml` tool access** — adds `--allowedTools` whitelist to limit blast radius if a prompt injection succeeds via fork PR content
- **Add CODEOWNERS** — requires review from `@acartag7` for any changes to `.github/` or `CLAUDE.md`

## What was already safe

- No `pull_request_target` usage anywhere (eliminates the deadliest attack vector)
- No `${{ }}` expressions in `run:` shell blocks (no shell injection surface)
- `claude.yml` already has `author_association` checks (MEMBER/OWNER/COLLABORATOR)
- `ci.yml` already has `permissions: contents: read`

## Remaining recommendation

Set org-level default token permissions to read-only in GitHub Settings > Actions > General > Workflow permissions.

## Test plan

- [ ] CI passes on this PR (validates pinned SHAs resolve correctly)
- [ ] Trigger `@claude` on a test PR to verify allowedTools doesn't break normal usage
- [ ] Verify CODEOWNERS shows up in branch protection rules