### PR TITLE
fix: reject backslash in tool_name validation

### DIFF
--- a/src/edictum/envelope.py
+++ b/src/edictum/envelope.py
@@ -182,7 +182,7 @@ def create_envelope(
     way to create ToolEnvelope instances.
     """
     # Validate tool_name: reject null bytes, control chars, path separators
-    if not tool_name or "\x00" in tool_name or "\n" in tool_name or "/" in tool_name:
+    if not tool_name or "\x00" in tool_name or "\n" in tool_name or "/" in tool_name or "\\" in tool_name:
         raise ValueError(f"Invalid tool_name: {tool_name!r}")
 
     # Deep-copy for immutability

--- a/tests/test_behavior/test_envelope_behavior.py
+++ b/tests/test_behavior/test_envelope_behavior.py
@@ -1,0 +1,41 @@
+"""Behavior tests for tool_name validation in create_envelope().
+
+Security tests verify that backslash (Windows path separator) is rejected
+alongside forward slash, preventing ambiguous session keys and audit entries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import create_envelope
+
+
+class TestToolNameBackslashRejection:
+    """Backslash in tool_name must be rejected (path separator on Windows)."""
+
+    @pytest.mark.security
+    def test_single_backslash_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil\\tool", {})
+
+    @pytest.mark.security
+    def test_backslash_path_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("path\\to\\tool", {})
+
+    @pytest.mark.security
+    def test_forward_slash_still_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil/tool", {})
+
+    @pytest.mark.security
+    def test_null_byte_still_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil\x00tool", {})
+
+    def test_valid_names_accepted(self):
+        """Normal tool names with hyphens, underscores, dots are fine."""
+        for name in ("Bash", "my-tool", "my_tool", "tool.v2", "ReadFile"):
+            env = create_envelope(name, {})
+            assert env.tool_name == name


### PR DESCRIPTION
## Summary
- Add backslash (`\`) rejection to `create_envelope()` tool_name validation, closing a gap where forward slash was rejected but backslash (Windows path separator) was not
- Tool names with backslash could create ambiguous session keys or audit log entries on Windows
- Add security behavior tests for backslash rejection in `tests/test_behavior/test_envelope_behavior.py`

## Test plan
- [x] `"evil\\tool"` is rejected with `ValueError`
- [x] `"path\\to\\tool"` is rejected with `ValueError`
- [x] Forward slash and null byte rejection still works
- [x] Valid names (`"Bash"`, `"my-tool"`, `"my_tool"`, `"tool.v2"`, `"ReadFile"`) are accepted
- [x] Full test suite passes (2048 passed, 22 skipped)
- [x] `ruff check` passes

Closes #85