### PR TITLE
feat(server): enforce HTTPS by default on EdictumServerClient

### DIFF
--- a/src/edictum/_guard.py
+++ b/src/edictum/_guard.py
@@ -406,6 +406,7 @@ class Edictum:
         principal: Principal | None = None,
         principal_resolver: Callable[[str, dict[str, Any]], Principal] | None = None,
         auto_watch: bool = True,
+        allow_insecure: bool = False,
     ) -> Edictum:
         """Create an Edictum instance wired to a remote edictum-server."""
         from edictum._server_factory import _from_server
@@ -428,6 +429,7 @@ class Edictum:
             principal=principal,
             principal_resolver=principal_resolver,
             auto_watch=auto_watch,
+            allow_insecure=allow_insecure,
         )
 
     async def run(

--- a/src/edictum/_server_factory.py
+++ b/src/edictum/_server_factory.py
@@ -44,6 +44,7 @@ async def _from_server(
     principal: Principal | None = None,
     principal_resolver: Callable[[str, dict[str, Any]], Principal] | None = None,
     auto_watch: bool = True,
+    allow_insecure: bool = False,
 ) -> Edictum:
     """Create an Edictum instance wired to a remote edictum-server.
 
@@ -68,6 +69,8 @@ async def _from_server(
         principal: Static principal for all tool calls.
         principal_resolver: Per-call dynamic principal resolution.
         auto_watch: If True (default), start an SSE background task.
+        allow_insecure: If True, allow plaintext HTTP to non-loopback
+            hosts (logs a warning). Defaults to False (raises ValueError).
 
     Returns:
         Configured Edictum instance connected to the server.
@@ -100,6 +103,7 @@ async def _from_server(
         env=environment,
         bundle_name=bundle_name,
         tags=tags,
+        allow_insecure=allow_insecure,
     )
 
     effective_sink = audit_sink or ServerAuditSink(client)

--- a/src/edictum/server/client.py
+++ b/src/edictum/server/client.py
@@ -43,6 +43,7 @@ class EdictumServerClient:
         tags: dict[str, str] | None = None,
         timeout: float = 30.0,
         max_retries: int = 3,
+        allow_insecure: bool = False,
     ) -> None:
         for name, value in [("agent_id", agent_id), ("env", env)]:
             if not _SAFE_IDENTIFIER_RE.match(value):
@@ -64,6 +65,25 @@ class EdictumServerClient:
                     raise ValueError(f"Tag key too long ({len(k)} > 128): {k!r}")
                 if len(v) > 256:
                     raise ValueError(f"Tag value too long ({len(v)} > 256) for key {k!r}")
+        # TLS enforcement: refuse plaintext HTTP to non-loopback hosts
+        from urllib.parse import urlparse
+
+        parsed = urlparse(base_url)
+        if parsed.scheme == "http":
+            host = parsed.hostname or ""
+            is_loopback = host in ("localhost", "127.0.0.1", "::1")
+            if not is_loopback:
+                if not allow_insecure:
+                    raise ValueError(
+                        f"Refusing plaintext HTTP connection to {host}. "
+                        f"Use HTTPS or pass allow_insecure=True for non-production use."
+                    )
+                logger.warning(
+                    "Plaintext HTTP connection to %s — credentials will be transmitted unencrypted. "
+                    "Use HTTPS in production.",
+                    host,
+                )
+
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.agent_id = agent_id

--- a/tests/test_behavior/test_server_client_behavior.py
+++ b/tests/test_behavior/test_server_client_behavior.py
@@ -1,0 +1,86 @@
+"""Behavior tests for EdictumServerClient HTTPS enforcement.
+
+Verifies that plaintext HTTP connections are refused by default,
+allowed with allow_insecure=True (with a warning), and that
+localhost/loopback addresses are exempt.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from edictum.server.client import EdictumServerClient
+
+
+class TestHttpsEnforcement:
+    """Observable effect: allow_insecure controls whether http:// URLs are accepted."""
+
+    def test_https_url_accepted(self):
+        """HTTPS URLs are always accepted without error."""
+        client = EdictumServerClient("https://example.com", "key")
+        assert client.base_url == "https://example.com"
+
+    def test_http_url_raises_by_default(self):
+        """Plaintext HTTP to a non-loopback host raises ValueError."""
+        with pytest.raises(ValueError, match="Refusing plaintext HTTP connection to example.com"):
+            EdictumServerClient("http://example.com", "key")
+
+    def test_http_url_with_allow_insecure_warns(self, caplog):
+        """allow_insecure=True allows HTTP but logs a warning."""
+        with caplog.at_level(logging.WARNING, logger="edictum.server.client"):
+            client = EdictumServerClient("http://example.com", "key", allow_insecure=True)
+        assert client.base_url == "http://example.com"
+        assert "Plaintext HTTP connection to example.com" in caplog.text
+        assert "Use HTTPS in production" in caplog.text
+
+    def test_http_localhost_allowed(self):
+        """http://localhost is exempt (common for development)."""
+        client = EdictumServerClient("http://localhost:8080", "key")
+        assert client.base_url == "http://localhost:8080"
+
+    def test_http_127_0_0_1_allowed(self):
+        """http://127.0.0.1 is exempt (IPv4 loopback)."""
+        client = EdictumServerClient("http://127.0.0.1:8080", "key")
+        assert client.base_url == "http://127.0.0.1:8080"
+
+    def test_http_ipv6_loopback_allowed(self):
+        """http://[::1] is exempt (IPv6 loopback)."""
+        client = EdictumServerClient("http://[::1]:8080", "key")
+        assert client.base_url == "http://[::1]:8080"
+
+    @pytest.mark.security
+    def test_http_non_loopback_raises(self):
+        """Private network IPs over HTTP are not exempt."""
+        with pytest.raises(ValueError, match="Refusing plaintext HTTP connection to 192.168.1.1"):
+            EdictumServerClient("http://192.168.1.1", "key")
+
+    def test_warning_message_contains_host(self, caplog):
+        """The warning message includes the specific hostname."""
+        with caplog.at_level(logging.WARNING, logger="edictum.server.client"):
+            EdictumServerClient("http://my-server.internal", "key", allow_insecure=True)
+        assert "my-server.internal" in caplog.text
+
+    @pytest.mark.security
+    def test_http_no_host_raises(self):
+        """HTTP URL with empty hostname is not exempt."""
+        # urlparse("http://") gives hostname="" — should not pass as loopback
+        with pytest.raises(ValueError, match="Refusing plaintext HTTP"):
+            EdictumServerClient("http://", "key")
+
+    @pytest.mark.security
+    def test_http_10_x_raises(self):
+        """Private 10.x.x.x addresses over HTTP are denied by default."""
+        with pytest.raises(ValueError, match="Refusing plaintext HTTP connection to 10.0.0.1"):
+            EdictumServerClient("http://10.0.0.1:8080", "key")
+
+    def test_allow_insecure_false_is_default(self):
+        """Verify that omitting allow_insecure defaults to strict enforcement."""
+        # HTTPS works fine without allow_insecure
+        client = EdictumServerClient("https://example.com", "key")
+        assert client.base_url == "https://example.com"
+
+        # HTTP to non-loopback fails without allow_insecure
+        with pytest.raises(ValueError):
+            EdictumServerClient("http://example.com", "key")

--- a/tests/test_server/test_from_server.py
+++ b/tests/test_server/test_from_server.py
@@ -99,6 +99,7 @@ class TestFromServer:
                 env="production",
                 bundle_name="default",
                 tags=None,
+                allow_insecure=False,
             )
             client.get.assert_called_once_with(
                 "/api/v1/bundles/default/current",
@@ -214,6 +215,7 @@ class TestFromServer:
                 env="production",
                 bundle_name="devops-agent",
                 tags=None,
+                allow_insecure=False,
             )
             client.get.assert_called_once_with(
                 "/api/v1/bundles/devops-agent/current",
@@ -319,6 +321,7 @@ class TestFromServer:
                 env="production",
                 bundle_name="default",
                 tags={"role": "finance"},
+                allow_insecure=False,
             )
             await guard.close()
 


