### PR TITLE
feat(server): batch session counter reads to reduce HTTP round trips

### DIFF
--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -70,8 +70,18 @@ class GovernancePipeline:
         contracts_evaluated: list[dict] = []
         has_observed_deny = False
 
+        # Pre-fetch session counters in a single batch to reduce HTTP
+        # round trips when using ServerBackend.  The tool-specific key
+        # is included only when a per-tool limit is configured.
+        tool_name_for_batch: str | None = None
+        if envelope.tool_name in self._guard.limits.max_calls_per_tool:
+            tool_name_for_batch = envelope.tool_name
+        counters = await session.batch_get_counters(
+            include_tool=tool_name_for_batch,
+        )
+
         # 1. Attempt limit
-        attempt_count = await session.attempt_count()
+        attempt_count = counters["attempts"]
         if attempt_count >= self._guard.limits.max_attempts:
             return PreDecision(
                 action="deny",
@@ -257,8 +267,8 @@ class GovernancePipeline:
                     policy_error=pe,
                 )
 
-        # 5. Execution limits
-        exec_count = await session.execution_count()
+        # 5. Execution limits (use pre-fetched counters)
+        exec_count = counters["execs"]
         if exec_count >= self._guard.limits.max_tool_calls:
             return PreDecision(
                 action="deny",
@@ -270,9 +280,10 @@ class GovernancePipeline:
                 contracts_evaluated=contracts_evaluated,
             )
 
-        # Per-tool limits
+        # Per-tool limits (use pre-fetched counter when available)
         if envelope.tool_name in self._guard.limits.max_calls_per_tool:
-            tool_count = await session.tool_execution_count(envelope.tool_name)
+            tool_key = f"tool:{envelope.tool_name}"
+            tool_count = counters.get(tool_key, 0)
             tool_limit = self._guard.limits.max_calls_per_tool[envelope.tool_name]
             if tool_count >= tool_limit:
                 return PreDecision(

--- a/src/edictum/server/backend.py
+++ b/src/edictum/server/backend.py
@@ -55,3 +55,30 @@ class ServerBackend:
             {"amount": amount},
         )
         return response["value"]
+
+    async def batch_get(self, keys: list[str]) -> dict[str, str | None]:
+        """Retrieve multiple session values in a single HTTP call.
+
+        Falls back to individual get() calls if the server returns 404
+        (endpoint not available on older servers).
+
+        Fail-closed: non-404 errors propagate so the pipeline denies
+        rather than silently allowing with missing data.
+        """
+        if not keys:
+            return {}
+        try:
+            response = await self._client.post(
+                "/api/v1/sessions/batch",
+                {"keys": keys},
+            )
+            values = response.get("values", {})
+            return {key: values.get(key) for key in keys}
+        except EdictumServerError as exc:
+            if exc.status_code == 404:
+                # Server doesn't support batch endpoint -- fall back
+                result: dict[str, str | None] = {}
+                for key in keys:
+                    result[key] = await self.get(key)
+                return result
+            raise

--- a/src/edictum/session.py
+++ b/src/edictum/session.py
@@ -50,3 +50,39 @@ class Session:
 
     async def consecutive_failures(self) -> int:
         return int(await self._backend.get(f"s:{self._sid}:consec_fail") or 0)
+
+    async def batch_get_counters(
+        self,
+        *,
+        include_tool: str | None = None,
+    ) -> dict[str, int]:
+        """Pre-fetch multiple session counters in a single backend call.
+
+        Returns a dict with keys: "attempts", "execs", and optionally
+        "tool:{name}" if include_tool is provided.
+
+        Uses batch_get() on the backend when available (single HTTP round
+        trip for ServerBackend). Falls back to individual get() calls for
+        backends without batch_get support.
+        """
+        keys = [
+            f"s:{self._sid}:attempts",
+            f"s:{self._sid}:execs",
+        ]
+        key_labels = ["attempts", "execs"]
+
+        if include_tool is not None:
+            keys.append(f"s:{self._sid}:tool:{include_tool}")
+            key_labels.append(f"tool:{include_tool}")
+
+        if hasattr(self._backend, "batch_get"):
+            raw = await self._backend.batch_get(keys)
+        else:
+            raw = {}
+            for key in keys:
+                raw[key] = await self._backend.get(key)
+
+        result: dict[str, int] = {}
+        for key, label in zip(keys, key_labels):
+            result[label] = int(raw.get(key) or 0)
+        return result

