### PR TITLE
fix: from_multiple() now merges observe-mode contracts

### DIFF
--- a/src/edictum/_factory.py
+++ b/src/edictum/_factory.py
@@ -398,26 +398,29 @@ def _from_multiple(cls: type[Edictum], guards: list[Edictum]) -> Edictum:
     )
     merged.tool_registry = first.tool_registry
 
-    seen_ids: set[str] = set()
+    regular_attrs = ("_preconditions", "_postconditions", "_session_contracts", "_sandbox_contracts")
+    shadow_attrs = (
+        "_shadow_preconditions",
+        "_shadow_postconditions",
+        "_shadow_session_contracts",
+        "_shadow_sandbox_contracts",
+    )
+
+    seen_regular_ids: set[str] = set()
+    seen_shadow_ids: set[str] = set()
 
     for guard in guards:
-        for attr in (
-            "_preconditions",
-            "_postconditions",
-            "_session_contracts",
-            "_sandbox_contracts",
-            "_shadow_preconditions",
-            "_shadow_postconditions",
-            "_shadow_session_contracts",
-            "_shadow_sandbox_contracts",
+        for attr, seen in (
+            *((a, seen_regular_ids) for a in regular_attrs),
+            *((a, seen_shadow_ids) for a in shadow_attrs),
         ):
             for contract in getattr(guard, attr):
                 cid = getattr(contract, "_edictum_id", None)
-                if cid and cid in seen_ids:
+                if cid and cid in seen:
                     logger.warning("Duplicate contract id '%s' in from_multiple() — first wins", cid)
                     continue
                 if cid:
-                    seen_ids.add(cid)
+                    seen.add(cid)
                 getattr(merged, attr).append(contract)
 
     return merged

--- a/tests/test_behavior/test_factory_behavior.py
+++ b/tests/test_behavior/test_factory_behavior.py
@@ -122,3 +122,87 @@ class TestFromMultipleShadowContracts:
         merged = Edictum.from_multiple([g1, g2])
 
         assert len(merged._shadow_preconditions) == 1
+
+    def test_shadow_session_contracts_merged(self):
+        """Shadow session contracts from both guards appear in merged guard."""
+
+        @precondition("*")
+        def shadow_sess_a(envelope):
+            return Verdict.pass_()
+
+        shadow_sess_a._edictum_id = "shadow-sess-a"
+        shadow_sess_a._edictum_type = "session_contract"
+        _make_shadow(shadow_sess_a)
+
+        @precondition("*")
+        def shadow_sess_b(envelope):
+            return Verdict.pass_()
+
+        shadow_sess_b._edictum_id = "shadow-sess-b"
+        shadow_sess_b._edictum_type = "session_contract"
+        _make_shadow(shadow_sess_b)
+
+        g1 = Edictum(mode="enforce", contracts=[shadow_sess_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[shadow_sess_b], audit_sink=_NullSink())
+
+        merged = Edictum.from_multiple([g1, g2])
+
+        ids = [getattr(c, "_edictum_id", None) for c in merged._shadow_session_contracts]
+        assert len(ids) == 2
+        assert "shadow-sess-a" in ids
+        assert "shadow-sess-b" in ids
+
+    def test_shadow_sandbox_contracts_merged(self):
+        """Shadow sandbox contracts from both guards appear in merged guard."""
+
+        @precondition("*")
+        def shadow_sb_a(envelope):
+            return Verdict.pass_()
+
+        shadow_sb_a._edictum_id = "shadow-sb-a"
+        shadow_sb_a._edictum_type = "sandbox"
+        shadow_sb_a._edictum_tools = ["*"]
+        _make_shadow(shadow_sb_a)
+
+        @precondition("*")
+        def shadow_sb_b(envelope):
+            return Verdict.pass_()
+
+        shadow_sb_b._edictum_id = "shadow-sb-b"
+        shadow_sb_b._edictum_type = "sandbox"
+        shadow_sb_b._edictum_tools = ["*"]
+        _make_shadow(shadow_sb_b)
+
+        g1 = Edictum(mode="enforce", contracts=[shadow_sb_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[shadow_sb_b], audit_sink=_NullSink())
+
+        merged = Edictum.from_multiple([g1, g2])
+
+        ids = [getattr(c, "_edictum_id", None) for c in merged._shadow_sandbox_contracts]
+        assert len(ids) == 2
+        assert "shadow-sb-a" in ids
+        assert "shadow-sb-b" in ids
+
+    def test_cross_type_id_collision_does_not_drop_shadow(self):
+        """A shadow contract with the same ID as a regular contract must NOT be dropped."""
+
+        @precondition("Bash")
+        def enforced(envelope):
+            return Verdict.fail("Enforced")
+
+        enforced._edictum_id = "shared-id"
+
+        @precondition("Bash")
+        def shadow(envelope):
+            return Verdict.fail("Shadow")
+
+        shadow._edictum_id = "shared-id"
+        _make_shadow(shadow)
+
+        g1 = Edictum(mode="enforce", contracts=[enforced], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[shadow], audit_sink=_NullSink())
+
+        merged = Edictum.from_multiple([g1, g2])
+
+        assert len(merged._preconditions) == 1
+        assert len(merged._shadow_preconditions) == 1


### PR DESCRIPTION
Closes #81

## Summary
- `_from_multiple()` only iterated the 4 enforced contract lists (`_preconditions`, `_postconditions`, `_session_contracts`, `_sandbox_contracts`), silently dropping observe-mode (shadow) contracts during guard merging.
- Added the 4 shadow attributes (`_shadow_preconditions`, `_shadow_postconditions`, `_shadow_session_contracts`, `_shadow_sandbox_contracts`) to the iteration tuple. The existing loop logic (dedup by `_edictum_id`, `getattr`) works generically.
- Added behavior tests in `tests/test_behavior/test_factory_behavior.py` covering: merging shadow preconditions from both guards, merging shadow postconditions, mixed enforce + shadow merging, and shadow dedup by ID.

## Test plan
- [x] `pytest tests/ -x -q` — 2066 passed, 3 skipped
- [x] `ruff check src/ tests/` — all checks passed
- [x] New tests in `tests/test_behavior/test_factory_behavior.py` verify shadow contracts are preserved through `from_multiple()`