### PR DESCRIPTION
Closes #90

## Summary

`EdictumServerClient` now enforces HTTPS by default for non-loopback hosts. This is critical for a security product — API keys and audit data should never traverse the wire in plaintext.

**Behavior:**
- `https://` URLs: always accepted (no change)
- `http://localhost`, `http://127.0.0.1`, `http://[::1]`: exempt (development use)
- `http://<any-other-host>`: raises `ValueError` by default
- `http://<any-other-host>` with `allow_insecure=True`: logs a warning, proceeds

**Propagation:** `allow_insecure` is threaded through `Edictum.from_server()` and the internal `_from_server()` factory, all the way down to `EdictumServerClient.__init__()`.

## Changes

- `src/edictum/server/client.py` — added `allow_insecure` parameter, TLS enforcement check after existing validation
- `src/edictum/_server_factory.py` — accept and forward `allow_insecure` to client constructor
- `src/edictum/_guard.py` — accept and forward `allow_insecure` in `Edictum.from_server()`
- `tests/test_server/test_from_server.py` — updated 3 `assert_called_once_with` assertions to include `allow_insecure=False`
- `tests/test_behavior/test_server_client_behavior.py` — 11 new behavior tests covering HTTPS enforcement, loopback exemption, warning behavior, and security edge cases

## Test plan

- [x] `test_https_url_accepted` — HTTPS URLs pass without error
- [x] `test_http_url_raises_by_default` — HTTP to non-loopback raises `ValueError`
- [x] `test_http_url_with_allow_insecure_warns` — `allow_insecure=True` logs warning, no error
- [x] `test_http_localhost_allowed` — localhost exempt
- [x] `test_http_127_0_0_1_allowed` — IPv4 loopback exempt
- [x] `test_http_ipv6_loopback_allowed` — IPv6 loopback exempt
- [x] `test_http_non_loopback_raises` — private IPs denied (security)
- [x] `test_warning_message_contains_host` — warning includes hostname
- [x] `test_http_no_host_raises` — empty hostname not exempt (security)
- [x] `test_http_10_x_raises` — 10.x.x.x addresses denied (security)
- [x] `test_allow_insecure_false_is_default` — default behavior is strict
- [x] Full test suite: 2085 passed, 3 skipped
- [x] `ruff check src/ tests/` — clean
- [x] Pre-commit hooks (ruff, ruff-format, check-terminology) — all passed