### PR TITLE
refactor: extract sandbox compiler and DRY CLI evaluation

### DIFF
--- a/src/edictum/cli/main.py
+++ b/src/edictum/cli/main.py
@@ -138,6 +138,25 @@ def _evaluate_sandbox_contracts(
     return "allowed", None, None, evaluated
 
 
+def _evaluate_all(
+    compiled: Any,
+    envelope: ToolEnvelope,
+) -> tuple[str, str | None, str | None, list[dict]]:
+    """Evaluate preconditions and sandbox contracts against an envelope.
+
+    Runs preconditions first. If all pass, runs sandbox contracts.
+    Returns (verdict, contract_id, message, evaluated_records).
+    verdict is "denied" or "allowed".
+    """
+    verdict, contract_id, message, evaluated = _evaluate_preconditions(compiled, envelope)
+    if verdict == "allowed":
+        sb_verdict, sb_id, sb_msg, sb_evaluated = _evaluate_sandbox_contracts(compiled, envelope)
+        evaluated.extend(sb_evaluated)
+        if sb_verdict == "denied":
+            verdict, contract_id, message = sb_verdict, sb_id, sb_msg
+    return verdict, contract_id, message, evaluated
+
+
 # ---------------------------------------------------------------------------
 # CLI group
 # ---------------------------------------------------------------------------
@@ -347,12 +366,7 @@ def check(
     envelope = _build_envelope(tool, parsed_args, environment, principal)
 
     # Evaluate
-    verdict, contract_id, message, evaluated = _evaluate_preconditions(compiled, envelope)
-    if verdict == "allowed":
-        sb_verdict, sb_id, sb_msg, sb_evaluated = _evaluate_sandbox_contracts(compiled, envelope)
-        evaluated.extend(sb_evaluated)
-        if sb_verdict == "denied":
-            verdict, contract_id, message = sb_verdict, sb_id, sb_msg
+    verdict, contract_id, message, evaluated = _evaluate_all(compiled, envelope)
 
     n_evaluated = len(evaluated)
     verdict_label = "deny" if verdict == "denied" else "allow"
@@ -577,12 +591,7 @@ def replay(file: str, audit_log: str, output: str | None) -> None:
 
         # Build envelope and evaluate
         envelope = _build_envelope(tool_name, tool_args, environment, principal)
-        new_verdict, contract_id, message, evaluated = _evaluate_preconditions(compiled, envelope)
-        if new_verdict == "allowed":
-            sb_verdict, sb_id, sb_msg, sb_evaluated = _evaluate_sandbox_contracts(compiled, envelope)
-            evaluated.extend(sb_evaluated)
-            if sb_verdict == "denied":
-                new_verdict, contract_id, message = sb_verdict, sb_id, sb_msg
+        new_verdict, contract_id, message, evaluated = _evaluate_all(compiled, envelope)
 
         # Map to action strings for comparison
         new_action = "call_denied" if new_verdict == "denied" else "call_allowed"
@@ -703,12 +712,7 @@ def _run_cases(file: str, cases: str, environment: str = "production") -> None:
         # Build envelope and evaluate
         case_env = tc.get("environment", environment)
         envelope = _build_envelope(tool, args, environment=case_env, principal=principal)
-        verdict, contract_id, message, evaluated = _evaluate_preconditions(compiled, envelope)
-        if verdict == "allowed":
-            sb_verdict, sb_id, _sb_msg, sb_evaluated = _evaluate_sandbox_contracts(compiled, envelope)
-            evaluated.extend(sb_evaluated)
-            if sb_verdict == "denied":
-                verdict, contract_id = sb_verdict, sb_id
+        verdict, contract_id, message, evaluated = _evaluate_all(compiled, envelope)
 
         # Map verdict to expected format
         actual = "deny" if verdict == "denied" else "allow"

--- a/src/edictum/yaml_engine/compiler.py
+++ b/src/edictum/yaml_engine/compiler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -111,6 +110,8 @@ def compile_contracts(
             fn = _compile_post(contract, contract_mode, custom_operators, custom_selectors)
             postconditions.append(fn)
         elif contract_type == "sandbox":
+            from edictum.yaml_engine.sandbox_compiler import _compile_sandbox
+
             fn = _compile_sandbox(contract, contract_mode)
             sandbox_contracts.append(fn)
         elif contract_type == "session":
@@ -391,191 +392,6 @@ def _merge_session_limits(contract: dict, existing: OperationLimits) -> Operatio
         max_tool_calls=max_tool_calls,
         max_calls_per_tool=max_calls_per_tool,
     )
-
-
-_PATH_ARG_KEYS = frozenset(
-    {
-        "path",
-        "file_path",
-        "filePath",
-        "directory",
-        "dir",
-        "folder",
-        "target",
-        "destination",
-        "source",
-        "src",
-        "dst",
-    }
-)
-
-
-def _extract_paths(envelope: ToolEnvelope) -> list[str]:
-    """Extract file paths from an envelope for sandbox evaluation.
-
-    Strategy (priority order):
-    1. envelope.file_path (bonus for Claude Code tools)
-    2. Args values with path-like keys
-    3. Args string values starting with /
-    4. Parse command string for /-prefixed tokens
-
-    Note: paths are resolved via ``os.path.realpath()`` which handles both
-    ``..`` traversals AND symlinks.  TOCTOU caveat: a symlink created after
-    evaluation but before tool execution is not caught; full mitigation
-    requires OS-level enforcement.
-    """
-    paths: list[str] = []
-    seen: set[str] = set()
-
-    def _add(p: str) -> None:
-        if p:
-            p = os.path.realpath(p)
-            if p not in seen:
-                seen.add(p)
-                paths.append(p)
-
-    # 1. Envelope convenience field
-    if envelope.file_path:
-        _add(envelope.file_path)
-
-    # 2. Path-like arg keys
-    for key, value in envelope.args.items():
-        if isinstance(value, str) and key in _PATH_ARG_KEYS:
-            _add(value)
-
-    # 3. Any arg value starting with /
-    for key, value in envelope.args.items():
-        if isinstance(value, str) and value.startswith("/") and key not in _PATH_ARG_KEYS:
-            _add(value)
-
-    # 4. Parse command string for path tokens
-    cmd = envelope.bash_command or envelope.args.get("command", "")
-    if cmd:
-        for token in cmd.split():
-            if token.startswith("/"):
-                _add(token)
-
-    return paths
-
-
-def _extract_command(envelope: ToolEnvelope) -> str | None:
-    """Extract the first command token from an envelope."""
-    cmd = envelope.bash_command or envelope.args.get("command")
-    if not cmd or not isinstance(cmd, str):
-        return None
-    stripped = cmd.strip()
-    if not stripped:
-        return None
-    return stripped.split()[0]
-
-
-def _extract_urls(envelope: ToolEnvelope) -> list[str]:
-    """Extract URL strings from envelope args."""
-    urls: list[str] = []
-    for value in envelope.args.values():
-        if isinstance(value, str) and "://" in value:
-            urls.append(value)
-    return urls
-
-
-def _extract_hostname(url: str) -> str | None:
-    """Extract hostname from a URL string."""
-    from urllib.parse import urlparse
-
-    try:
-        parsed = urlparse(url)
-        return parsed.hostname
-    except Exception:
-        return None
-
-
-def _domain_matches(hostname: str, patterns: list[str]) -> bool:
-    """Check if hostname matches any domain pattern (supports wildcards)."""
-    from fnmatch import fnmatch
-
-    return any(fnmatch(hostname, p) for p in patterns)
-
-
-def _compile_sandbox(contract: dict, mode: str) -> Any:
-    """Compile a sandbox contract into a sandbox callable."""
-    contract_id = contract["id"]
-
-    # Normalize tool/tools to a list
-    if "tools" in contract:
-        tool_patterns = contract["tools"]
-    else:
-        tool_patterns = [contract["tool"]]
-
-    within = [os.path.realpath(p) for p in contract.get("within", [])]
-    not_within = [os.path.realpath(p) for p in contract.get("not_within", [])]
-    allows = contract.get("allows", {})
-    not_allows = contract.get("not_allows", {})
-    allowed_commands = allows.get("commands", [])
-    allowed_domains = allows.get("domains", [])
-    blocked_domains = not_allows.get("domains", [])
-    outside = contract.get("outside", "deny")
-    message_template = contract.get("message", "Tool call outside sandbox boundary.")
-    timeout = contract.get("timeout", 300)
-    timeout_effect = contract.get("timeout_effect", "deny")
-
-    def sandbox_fn(envelope: ToolEnvelope) -> Verdict:
-        # Path checks
-        if within or not_within:
-            paths = _extract_paths(envelope)
-            if paths:
-                # not_within: deny if any path matches an exclusion
-                for path in paths:
-                    for excluded in not_within:
-                        if path == excluded or path.startswith(excluded.rstrip("/") + "/"):
-                            msg = _expand_message(message_template, envelope)
-                            return Verdict.fail(msg)
-
-                # within: every path must be within at least one allowed prefix
-                if within:
-                    for path in paths:
-                        if not any(path == allowed or path.startswith(allowed.rstrip("/") + "/") for allowed in within):
-                            msg = _expand_message(message_template, envelope)
-                            return Verdict.fail(msg)
-
-        # Command checks
-        if allowed_commands:
-            first_token = _extract_command(envelope)
-            if first_token is not None:
-                if first_token not in allowed_commands:
-                    msg = _expand_message(message_template, envelope)
-                    return Verdict.fail(msg)
-
-        # Domain checks
-        urls = _extract_urls(envelope)
-        if urls:
-            for url in urls:
-                hostname = _extract_hostname(url)
-                if hostname:
-                    # not_allows.domains: deny if hostname matches excluded domain
-                    if blocked_domains and _domain_matches(hostname, blocked_domains):
-                        msg = _expand_message(message_template, envelope)
-                        return Verdict.fail(msg)
-                    # allows.domains: deny if hostname doesn't match any allowed domain
-                    if allowed_domains and not _domain_matches(hostname, allowed_domains):
-                        msg = _expand_message(message_template, envelope)
-                        return Verdict.fail(msg)
-
-        return Verdict.pass_()
-
-    # Stamp metadata for pipeline routing
-    sandbox_fn.__name__ = contract_id
-    sandbox_fn._edictum_type = "sandbox"
-    sandbox_fn._edictum_tools = tool_patterns
-    sandbox_fn._edictum_mode = mode
-    sandbox_fn._edictum_id = contract_id
-    sandbox_fn._edictum_source = "yaml_sandbox"
-    sandbox_fn._edictum_effect = outside
-    sandbox_fn._edictum_timeout = timeout
-    sandbox_fn._edictum_timeout_effect = timeout_effect
-    if contract.get("_shadow"):
-        sandbox_fn._edictum_shadow = True
-
-    return sandbox_fn
 
 
 def _expand_message(

--- a/src/edictum/yaml_engine/sandbox_compiler.py
+++ b/src/edictum/yaml_engine/sandbox_compiler.py
@@ -1,0 +1,195 @@
+"""Sandbox contract compiler -- extract/classify tool call resources and compile sandbox contracts."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from edictum.contracts import Verdict
+from edictum.envelope import ToolEnvelope
+
+_PATH_ARG_KEYS = frozenset(
+    {
+        "path",
+        "file_path",
+        "filePath",
+        "directory",
+        "dir",
+        "folder",
+        "target",
+        "destination",
+        "source",
+        "src",
+        "dst",
+    }
+)
+
+
+def _extract_paths(envelope: ToolEnvelope) -> list[str]:
+    """Extract file paths from an envelope for sandbox evaluation.
+
+    Strategy (priority order):
+    1. envelope.file_path (bonus for Claude Code tools)
+    2. Args values with path-like keys
+    3. Args string values starting with /
+    4. Parse command string for /-prefixed tokens
+
+    Note: paths are resolved via ``os.path.realpath()`` which handles both
+    ``..`` traversals AND symlinks.  TOCTOU caveat: a symlink created after
+    evaluation but before tool execution is not caught; full mitigation
+    requires OS-level enforcement.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    def _add(p: str) -> None:
+        if p:
+            p = os.path.realpath(p)
+            if p not in seen:
+                seen.add(p)
+                paths.append(p)
+
+    # 1. Envelope convenience field
+    if envelope.file_path:
+        _add(envelope.file_path)
+
+    # 2. Path-like arg keys
+    for key, value in envelope.args.items():
+        if isinstance(value, str) and key in _PATH_ARG_KEYS:
+            _add(value)
+
+    # 3. Any arg value starting with /
+    for key, value in envelope.args.items():
+        if isinstance(value, str) and value.startswith("/") and key not in _PATH_ARG_KEYS:
+            _add(value)
+
+    # 4. Parse command string for path tokens
+    cmd = envelope.bash_command or envelope.args.get("command", "")
+    if cmd:
+        for token in cmd.split():
+            if token.startswith("/"):
+                _add(token)
+
+    return paths
+
+
+def _extract_command(envelope: ToolEnvelope) -> str | None:
+    """Extract the first command token from an envelope."""
+    cmd = envelope.bash_command or envelope.args.get("command")
+    if not cmd or not isinstance(cmd, str):
+        return None
+    stripped = cmd.strip()
+    if not stripped:
+        return None
+    return stripped.split()[0]
+
+
+def _extract_urls(envelope: ToolEnvelope) -> list[str]:
+    """Extract URL strings from envelope args."""
+    urls: list[str] = []
+    for value in envelope.args.values():
+        if isinstance(value, str) and "://" in value:
+            urls.append(value)
+    return urls
+
+
+def _extract_hostname(url: str) -> str | None:
+    """Extract hostname from a URL string."""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(url)
+        return parsed.hostname
+    except Exception:
+        return None
+
+
+def _domain_matches(hostname: str, patterns: list[str]) -> bool:
+    """Check if hostname matches any domain pattern (supports wildcards)."""
+    from fnmatch import fnmatch
+
+    return any(fnmatch(hostname, p) for p in patterns)
+
+
+def _compile_sandbox(contract: dict, mode: str) -> Any:
+    """Compile a sandbox contract into a sandbox callable."""
+    from edictum.yaml_engine.compiler import _expand_message
+
+    contract_id = contract["id"]
+
+    # Normalize tool/tools to a list
+    if "tools" in contract:
+        tool_patterns = contract["tools"]
+    else:
+        tool_patterns = [contract["tool"]]
+
+    within = [os.path.realpath(p) for p in contract.get("within", [])]
+    not_within = [os.path.realpath(p) for p in contract.get("not_within", [])]
+    allows = contract.get("allows", {})
+    not_allows = contract.get("not_allows", {})
+    allowed_commands = allows.get("commands", [])
+    allowed_domains = allows.get("domains", [])
+    blocked_domains = not_allows.get("domains", [])
+    outside = contract.get("outside", "deny")
+    message_template = contract.get("message", "Tool call outside sandbox boundary.")
+    timeout = contract.get("timeout", 300)
+    timeout_effect = contract.get("timeout_effect", "deny")
+
+    def sandbox_fn(envelope: ToolEnvelope) -> Verdict:
+        # Path checks
+        if within or not_within:
+            paths = _extract_paths(envelope)
+            if paths:
+                # not_within: deny if any path matches an exclusion
+                for path in paths:
+                    for excluded in not_within:
+                        if path == excluded or path.startswith(excluded.rstrip("/") + "/"):
+                            msg = _expand_message(message_template, envelope)
+                            return Verdict.fail(msg)
+
+                # within: every path must be within at least one allowed prefix
+                if within:
+                    for path in paths:
+                        if not any(path == allowed or path.startswith(allowed.rstrip("/") + "/") for allowed in within):
+                            msg = _expand_message(message_template, envelope)
+                            return Verdict.fail(msg)
+
+        # Command checks
+        if allowed_commands:
+            first_token = _extract_command(envelope)
+            if first_token is not None:
+                if first_token not in allowed_commands:
+                    msg = _expand_message(message_template, envelope)
+                    return Verdict.fail(msg)
+
+        # Domain checks
+        urls = _extract_urls(envelope)
+        if urls:
+            for url in urls:
+                hostname = _extract_hostname(url)
+                if hostname:
+                    # not_allows.domains: deny if hostname matches excluded domain
+                    if blocked_domains and _domain_matches(hostname, blocked_domains):
+                        msg = _expand_message(message_template, envelope)
+                        return Verdict.fail(msg)
+                    # allows.domains: deny if hostname doesn't match any allowed domain
+                    if allowed_domains and not _domain_matches(hostname, allowed_domains):
+                        msg = _expand_message(message_template, envelope)
+                        return Verdict.fail(msg)
+
+        return Verdict.pass_()
+
+    # Stamp metadata for pipeline routing
+    sandbox_fn.__name__ = contract_id
+    sandbox_fn._edictum_type = "sandbox"
+    sandbox_fn._edictum_tools = tool_patterns
+    sandbox_fn._edictum_mode = mode
+    sandbox_fn._edictum_id = contract_id
+    sandbox_fn._edictum_source = "yaml_sandbox"
+    sandbox_fn._edictum_effect = outside
+    sandbox_fn._edictum_timeout = timeout
+    sandbox_fn._edictum_timeout_effect = timeout_effect
+    if contract.get("_shadow"):
+        sandbox_fn._edictum_shadow = True
+
+    return sandbox_fn

--- a/tests/test_adversarial/test_sandbox_escape.py
+++ b/tests/test_adversarial/test_sandbox_escape.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from edictum.envelope import create_envelope
-from edictum.yaml_engine.compiler import _compile_sandbox, _extract_paths
+from edictum.yaml_engine.sandbox_compiler import _compile_sandbox, _extract_paths
 
 pytestmark = pytest.mark.security
 

--- a/tests/test_behavior/test_sandbox_path_traversal.py
+++ b/tests/test_behavior/test_sandbox_path_traversal.py
@@ -13,7 +13,7 @@ import pytest
 
 from edictum import Edictum, create_envelope
 from edictum.storage import MemoryBackend
-from edictum.yaml_engine.compiler import _extract_paths
+from edictum.yaml_engine.sandbox_compiler import _extract_paths
 
 
 class NullSink:


### PR DESCRIPTION
## Summary

- Extract sandbox compilation logic (`_compile_sandbox`, `_extract_paths`, `_extract_command`, `_extract_urls`, `_extract_hostname`, `_domain_matches`) from `compiler.py` into new `sandbox_compiler.py` — reduces compiler.py from 611 to 432 lines
- Consolidate 3 duplicated precondition+sandbox evaluation blocks in CLI (`check`, `replay`, `test`) into a single `_evaluate_all()` helper
- Fix minor inconsistency in `_run_cases` where sandbox denial message was discarded (harmless but now consistent)

## Test plan

- [x] Full test suite passes (2043 passed, 0 failed)
- [x] Ruff lint clean on all `src/` and `tests/`
- [x] Pre-commit hooks pass (ruff, ruff-format, check-terminology)
- [x] CI green
- [x] Review confirms no behavioral changes