### PR TITLE
fix: add __post_init__ validation to ToolEnvelope (#88)

### DIFF
--- a/src/edictum/envelope.py
+++ b/src/edictum/envelope.py
@@ -49,11 +49,28 @@ class Principal:
     claims: dict[str, Any] = field(default_factory=dict)
 
 
+def _validate_tool_name(tool_name: str) -> None:
+    """Validate tool_name: reject empty, control chars, path separators.
+
+    Raises ValueError for:
+    - Empty string
+    - Any ASCII control character (ord < 0x20 or ord == 0x7f)
+    - Forward slash ``/``
+    - Backslash ``\\``
+    """
+    if not tool_name:
+        raise ValueError(f"Invalid tool_name: {tool_name!r}")
+    for ch in tool_name:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F or ch in ("/", "\\"):
+            raise ValueError(f"Invalid tool_name: {tool_name!r}")
+
+
 @dataclass(frozen=True)
 class ToolEnvelope:
     """Immutable snapshot of a tool invocation.
 
-    ALWAYS create via create_envelope() factory, never directly.
+    Prefer create_envelope() factory for deep-copy guarantees.
+    Direct construction validates tool_name but does NOT deep-copy args.
     """
 
     # Identity
@@ -84,6 +101,9 @@ class ToolEnvelope:
 
     # Extensible
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_tool_name(self.tool_name)
 
 
 class ToolRegistry:
@@ -178,12 +198,11 @@ def create_envelope(
 ) -> ToolEnvelope:
     """Factory that enforces immutability guarantees.
 
-    Deep-copies args and metadata. This is the ONLY sanctioned
-    way to create ToolEnvelope instances.
+    Prefer this factory over direct construction — it deep-copies args
+    and metadata to ensure the envelope is a true immutable snapshot.
+    Direct construction is permitted but skips the deep-copy.
     """
-    # Validate tool_name: reject null bytes, control chars, path separators
-    if not tool_name or "\x00" in tool_name or "\n" in tool_name or "/" in tool_name:
-        raise ValueError(f"Invalid tool_name: {tool_name!r}")
+    _validate_tool_name(tool_name)
 
     # Deep-copy for immutability
     try:

--- a/tests/test_behavior/test_envelope_behavior.py
+++ b/tests/test_behavior/test_envelope_behavior.py
@@ -1,10 +1,10 @@
-"""Behavior tests for BashClassifier bare $VAR detection."""
+"""Behavior tests for envelope module — BashClassifier and ToolEnvelope validation."""
 
 from __future__ import annotations
 
 import pytest
 
-from edictum.envelope import BashClassifier, SideEffect
+from edictum.envelope import BashClassifier, SideEffect, ToolEnvelope, create_envelope
 
 pytestmark = pytest.mark.security
 
@@ -44,3 +44,51 @@ class TestNoFalsePositivesFromDollarOperator:
 
     def test_git_status_still_read(self):
         assert BashClassifier.classify("git status") == SideEffect.READ
+
+
+class TestToolEnvelopeDirectConstructionValidation:
+    """ToolEnvelope.__post_init__ must reject dangerous tool_name values,
+    closing the bypass where callers skip create_envelope().
+    """
+
+    def test_null_byte_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="\x00evil", args={})
+
+    def test_newline_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil\ntool", args={})
+
+    def test_forward_slash_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil/tool", args={})
+
+    def test_backslash_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil\\tool", args={})
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="", args={})
+
+    def test_carriage_return_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil\rtool", args={})
+
+    def test_tab_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil\ttool", args={})
+
+    def test_delete_char_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            ToolEnvelope(tool_name="evil\x7ftool", args={})
+
+    def test_valid_name_accepted(self):
+        envelope = ToolEnvelope(tool_name="ValidTool", args={})
+        assert envelope.tool_name == "ValidTool"
+
+    def test_create_envelope_still_works(self):
+        """create_envelope() must not regress — validation is idempotent."""
+        envelope = create_envelope("ValidTool", {"key": "value"})
+        assert envelope.tool_name == "ValidTool"
+        assert envelope.args == {"key": "value"}


### PR DESCRIPTION
## Summary

- Extracts tool_name validation into `_validate_tool_name()` helper in `envelope.py`
- Adds `__post_init__` to `ToolEnvelope` that calls the shared validator, preventing direct construction bypass of `create_envelope()`
- Strengthens validation to reject all ASCII control chars (ord < 0x20 and 0x7F) and backslashes, not just null/newline/forward-slash
- `create_envelope()` now uses the same shared helper

## Test plan

- [x] 10 new security behavior tests in `tests/test_behavior/test_envelope_behavior.py`
- [x] All 39 existing `test_envelope.py` tests pass (no regression)
- [x] Full suite: 2072 passed, 3 skipped
- [x] `ruff check src/ tests/` clean

Closes #88