### PR TITLE
fix: detect bare $VAR expansions in BashClassifier

### DIFF
--- a/src/edictum/envelope.py
+++ b/src/edictum/envelope.py
@@ -149,7 +149,7 @@ class BashClassifier:
         "more",
     ]
 
-    SHELL_OPERATORS = ["\n", "\r", "<(", "<<", "${", ">", ">>", "|", ";", "&&", "||", "$(", "`", "#{"]
+    SHELL_OPERATORS = ["\n", "\r", "<(", "<<", "$", "${", ">", ">>", "|", ";", "&&", "||", "$(", "`", "#{"]
 
     @classmethod
     def classify(cls, command: str) -> SideEffect:

--- a/tests/test_behavior/test_envelope_behavior.py
+++ b/tests/test_behavior/test_envelope_behavior.py
@@ -1,0 +1,46 @@
+"""Behavior tests for BashClassifier bare $VAR detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum.envelope import BashClassifier, SideEffect
+
+pytestmark = pytest.mark.security
+
+
+class TestBareVariableExpansionDetected:
+    """Bare $VAR expansions must classify as IRREVERSIBLE to prevent secret exfiltration."""
+
+    def test_echo_bare_var_is_irreversible(self):
+        assert BashClassifier.classify("echo $AWS_SECRET_KEY") == SideEffect.IRREVERSIBLE
+
+    def test_cat_bare_var_path_is_irreversible(self):
+        assert BashClassifier.classify("cat $HOME/.ssh/id_rsa") == SideEffect.IRREVERSIBLE
+
+    def test_braced_var_still_irreversible(self):
+        """Regression: ${VAR} must still be caught."""
+        assert BashClassifier.classify("echo ${VAR}") == SideEffect.IRREVERSIBLE
+
+    def test_command_substitution_still_irreversible(self):
+        """Regression: $(cmd) must still be caught."""
+        assert BashClassifier.classify("echo $(whoami)") == SideEffect.IRREVERSIBLE
+
+
+class TestNoFalsePositivesFromDollarOperator:
+    """Commands without $ must not be affected by the new operator."""
+
+    def test_ls_tmp_still_read(self):
+        assert BashClassifier.classify("ls /tmp") == SideEffect.READ
+
+    def test_cat_file_still_read(self):
+        assert BashClassifier.classify("cat file.txt") == SideEffect.READ
+
+    def test_echo_literal_still_read(self):
+        assert BashClassifier.classify("echo hello") == SideEffect.READ
+
+    def test_grep_still_read(self):
+        assert BashClassifier.classify("grep pattern somefile") == SideEffect.READ
+
+    def test_git_status_still_read(self):
+        assert BashClassifier.classify("git status") == SideEffect.READ


### PR DESCRIPTION
## Summary
- Add `"$"` to `BashClassifier.SHELL_OPERATORS` to detect bare `$VAR` variable expansions that bypass shell operator detection
- Commands like `echo $AWS_SECRET_ACCESS_KEY` were classified as READ (via allowlisted `echo`) instead of IRREVERSIBLE, enabling potential secret exfiltration through read-classified commands
- Add security behavior tests covering bare `$VAR`, `${VAR}`, `$(cmd)` detection and no-false-positive regression for clean commands

Closes #87

## Test plan
- [x] `echo $AWS_SECRET_KEY` returns IRREVERSIBLE (not READ)
- [x] `cat $HOME/.ssh/id_rsa` returns IRREVERSIBLE
- [x] `echo ${VAR}` still returns IRREVERSIBLE (regression)
- [x] `echo $(whoami)` still returns IRREVERSIBLE (regression)
- [x] `ls /tmp`, `cat file.txt`, `echo hello` still return READ (no false positives)
- [x] Full test suite: 2052 passed, 0 failures
- [x] ruff: all checks passed
- [x] Pre-commit hooks: ruff, ruff-format, check-terminology all passed