### PR TITLE
fix: reject all ASCII control chars in tool_name validation

### DIFF
--- a/src/edictum/envelope.py
+++ b/src/edictum/envelope.py
@@ -181,8 +181,8 @@ def create_envelope(
     Deep-copies args and metadata. This is the ONLY sanctioned
     way to create ToolEnvelope instances.
     """
-    # Validate tool_name: reject null bytes, control chars, path separators
-    if not tool_name or "\x00" in tool_name or "\n" in tool_name or "/" in tool_name:
+    # Validate tool_name: reject all ASCII control chars (0x00-0x1f, 0x7f) and path separators
+    if not tool_name or "/" in tool_name or any(ord(c) < 0x20 or ord(c) == 0x7F for c in tool_name):
         raise ValueError(f"Invalid tool_name: {tool_name!r}")
 
     # Deep-copy for immutability

--- a/tests/test_behavior/test_envelope_behavior.py
+++ b/tests/test_behavior/test_envelope_behavior.py
@@ -1,0 +1,81 @@
+"""Behavior tests for create_envelope tool_name validation.
+
+Verifies that ALL ASCII control characters (0x00-0x1f, 0x7f) are rejected,
+not just NUL and newline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum.envelope import create_envelope
+
+
+@pytest.mark.security
+class TestToolNameControlCharRejection:
+    """Security: create_envelope rejects all ASCII control characters in tool_name."""
+
+    def test_carriage_return_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\rname", {})
+
+    def test_tab_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\tname", {})
+
+    def test_del_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\x7fname", {})
+
+    def test_soh_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\x01name", {})
+
+    def test_null_byte_still_rejected(self):
+        """Regression: NUL byte rejection must survive the refactor."""
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\x00name", {})
+
+    def test_newline_still_rejected(self):
+        """Regression: newline rejection must survive the refactor."""
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("tool\nname", {})
+
+    def test_path_separator_still_rejected(self):
+        """Regression: forward slash rejection must survive the refactor."""
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("path/to/tool", {})
+
+    def test_empty_string_still_rejected(self):
+        """Regression: empty tool_name rejection must survive the refactor."""
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("", {})
+
+
+@pytest.mark.security
+class TestToolNameValidNamesAccepted:
+    """Valid tool names must pass validation after the control-char fix."""
+
+    def test_simple_name(self):
+        envelope = create_envelope("Bash", {})
+        assert envelope.tool_name == "Bash"
+
+    def test_hyphenated_name(self):
+        envelope = create_envelope("my-tool", {})
+        assert envelope.tool_name == "my-tool"
+
+    def test_underscored_name(self):
+        envelope = create_envelope("my_tool", {})
+        assert envelope.tool_name == "my_tool"
+
+    def test_dotted_version_name(self):
+        envelope = create_envelope("Tool.v2", {})
+        assert envelope.tool_name == "Tool.v2"
+
+    def test_colon_namespace(self):
+        envelope = create_envelope("ns:tool", {})
+        assert envelope.tool_name == "ns:tool"
+
+    def test_unicode_name(self):
+        envelope = create_envelope("tool_\u00e9", {})
+        assert envelope.tool_name == "tool_\u00e9"


### PR DESCRIPTION
Closes #99

## Summary
- `create_envelope()` only rejected NUL (`\x00`) and newline (`\n`) in `tool_name`, allowing carriage return, tab, DEL, and other ASCII control characters (0x01-0x1f, 0x7f) through.
- Replaced the individual character checks with a comprehensive `any(ord(c) < 0x20 or ord(c) == 0x7F for c in tool_name)` guard that rejects all ASCII control characters. The `/` (path separator) check is preserved.
- Added 14 security behavior tests in `tests/test_behavior/test_envelope_behavior.py` covering rejected control chars (`\r`, `\t`, `\x7f`, `\x01`) and regressions for existing checks (`\x00`, `\n`, `/`, empty string), plus valid name acceptance.

## Test plan
- [x] All 2076 tests pass (`pytest tests/ -x -q`)
- [x] Lint clean (`ruff check src/ tests/`)
- [x] New tests marked `@pytest.mark.security`
- [x] Regression tests confirm NUL, newline, `/`, and empty string still rejected
- [x] Valid names (`Bash`, `my-tool`, `my_tool`, `Tool.v2`, unicode) still accepted