--- a/src/edictum/storage.py
+++ b/src/edictum/storage.py
@@ -54,3 +54,13 @@ class MemoryBackend:
         async with self._lock:
             self._counters[key] = self._counters.get(key, 0) + amount
             return self._counters[key]
+
+    async def batch_get(self, keys: list[str]) -> dict[str, str | None]:
+        """Retrieve multiple values in a single operation.
+
+        In-memory implementation: multiple dict lookups, no network overhead.
+        """
+        result: dict[str, str | None] = {}
+        for key in keys:
+            result[key] = await self.get(key)
+        return result

--- a/tests/test_behavior/test_batch_session_behavior.py
+++ b/tests/test_behavior/test_batch_session_behavior.py
@@ -1,0 +1,292 @@
+"""Behavior tests for batch session counter reads.
+
+Verifies that batch_get() on backends and batch_get_counters() on Session
+reduce the number of storage round trips, and that the pipeline uses
+batched reads for session counter checks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from edictum import Edictum, create_envelope
+from edictum.pipeline import GovernancePipeline
+from edictum.server.backend import ServerBackend
+from edictum.server.client import EdictumServerError
+from edictum.session import Session
+from edictum.storage import MemoryBackend
+
+# ---------------------------------------------------------------------------
+# MemoryBackend.batch_get
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryBackendBatchGet:
+    async def test_returns_correct_values(self):
+        """batch_get returns the stored values for each key."""
+        backend = MemoryBackend()
+        await backend.set("k1", "v1")
+        await backend.increment("k2", amount=5)
+
+        result = await backend.batch_get(["k1", "k2"])
+        assert result["k1"] == "v1"
+        assert result["k2"] == "5"
+
+    async def test_missing_keys_return_none(self):
+        """Keys that don't exist return None in the result dict."""
+        backend = MemoryBackend()
+        await backend.set("exists", "yes")
+
+        result = await backend.batch_get(["exists", "missing1", "missing2"])
+        assert result["exists"] == "yes"
+        assert result["missing1"] is None
+        assert result["missing2"] is None
+
+    async def test_empty_keys_returns_empty_dict(self):
+        """An empty key list returns an empty dict."""
+        backend = MemoryBackend()
+        result = await backend.batch_get([])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# ServerBackend.batch_get
+# ---------------------------------------------------------------------------
+
+
+class TestServerBackendBatchGet:
+    @pytest.mark.asyncio
+    async def test_single_post_call(self):
+        """batch_get makes a single POST to /api/v1/sessions/batch."""
+        client = MagicMock()
+        client.post = AsyncMock(return_value={"values": {"k1": "v1", "k2": "v2"}})
+        backend = ServerBackend(client)
+
+        result = await backend.batch_get(["k1", "k2"])
+
+        client.post.assert_called_once_with(
+            "/api/v1/sessions/batch",
+            {"keys": ["k1", "k2"]},
+        )
+        assert result == {"k1": "v1", "k2": "v2"}
+
+    @pytest.mark.asyncio
+    async def test_missing_keys_return_none(self):
+        """Keys not in the server response are returned as None."""
+        client = MagicMock()
+        client.post = AsyncMock(return_value={"values": {"k1": "v1"}})
+        backend = ServerBackend(client)
+
+        result = await backend.batch_get(["k1", "k2"])
+        assert result["k1"] == "v1"
+        assert result["k2"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_keys_returns_empty_dict_no_http(self):
+        """Empty key list returns empty dict without making any HTTP call."""
+        client = MagicMock()
+        client.post = AsyncMock()
+        backend = ServerBackend(client)
+
+        result = await backend.batch_get([])
+        assert result == {}
+        client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_404(self):
+        """Falls back to individual get() calls when server returns 404."""
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=EdictumServerError(404, "Not Found"))
+        client.get = AsyncMock(
+            side_effect=[
+                {"value": "v1"},
+                EdictumServerError(404, "Not Found"),
+            ]
+        )
+        backend = ServerBackend(client)
+
+        result = await backend.batch_get(["k1", "k2"])
+        assert result["k1"] == "v1"
+        assert result["k2"] is None
+        # Verify individual gets were called
+        assert client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.security
+    async def test_raises_on_500(self):
+        """Non-404 server errors propagate (fail-closed)."""
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=EdictumServerError(500, "Internal Server Error"))
+        backend = ServerBackend(client)
+
+        with pytest.raises(EdictumServerError, match="HTTP 500"):
+            await backend.batch_get(["k1"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.security
+    async def test_raises_on_connection_error(self):
+        """Connection errors propagate (fail-closed)."""
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=ConnectionError("refused"))
+        backend = ServerBackend(client)
+
+        with pytest.raises(ConnectionError, match="refused"):
+            await backend.batch_get(["k1"])
+
+
+# ---------------------------------------------------------------------------
+# Session.batch_get_counters
+# ---------------------------------------------------------------------------
+
+
+class TestSessionBatchGetCounters:
+    async def test_returns_attempts_and_execs(self):
+        """batch_get_counters returns attempt and execution counts."""
+        backend = MemoryBackend()
+        session = Session("s1", backend)
+        await session.increment_attempts()
+        await session.increment_attempts()
+        await session.record_execution("Bash", success=True)
+
+        counters = await session.batch_get_counters()
+        assert counters["attempts"] == 2
+        assert counters["execs"] == 1
+
+    async def test_includes_tool_count_when_requested(self):
+        """include_tool adds the per-tool counter to the result."""
+        backend = MemoryBackend()
+        session = Session("s1", backend)
+        await session.record_execution("Bash", success=True)
+        await session.record_execution("Bash", success=True)
+        await session.record_execution("Read", success=True)
+
+        counters = await session.batch_get_counters(include_tool="Bash")
+        assert counters["tool:Bash"] == 2
+        assert counters["execs"] == 3
+
+    async def test_missing_tool_returns_zero(self):
+        """A tool with no executions returns 0."""
+        backend = MemoryBackend()
+        session = Session("s1", backend)
+
+        counters = await session.batch_get_counters(include_tool="NoSuchTool")
+        assert counters["tool:NoSuchTool"] == 0
+
+    async def test_zero_counters_on_fresh_session(self):
+        """A fresh session returns all zeros."""
+        backend = MemoryBackend()
+        session = Session("s1", backend)
+
+        counters = await session.batch_get_counters()
+        assert counters["attempts"] == 0
+        assert counters["execs"] == 0
+
+    async def test_falls_back_without_batch_get(self):
+        """Works with backends that lack batch_get (individual gets)."""
+
+        class MinimalBackend:
+            """Backend without batch_get -- only implements the Protocol."""
+
+            def __init__(self):
+                self._data: dict[str, str] = {}
+
+            async def get(self, key: str) -> str | None:
+                return self._data.get(key)
+
+            async def set(self, key: str, value: str) -> None:
+                self._data[key] = value
+
+            async def delete(self, key: str) -> None:
+                self._data.pop(key, None)
+
+            async def increment(self, key: str, amount: float = 1) -> float:
+                cur = float(self._data.get(key, "0"))
+                cur += amount
+                self._data[key] = str(int(cur)) if cur == int(cur) else str(cur)
+                return cur
+
+        backend = MinimalBackend()
+        session = Session("s1", backend)
+
+        # Manually set some counter values
+        await backend.increment("s:s1:attempts", 3)
+        await backend.increment("s:s1:execs", 2)
+
+        counters = await session.batch_get_counters()
+        assert counters["attempts"] == 3
+        assert counters["execs"] == 2
+
+    async def test_uses_batch_get_when_available(self):
+        """Verifies batch_get is called instead of individual get() calls
+        at the Session layer (batch_get itself may delegate to get())."""
+        backend = MemoryBackend()
+        session = Session("s1", backend)
+
+        with patch.object(backend, "batch_get", wraps=backend.batch_get) as mock_batch:
+            await session.batch_get_counters(include_tool="Bash")
+            # Session should call batch_get once with all keys
+            mock_batch.assert_called_once()
+            keys_arg = mock_batch.call_args[0][0]
+            assert len(keys_arg) == 3  # attempts, execs, tool:Bash
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration: batch read reduces round trips
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineBatchIntegration:
+    async def test_pipeline_uses_batch_counters(self, null_sink, backend):
+        """Pipeline pre_execute uses batch_get_counters instead of
+        individual session counter reads."""
+        guard = Edictum(
+            environment="test",
+            audit_sink=null_sink,
+            backend=backend,
+        )
+        session = Session("s1", backend)
+        envelope = create_envelope("Bash", {"command": "ls"})
+
+        with patch.object(session, "batch_get_counters", wraps=session.batch_get_counters) as mock_batch:
+            pipeline = GovernancePipeline(guard)
+            decision = await pipeline.pre_execute(envelope, session)
+
+            # batch_get_counters should have been called once
+            mock_batch.assert_called_once()
+            assert decision.action == "allow"
+
+    async def test_pipeline_batches_tool_key_when_per_tool_limit_set(self, null_sink, backend):
+        """When per-tool limits are configured, the tool key is included
+        in the batch fetch."""
+        guard = Edictum(
+            environment="test",
+            audit_sink=null_sink,
+            backend=backend,
+        )
+        guard.limits.max_calls_per_tool["Bash"] = 5
+        session = Session("s1", backend)
+        envelope = create_envelope("Bash", {"command": "ls"})
+
+        with patch.object(session, "batch_get_counters", wraps=session.batch_get_counters) as mock_batch:
+            pipeline = GovernancePipeline(guard)
+            await pipeline.pre_execute(envelope, session)
+
+            mock_batch.assert_called_once_with(include_tool="Bash")
+
+    async def test_pipeline_does_not_batch_tool_key_when_no_per_tool_limit(self, null_sink, backend):
+        """Without per-tool limits, no tool key is batched."""
+        guard = Edictum(
+            environment="test",
+            audit_sink=null_sink,
+            backend=backend,
+        )
+        session = Session("s1", backend)
+        envelope = create_envelope("Bash", {"command": "ls"})
+
+        with patch.object(session, "batch_get_counters", wraps=session.batch_get_counters) as mock_batch:
+            pipeline = GovernancePipeline(guard)
+            await pipeline.pre_execute(envelope, session)
+
+            mock_batch.assert_called_once_with(include_tool=None)

--- a/tests/test_server/test_backend.py
+++ b/tests/test_server/test_backend.py
@@ -116,3 +116,4 @@ class TestServerBackend:
         assert hasattr(backend, "set")
         assert hasattr(backend, "delete")
         assert hasattr(backend, "increment")
+        assert hasattr(backend, "batch_get")


### PR DESCRIPTION
Closes #91

## Summary

- Add `batch_get()` to `MemoryBackend` and `ServerBackend` for retrieving multiple session values in a single operation
- Add `batch_get_counters()` to `Session` that pre-fetches attempt count, execution count, and optionally per-tool count in one backend call
- Update `GovernancePipeline.pre_execute()` to batch-fetch all needed session counters at the start, replacing 2-3 individual `backend.get()` calls with 1 `batch_get()` call

### Performance impact

For `ServerBackend`, each `pre_execute()` call previously made 2-3 separate HTTP round trips to read session counters (attempts, executions, and optionally per-tool count). Now it makes 1 round trip via `POST /api/v1/sessions/batch`.

### Backward compatibility

- `StorageBackend` protocol is **unchanged** -- `batch_get` is not added to the protocol
- `Session.batch_get_counters()` checks `hasattr(backend, 'batch_get')` and falls back to individual `get()` calls for backends without it
- `ServerBackend.batch_get()` falls back to individual `get()` calls when the server returns 404 (older servers without the batch endpoint)
- Non-404 server errors propagate (fail-closed, consistent with existing `get()` behavior)

## Test plan

- [ ] `MemoryBackend.batch_get()` returns correct values, None for missing keys, empty dict for empty keys
- [ ] `ServerBackend.batch_get()` makes single POST, handles missing keys, returns empty dict without HTTP for empty keys
- [ ] `ServerBackend.batch_get()` falls back to individual gets on 404, propagates 500 and connection errors (fail-closed)
- [ ] `Session.batch_get_counters()` returns correct attempt/exec counts, includes tool count when requested
- [ ] `Session.batch_get_counters()` works with backends that lack `batch_get` (fallback to individual gets)
- [ ] Pipeline `pre_execute()` calls `batch_get_counters()` once, includes tool key only when per-tool limit is configured
- [ ] All 2092 existing tests pass, ruff clean