### PR TITLE
refactor: enforce observe-mode terminology, ban "shadow" in prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,10 +136,10 @@
 ### Added
 - `compose_bundles()` — multi-file YAML composition with deterministic left-to-right merge
 - `from_yaml()` now accepts multiple file paths with automatic composition
-- `observe_alongside: true` — dual-mode evaluation (shadow contracts run without affecting decisions)
-- `CompositionReport` with override and shadow tracking
+- `observe_alongside: true` — dual-mode evaluation (observe-mode contracts run without affecting decisions)
+- `CompositionReport` with override and observe-mode tracking
 - `edictum validate` and `edictum diff` support multi-file arguments
-- CLI composition report output for overrides and shadow contracts
+- CLI composition report output for overrides and observe-mode contracts
 
 ## 0.7.0
 

--- a/scripts/check-terminology.py
+++ b/scripts/check-terminology.py
@@ -35,6 +35,30 @@ BLOCKED_ALLOWLIST = {
     "{blocked}",
 }
 
+# "shadow" needs special handling — internal code uses shadow_* field names
+# in _CompiledState and _edictum_shadow attribute, but prose should say
+# "observe mode" / "observe-mode".
+SHADOW_PATTERN = re.compile(r"\bshadow\b", re.IGNORECASE)
+SHADOW_ALLOWLIST = {
+    # _CompiledState frozen dataclass fields
+    "shadow_preconditions",
+    "shadow_postconditions",
+    "shadow_session_contracts",
+    "shadow_sandbox_contracts",
+    # Internal attribute on contract callables
+    "_edictum_shadow",
+    # Local variable reading the attribute
+    "is_shadow",
+    # Getter methods on Edictum
+    "get_shadow_preconditions",
+    "get_shadow_postconditions",
+    "get_shadow_sandbox_contracts",
+    "get_shadow_session_contracts",
+    # Real file path in sandbox tests (with and without leading slash)
+    "/etc/shadow",
+    '"etc" / "shadow"',
+}
+
 # Files/dirs to skip
 SKIP_PATHS = {
     ".docs-style-guide.md",
@@ -90,6 +114,13 @@ def check_file(path: Path) -> list[str]:
             line_stripped = line.strip()
             if not any(allowed in line_stripped for allowed in BLOCKED_ALLOWLIST):
                 violations.append(f"  {path}:{i}: 'blocked' — use 'denied' instead")
+                violations.append(f"    {line_stripped}")
+
+        # Check "shadow" with allowlist
+        if SHADOW_PATTERN.search(line):
+            line_stripped = line.strip()
+            if not any(allowed in line_stripped for allowed in SHADOW_ALLOWLIST):
+                violations.append(f"  {path}:{i}: 'shadow' — use 'observe mode' / 'observe-mode' instead")
                 violations.append(f"    {line_stripped}")
 
     return violations

--- a/src/edictum/_guard.py
+++ b/src/edictum/_guard.py
@@ -213,7 +213,7 @@ class Edictum:
         bundle_data, bundle_hash = load_bundle_string(contracts_yaml)
         compiled = compile_contracts(bundle_data)
 
-        # Sort compiled contracts into enforced vs observe-mode (shadow) lists,
+        # Sort compiled contracts into enforced vs observe-mode lists,
         # mirroring the classification that __init__() does at construction time.
         # Build the full state before touching self._state for atomicity.
         all_contracts = (

--- a/src/edictum/cli/main.py
+++ b/src/edictum/cli/main.py
@@ -40,7 +40,7 @@ def _print_composition_report(report: Any) -> None:
         )
     for s in report.shadow_contracts:
         _console.print(
-            f"  \u2295 {escape(s.contract_id)} \u2014 shadow from "
+            f"  \u2295 {escape(s.contract_id)} \u2014 observe-mode from "
             f"{escape(s.observed_source)} (enforced in {escape(s.enforced_source)})"
         )
 

--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -287,7 +287,7 @@ class GovernancePipeline:
         # 6. All checks passed
         pe = any(c.get("metadata", {}).get("policy_error") for c in contracts_evaluated)
 
-        # 7. Shadow contract evaluation (never affects the decision)
+        # 7. Observe-mode contract evaluation (never affects the decision)
         shadow_results = await self._evaluate_shadow_contracts(envelope, session)
 
         return PreDecision(
@@ -403,22 +403,22 @@ class GovernancePipeline:
         envelope: ToolEnvelope,
         session: Session,
     ) -> list[dict]:
-        """Evaluate shadow contracts without affecting the real decision.
+        """Evaluate observe-mode contracts without affecting the real decision.
 
-        Shadow contracts are identified by ``_edictum_shadow = True``.
+        Observe-mode contracts are identified by ``_edictum_shadow = True``.
         Results are returned as dicts for audit emission but never block calls.
         """
         results: list[dict] = []
 
-        # Shadow preconditions
+        # Observe-mode preconditions
         for contract in self._guard.get_shadow_preconditions(envelope):
             try:
                 verdict = contract(envelope)
                 if asyncio.iscoroutine(verdict):
                     verdict = await verdict
             except Exception as exc:
-                logger.exception("Shadow precondition %s raised", getattr(contract, "__name__", "anonymous"))
-                verdict = Verdict.fail(f"Shadow precondition error: {exc}", policy_error=True)
+                logger.exception("Observe-mode precondition %s raised", getattr(contract, "__name__", "anonymous"))
+                verdict = Verdict.fail(f"Observe-mode precondition error: {exc}", policy_error=True)
 
             results.append(
                 {
@@ -430,15 +430,15 @@ class GovernancePipeline:
                 }
             )
 
-        # Shadow sandbox contracts
+        # Observe-mode sandbox contracts
         for contract in self._guard.get_shadow_sandbox_contracts(envelope):
             try:
                 verdict = contract(envelope)
                 if asyncio.iscoroutine(verdict):
                     verdict = await verdict
             except Exception as exc:
-                logger.exception("Shadow sandbox %s raised", getattr(contract, "__name__", "anonymous"))
-                verdict = Verdict.fail(f"Shadow sandbox error: {exc}", policy_error=True)
+                logger.exception("Observe-mode sandbox %s raised", getattr(contract, "__name__", "anonymous"))
+                verdict = Verdict.fail(f"Observe-mode sandbox error: {exc}", policy_error=True)
 
             results.append(
                 {
@@ -450,15 +450,15 @@ class GovernancePipeline:
                 }
             )
 
-        # Shadow session contracts — evaluate against the real session
+        # Observe-mode session contracts — evaluate against the real session
         for contract in self._guard.get_shadow_session_contracts():
             try:
                 verdict = contract(session)
                 if asyncio.iscoroutine(verdict):
                     verdict = await verdict
             except Exception as exc:
-                logger.exception("Shadow session contract %s raised", getattr(contract, "__name__", "anonymous"))
-                verdict = Verdict.fail(f"Shadow session contract error: {exc}", policy_error=True)
+                logger.exception("Observe-mode session contract %s raised", getattr(contract, "__name__", "anonymous"))
+                verdict = Verdict.fail(f"Observe-mode session contract error: {exc}", policy_error=True)
 
             results.append(
                 {

--- a/src/edictum/yaml_engine/composer.py
+++ b/src/edictum/yaml_engine/composer.py
@@ -17,11 +17,11 @@ class CompositionOverride:
 
 @dataclass(frozen=True)
 class ShadowContract:
-    """Records a contract added as a shadow (observe_alongside)."""
+    """Records a contract added as an observe-mode copy (observe_alongside)."""
 
     contract_id: str
     enforced_source: str  # source label of the enforced version
-    observed_source: str  # source label of the shadow version
+    observed_source: str  # source label of the observe-mode version
 
 
 @dataclass(frozen=True)
@@ -173,7 +173,7 @@ def _merge_observe_alongside(
     contract_sources: dict[str, str],
     shadows: list[ShadowContract],
 ) -> None:
-    """Merge an observe_alongside layer — contracts become shadow copies."""
+    """Merge an observe_alongside layer — contracts become observe-mode copies."""
     for contract in layer.get("contracts", []):
         cid = contract["id"]
         shadow_id = f"{cid}:candidate"

--- a/tests/test_behavior/test_callback_behavior.py
+++ b/tests/test_behavior/test_callback_behavior.py
@@ -290,7 +290,7 @@ class TestOnAllowCallback:
 
 
 class TestOnDenyNotInObserveMode:
-    """on_deny must NOT fire in observe mode (denials are shadow-only)."""
+    """on_deny must NOT fire in observe mode (denials are observe-mode only)."""
 
     async def test_on_deny_skipped_in_observe_mode(self):
         """Observe mode logs would-deny but must not invoke on_deny."""

--- a/tests/test_behavior/test_factory_behavior.py
+++ b/tests/test_behavior/test_factory_behavior.py
@@ -11,68 +11,68 @@ class _NullSink:
         pass
 
 
-def _make_shadow(fn):
-    """Mark a contract function as observe-mode (shadow)."""
+def _make_observe(fn):
+    """Mark a contract function as observe-mode."""
     fn._edictum_shadow = True
     return fn
 
 
-class TestFromMultipleShadowContracts:
+class TestFromMultipleObserveModeContracts:
     """from_multiple() must merge observe-mode contracts from all guards."""
 
-    def test_shadow_preconditions_merged_from_both_guards(self):
+    def test_observe_preconditions_merged_from_both_guards(self):
         @precondition("Bash")
-        def shadow_pre_a(envelope):
-            return Verdict.fail("Shadow pre A")
+        def observe_pre_a(envelope):
+            return Verdict.fail("Observe-mode pre A")
 
-        shadow_pre_a._edictum_id = "shadow-pre-a"
-        _make_shadow(shadow_pre_a)
+        observe_pre_a._edictum_id = "observe-pre-a"
+        _make_observe(observe_pre_a)
 
         @precondition("Write")
-        def shadow_pre_b(envelope):
-            return Verdict.fail("Shadow pre B")
+        def observe_pre_b(envelope):
+            return Verdict.fail("Observe-mode pre B")
 
-        shadow_pre_b._edictum_id = "shadow-pre-b"
-        _make_shadow(shadow_pre_b)
+        observe_pre_b._edictum_id = "observe-pre-b"
+        _make_observe(observe_pre_b)
 
-        g1 = Edictum(mode="enforce", contracts=[shadow_pre_a], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow_pre_b], audit_sink=_NullSink())
+        g1 = Edictum(mode="enforce", contracts=[observe_pre_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe_pre_b], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 
         ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_preconditions]
         assert len(ids) == 2
-        assert "shadow-pre-a" in ids
-        assert "shadow-pre-b" in ids
+        assert "observe-pre-a" in ids
+        assert "observe-pre-b" in ids
         # Enforced lists should be empty
         assert len(merged._state.preconditions) == 0
 
-    def test_shadow_postconditions_merged(self):
+    def test_observe_postconditions_merged(self):
         @postcondition("*")
-        def shadow_post_a(envelope, response):
+        def observe_post_a(envelope, response):
             return Verdict.pass_()
 
-        shadow_post_a._edictum_id = "shadow-post-a"
-        _make_shadow(shadow_post_a)
+        observe_post_a._edictum_id = "observe-post-a"
+        _make_observe(observe_post_a)
 
         @postcondition("*")
-        def shadow_post_b(envelope, response):
+        def observe_post_b(envelope, response):
             return Verdict.pass_()
 
-        shadow_post_b._edictum_id = "shadow-post-b"
-        _make_shadow(shadow_post_b)
+        observe_post_b._edictum_id = "observe-post-b"
+        _make_observe(observe_post_b)
 
-        g1 = Edictum(mode="enforce", contracts=[shadow_post_a], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow_post_b], audit_sink=_NullSink())
+        g1 = Edictum(mode="enforce", contracts=[observe_post_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe_post_b], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 
         ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_postconditions]
         assert len(ids) == 2
-        assert "shadow-post-a" in ids
-        assert "shadow-post-b" in ids
+        assert "observe-post-a" in ids
+        assert "observe-post-b" in ids
 
-    def test_mixed_enforce_and_shadow_merged(self):
+    def test_mixed_enforce_and_observe_merged(self):
         """Only one guard has observe-mode contracts; merged guard retains them."""
 
         @precondition("Bash")
@@ -82,14 +82,14 @@ class TestFromMultipleShadowContracts:
         enforced_pre._edictum_id = "enforced-pre"
 
         @precondition("Write")
-        def shadow_pre(envelope):
-            return Verdict.fail("Shadow")
+        def observe_pre(envelope):
+            return Verdict.fail("Observe-mode")
 
-        shadow_pre._edictum_id = "shadow-pre"
-        _make_shadow(shadow_pre)
+        observe_pre._edictum_id = "observe-pre"
+        _make_observe(observe_pre)
 
         g_enforce = Edictum(mode="enforce", contracts=[enforced_pre], audit_sink=_NullSink())
-        g_observe = Edictum(mode="enforce", contracts=[shadow_pre], audit_sink=_NullSink())
+        g_observe = Edictum(mode="enforce", contracts=[observe_pre], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g_enforce, g_observe])
 
@@ -97,94 +97,94 @@ class TestFromMultipleShadowContracts:
         assert getattr(merged._state.preconditions[0], "_edictum_id", None) == "enforced-pre"
 
         assert len(merged._state.shadow_preconditions) == 1
-        assert getattr(merged._state.shadow_preconditions[0], "_edictum_id", None) == "shadow-pre"
+        assert getattr(merged._state.shadow_preconditions[0], "_edictum_id", None) == "observe-pre"
 
-    def test_shadow_dedup_by_id(self):
+    def test_observe_dedup_by_id(self):
         """Duplicate observe-mode contract IDs are deduplicated (first wins)."""
 
         @precondition("Bash")
-        def shadow_a(envelope):
+        def observe_a(envelope):
             return Verdict.fail("First")
 
-        shadow_a._edictum_id = "same-id"
-        _make_shadow(shadow_a)
+        observe_a._edictum_id = "same-id"
+        _make_observe(observe_a)
 
         @precondition("Bash")
-        def shadow_b(envelope):
+        def observe_b(envelope):
             return Verdict.fail("Second")
 
-        shadow_b._edictum_id = "same-id"
-        _make_shadow(shadow_b)
+        observe_b._edictum_id = "same-id"
+        _make_observe(observe_b)
 
-        g1 = Edictum(mode="enforce", contracts=[shadow_a], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow_b], audit_sink=_NullSink())
+        g1 = Edictum(mode="enforce", contracts=[observe_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe_b], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 
         assert len(merged._state.shadow_preconditions) == 1
 
-    def test_shadow_session_contracts_merged(self):
-        """Shadow session contracts from both guards appear in merged guard."""
+    def test_observe_session_contracts_merged(self):
+        """Observe-mode session contracts from both guards appear in merged guard."""
 
         @precondition("*")
-        def shadow_sess_a(envelope):
+        def observe_sess_a(envelope):
             return Verdict.pass_()
 
-        shadow_sess_a._edictum_id = "shadow-sess-a"
-        shadow_sess_a._edictum_type = "session_contract"
-        _make_shadow(shadow_sess_a)
+        observe_sess_a._edictum_id = "observe-sess-a"
+        observe_sess_a._edictum_type = "session_contract"
+        _make_observe(observe_sess_a)
 
         @precondition("*")
-        def shadow_sess_b(envelope):
+        def observe_sess_b(envelope):
             return Verdict.pass_()
 
-        shadow_sess_b._edictum_id = "shadow-sess-b"
-        shadow_sess_b._edictum_type = "session_contract"
-        _make_shadow(shadow_sess_b)
+        observe_sess_b._edictum_id = "observe-sess-b"
+        observe_sess_b._edictum_type = "session_contract"
+        _make_observe(observe_sess_b)
 
-        g1 = Edictum(mode="enforce", contracts=[shadow_sess_a], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow_sess_b], audit_sink=_NullSink())
+        g1 = Edictum(mode="enforce", contracts=[observe_sess_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe_sess_b], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 
         ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_session_contracts]
         assert len(ids) == 2
-        assert "shadow-sess-a" in ids
-        assert "shadow-sess-b" in ids
+        assert "observe-sess-a" in ids
+        assert "observe-sess-b" in ids
 
-    def test_shadow_sandbox_contracts_merged(self):
-        """Shadow sandbox contracts from both guards appear in merged guard."""
-
-        @precondition("*")
-        def shadow_sb_a(envelope):
-            return Verdict.pass_()
-
-        shadow_sb_a._edictum_id = "shadow-sb-a"
-        shadow_sb_a._edictum_type = "sandbox"
-        shadow_sb_a._edictum_tools = ["*"]
-        _make_shadow(shadow_sb_a)
+    def test_observe_sandbox_contracts_merged(self):
+        """Observe-mode sandbox contracts from both guards appear in merged guard."""
 
         @precondition("*")
-        def shadow_sb_b(envelope):
+        def observe_sb_a(envelope):
             return Verdict.pass_()
 
-        shadow_sb_b._edictum_id = "shadow-sb-b"
-        shadow_sb_b._edictum_type = "sandbox"
-        shadow_sb_b._edictum_tools = ["*"]
-        _make_shadow(shadow_sb_b)
+        observe_sb_a._edictum_id = "observe-sb-a"
+        observe_sb_a._edictum_type = "sandbox"
+        observe_sb_a._edictum_tools = ["*"]
+        _make_observe(observe_sb_a)
 
-        g1 = Edictum(mode="enforce", contracts=[shadow_sb_a], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow_sb_b], audit_sink=_NullSink())
+        @precondition("*")
+        def observe_sb_b(envelope):
+            return Verdict.pass_()
+
+        observe_sb_b._edictum_id = "observe-sb-b"
+        observe_sb_b._edictum_type = "sandbox"
+        observe_sb_b._edictum_tools = ["*"]
+        _make_observe(observe_sb_b)
+
+        g1 = Edictum(mode="enforce", contracts=[observe_sb_a], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe_sb_b], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 
         ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_sandbox_contracts]
         assert len(ids) == 2
-        assert "shadow-sb-a" in ids
-        assert "shadow-sb-b" in ids
+        assert "observe-sb-a" in ids
+        assert "observe-sb-b" in ids
 
-    def test_cross_type_id_collision_does_not_drop_shadow(self):
-        """A shadow contract with the same ID as a regular contract must NOT be dropped."""
+    def test_cross_type_id_collision_does_not_drop_observe(self):
+        """An observe-mode contract with the same ID as a regular contract must NOT be dropped."""
 
         @precondition("Bash")
         def enforced(envelope):
@@ -193,14 +193,14 @@ class TestFromMultipleShadowContracts:
         enforced._edictum_id = "shared-id"
 
         @precondition("Bash")
-        def shadow(envelope):
-            return Verdict.fail("Shadow")
+        def observe(envelope):
+            return Verdict.fail("Observe-mode")
 
-        shadow._edictum_id = "shared-id"
-        _make_shadow(shadow)
+        observe._edictum_id = "shared-id"
+        _make_observe(observe)
 
         g1 = Edictum(mode="enforce", contracts=[enforced], audit_sink=_NullSink())
-        g2 = Edictum(mode="enforce", contracts=[shadow], audit_sink=_NullSink())
+        g2 = Edictum(mode="enforce", contracts=[observe], audit_sink=_NullSink())
 
         merged = Edictum.from_multiple([g1, g2])
 

--- a/tests/test_behavior/test_guard_behavior.py
+++ b/tests/test_behavior/test_guard_behavior.py
@@ -1,7 +1,7 @@
 """Behavior tests for Edictum._guard reload() observe-mode handling.
 
-Covers bug #80: reload() did not reset observe-mode (shadow) contract lists,
-leaving stale shadow contracts from the previous bundle.
+Covers bug #80: reload() did not reset observe-mode contract lists,
+leaving stale observe-mode contracts from the previous bundle.
 """
 
 from __future__ import annotations
@@ -57,8 +57,8 @@ def _envelope(tool: str = "test_tool", **args) -> ToolEnvelope:
     return ToolEnvelope(tool_name=tool, args=args)
 
 
-def _make_shadow_precondition(contract_id: str) -> object:
-    """Create a minimal shadow precondition callable with edictum metadata."""
+def _make_observe_precondition(contract_id: str) -> object:
+    """Create a minimal observe-mode precondition callable with edictum metadata."""
 
     def fn(envelope: ToolEnvelope) -> Verdict:
         return Verdict.pass_()
@@ -75,8 +75,8 @@ def _make_shadow_precondition(contract_id: str) -> object:
     return fn
 
 
-def _make_shadow_postcondition(contract_id: str) -> object:
-    """Create a minimal shadow postcondition callable with edictum metadata."""
+def _make_observe_postcondition(contract_id: str) -> object:
+    """Create a minimal observe-mode postcondition callable with edictum metadata."""
 
     def fn(envelope: ToolEnvelope, response) -> Verdict:
         return Verdict.pass_()
@@ -93,8 +93,8 @@ def _make_shadow_postcondition(contract_id: str) -> object:
     return fn
 
 
-def _make_shadow_session_contract(contract_id: str) -> object:
-    """Create a minimal shadow session contract callable with edictum metadata."""
+def _make_observe_session_contract(contract_id: str) -> object:
+    """Create a minimal observe-mode session contract callable with edictum metadata."""
 
     async def fn(session) -> Verdict:
         return Verdict.pass_()
@@ -108,8 +108,8 @@ def _make_shadow_session_contract(contract_id: str) -> object:
     return fn
 
 
-def _make_shadow_sandbox(contract_id: str) -> object:
-    """Create a minimal shadow sandbox callable with edictum metadata."""
+def _make_observe_sandbox(contract_id: str) -> object:
+    """Create a minimal observe-mode sandbox callable with edictum metadata."""
 
     def fn(envelope: ToolEnvelope) -> Verdict:
         return Verdict.pass_()
@@ -126,16 +126,16 @@ def _make_shadow_sandbox(contract_id: str) -> object:
 
 
 @pytest.mark.asyncio
-async def test_reload_clears_stale_shadow_preconditions():
-    """Shadow preconditions from the previous bundle must not survive reload()."""
+async def test_reload_clears_stale_observe_preconditions():
+    """Observe-mode preconditions from the previous bundle must not survive reload()."""
     guard = Edictum.from_yaml_string(_BUNDLE_A)
     env = _envelope()
 
     # Inject observe-mode preconditions as if set by the composer/server
-    shadow = _make_shadow_precondition("old-shadow-pre")
+    observe = _make_observe_precondition("old-observe-pre")
     guard._state = replace(
         guard._state,
-        shadow_preconditions=guard._state.shadow_preconditions + (shadow,),
+        shadow_preconditions=guard._state.shadow_preconditions + (observe,),
     )
     assert len(guard.get_shadow_preconditions(env)) == 1
 
@@ -145,15 +145,15 @@ async def test_reload_clears_stale_shadow_preconditions():
 
 
 @pytest.mark.asyncio
-async def test_reload_clears_stale_shadow_postconditions():
-    """Shadow postconditions from the previous bundle must not survive reload()."""
+async def test_reload_clears_stale_observe_postconditions():
+    """Observe-mode postconditions from the previous bundle must not survive reload()."""
     guard = Edictum.from_yaml_string(_BUNDLE_A)
     env = _envelope()
 
-    shadow = _make_shadow_postcondition("old-shadow-post")
+    observe = _make_observe_postcondition("old-observe-post")
     guard._state = replace(
         guard._state,
-        shadow_postconditions=guard._state.shadow_postconditions + (shadow,),
+        shadow_postconditions=guard._state.shadow_postconditions + (observe,),
     )
     assert len(guard.get_shadow_postconditions(env)) == 1
 
@@ -163,14 +163,14 @@ async def test_reload_clears_stale_shadow_postconditions():
 
 
 @pytest.mark.asyncio
-async def test_reload_clears_stale_shadow_session_contracts():
-    """Shadow session contracts from the previous bundle must not survive reload()."""
+async def test_reload_clears_stale_observe_session_contracts():
+    """Observe-mode session contracts from the previous bundle must not survive reload()."""
     guard = Edictum.from_yaml_string(_BUNDLE_A)
 
-    shadow = _make_shadow_session_contract("old-shadow-session")
+    observe = _make_observe_session_contract("old-observe-session")
     guard._state = replace(
         guard._state,
-        shadow_session_contracts=guard._state.shadow_session_contracts + (shadow,),
+        shadow_session_contracts=guard._state.shadow_session_contracts + (observe,),
     )
     assert len(guard.get_shadow_session_contracts()) == 1
 
@@ -180,15 +180,15 @@ async def test_reload_clears_stale_shadow_session_contracts():
 
 
 @pytest.mark.asyncio
-async def test_reload_clears_stale_shadow_sandbox_contracts():
-    """Shadow sandbox contracts from the previous bundle must not survive reload()."""
+async def test_reload_clears_stale_observe_sandbox_contracts():
+    """Observe-mode sandbox contracts from the previous bundle must not survive reload()."""
     guard = Edictum.from_yaml_string(_BUNDLE_A)
     env = _envelope()
 
-    shadow = _make_shadow_sandbox("old-shadow-sandbox")
+    observe = _make_observe_sandbox("old-observe-sandbox")
     guard._state = replace(
         guard._state,
-        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (shadow,),
+        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (observe,),
     )
     assert len(guard.get_shadow_sandbox_contracts(env)) == 1
 
@@ -198,18 +198,18 @@ async def test_reload_clears_stale_shadow_sandbox_contracts():
 
 
 @pytest.mark.asyncio
-async def test_reload_clears_all_four_shadow_lists_simultaneously():
-    """All four shadow lists must be cleared in a single reload() call."""
+async def test_reload_clears_all_four_observe_lists_simultaneously():
+    """All four observe-mode lists must be cleared in a single reload() call."""
     guard = Edictum.from_yaml_string(_BUNDLE_A)
     env = _envelope()
 
     # Populate all four observe-mode lists via frozen state replacement
     guard._state = replace(
         guard._state,
-        shadow_preconditions=guard._state.shadow_preconditions + (_make_shadow_precondition("sp"),),
-        shadow_postconditions=guard._state.shadow_postconditions + (_make_shadow_postcondition("spo"),),
-        shadow_session_contracts=guard._state.shadow_session_contracts + (_make_shadow_session_contract("ss"),),
-        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (_make_shadow_sandbox("ssb"),),
+        shadow_preconditions=guard._state.shadow_preconditions + (_make_observe_precondition("sp"),),
+        shadow_postconditions=guard._state.shadow_postconditions + (_make_observe_postcondition("spo"),),
+        shadow_session_contracts=guard._state.shadow_session_contracts + (_make_observe_session_contract("ss"),),
+        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (_make_observe_sandbox("ssb"),),
     )
 
     assert len(guard.get_shadow_preconditions(env)) == 1

--- a/tests/test_from_yaml_multi.py
+++ b/tests/test_from_yaml_multi.py
@@ -209,35 +209,35 @@ class TestThreePaths:
 
 
 class TestObserveAlongside:
-    """Load a YAML with observe_alongside: true, verify shadow contracts."""
+    """Load a YAML with observe_alongside: true, verify observe-mode contracts."""
 
-    def test_shadow_contracts_created(self, tmp_path):
+    def test_observe_contracts_created(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)
         candidate = _write_yaml(tmp_path, "candidate.yaml", OBSERVE_ALONGSIDE_BUNDLE)
         guard, report = Edictum.from_yaml(base, candidate, return_report=True)
 
-        # Shadow contract should be in the report
+        # Observe-mode contract should be in the report
         assert len(report.shadow_contracts) == 1
         assert report.shadow_contracts[0].contract_id == "block-sensitive-reads"
 
-    def test_shadow_contracts_in_observe_mode(self, tmp_path):
+    def test_observe_contracts_in_observe_mode(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)
         candidate = _write_yaml(tmp_path, "candidate.yaml", OBSERVE_ALONGSIDE_BUNDLE)
         guard = Edictum.from_yaml(base, candidate)
 
-        # Original contract still works — .env denied
+        # Original contract still works -- .env denied
         result = guard.evaluate("read_file", {"path": "app.env"})
         assert result.verdict == "deny"
 
-        # Shadow contracts are routed to separate lists
+        # Observe-mode contracts are routed to separate lists
         env = create_envelope("read_file", {"path": "test.key"})
         preconditions = guard.get_preconditions(env)
-        shadow_preconditions = guard.get_shadow_preconditions(env)
+        observe_preconditions = guard.get_shadow_preconditions(env)
         # Original precondition in main list
         assert len(preconditions) == 1
-        # Shadow :candidate in shadow list
-        assert len(shadow_preconditions) == 1
-        assert getattr(shadow_preconditions[0], "_edictum_shadow", False) is True
+        # Observe-mode :candidate in observe list
+        assert len(observe_preconditions) == 1
+        assert getattr(observe_preconditions[0], "_edictum_shadow", False) is True
 
 
 class TestReturnReport:
@@ -320,15 +320,15 @@ class TestEdgeCases:
             Edictum.from_yaml(base, tmp_path / "nonexistent.yaml")
 
 
-class TestEvaluateDryRunExcludesShadow:
-    """evaluate() must NOT include shadow contracts in dry-run results."""
+class TestEvaluateDryRunExcludesObserveMode:
+    """evaluate() must NOT include observe-mode contracts in dry-run results."""
 
-    def test_evaluate_ignores_shadow_contracts(self, tmp_path):
+    def test_evaluate_ignores_observe_contracts(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)
         candidate = _write_yaml(tmp_path, "candidate.yaml", OBSERVE_ALONGSIDE_BUNDLE)
         guard = Edictum.from_yaml(base, candidate)
 
-        # .key triggers shadow but not enforced. evaluate() should allow.
+        # .key triggers observe-mode but not enforced. evaluate() should allow.
         result = guard.evaluate("read_file", {"path": "app.key"})
         assert result.verdict == "allow"
 
@@ -336,13 +336,13 @@ class TestEvaluateDryRunExcludesShadow:
         result = guard.evaluate("read_file", {"path": "app.env"})
         assert result.verdict == "deny"
 
-    def test_evaluate_does_not_report_shadow_contracts(self, tmp_path):
+    def test_evaluate_does_not_report_observe_contracts(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)
         candidate = _write_yaml(tmp_path, "candidate.yaml", OBSERVE_ALONGSIDE_BUNDLE)
         guard = Edictum.from_yaml(base, candidate)
 
         result = guard.evaluate("read_file", {"path": "app.key"})
-        # Shadow contracts should not appear in contracts_evaluated
+        # Observe-mode contracts should not appear in contracts_evaluated
         contract_ids = [r.contract_id for r in result.contracts]
         assert not any(":candidate" in cid for cid in contract_ids)
 

--- a/tests/test_observe_alongside.py
+++ b/tests/test_observe_alongside.py
@@ -53,7 +53,7 @@ contracts:
     then:
       effect: deny
       message: "Denied read of .secret file"
-  - id: new-shadow-only
+  - id: new-observe-only
     type: pre
     tool: "*"
     when:
@@ -95,15 +95,15 @@ def _write_bundles(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-class TestShadowAuditEvents:
-    """Shadow evaluation produces separate audit events with mode='observe'."""
+class TestObserveModeAuditEvents:
+    """Observe-mode evaluation produces separate audit events with mode='observe'."""
 
-    async def test_shadow_produces_observe_audit_events(self, tmp_path):
+    async def test_observe_mode_produces_audit_events(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
 
-        # read_file with .secret triggers the shadow contract but not the enforced one
+        # read_file with .secret triggers the observe-mode contract but not the enforced one
         result = await guard.run(
             "read_file",
             {"path": "/home/config.secret"},
@@ -111,20 +111,20 @@ class TestShadowAuditEvents:
         )
         assert result == "contents of /home/config.secret"
 
-        # Check for shadow audit events with mode="observe"
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        assert len(shadow_events) >= 1
+        # Check for observe-mode audit events with mode="observe"
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        assert len(observe_events) >= 1
 
-        # The shadow denial should have CALL_WOULD_DENY
-        shadow_deny = [e for e in shadow_events if e.action == AuditAction.CALL_WOULD_DENY]
-        assert len(shadow_deny) >= 1
-        assert "block-env-reads:candidate" in shadow_deny[0].decision_name
+        # The observe-mode denial should have CALL_WOULD_DENY
+        observe_deny = [e for e in observe_events if e.action == AuditAction.CALL_WOULD_DENY]
+        assert len(observe_deny) >= 1
+        assert "block-env-reads:candidate" in observe_deny[0].decision_name
 
 
-class TestShadowDoesNotBlockRealCalls:
-    """Shadow contracts don't block real calls — PreDecision still allows."""
+class TestObserveModeDoesNotBlockRealCalls:
+    """Observe-mode contracts don't block real calls -- PreDecision still allows."""
 
-    async def test_shadow_deny_does_not_block(self, tmp_path):
+    async def test_observe_deny_does_not_block(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
@@ -151,16 +151,16 @@ class TestShadowDoesNotBlockRealCalls:
             )
 
 
-class TestShadowSessionContracts:
-    """Shadow session contracts track counters independently."""
+class TestObserveModeSessionContracts:
+    """Observe-mode session contracts track counters independently."""
 
-    async def test_shadow_session_evaluates_against_real_counters(self, tmp_path):
+    async def test_observe_session_evaluates_against_real_counters(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
 
         # The candidate has max_tool_calls=5, enforced has 100
-        # After 5 calls, the shadow session contract should report would-deny
+        # After 5 calls, the observe-mode session contract should report would-deny
         # but the real session should still allow
         for _ in range(6):
             await guard.run(
@@ -170,69 +170,69 @@ class TestShadowSessionContracts:
             )
 
         # All calls should succeed (enforced limit is 100)
-        # But we should see shadow audit events after the 5th call
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        # Shadow session contract events should appear
-        assert len(shadow_events) > 0
+        # But we should see observe-mode audit events after the 5th call
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        # Observe-mode session contract events should appear
+        assert len(observe_events) > 0
 
 
-class TestShadowWithoutEnforcedCounterpart:
-    """observe_alongside with new contract ID (no enforced counterpart) — shadow still evaluates."""
+class TestObserveModeWithoutEnforcedCounterpart:
+    """observe_alongside with new contract ID (no enforced counterpart) -- observe-mode still evaluates."""
 
-    async def test_new_shadow_only_contract(self, tmp_path):
+    async def test_new_observe_only_contract(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
 
-        # new-shadow-only:candidate should trigger for rm -rf
+        # new-observe-only:candidate should trigger for rm -rf
         result = await guard.run(
             "bash",
             {"cmd": "rm -rf /"},
             lambda cmd: "done",
         )
-        assert result == "done"  # Not denied — shadow only
+        assert result == "done"  # Not denied -- observe-mode only
 
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        shadow_deny = [e for e in shadow_events if e.action == AuditAction.CALL_WOULD_DENY]
-        rm_events = [e for e in shadow_deny if "new-shadow-only:candidate" in (e.decision_name or "")]
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        observe_deny = [e for e in observe_events if e.action == AuditAction.CALL_WOULD_DENY]
+        rm_events = [e for e in observe_deny if "new-observe-only:candidate" in (e.decision_name or "")]
         assert len(rm_events) >= 1
 
 
-class TestShadowAuditActions:
-    """Shadow audit events use CALL_WOULD_DENY / CALL_ALLOWED actions."""
+class TestObserveModeAuditActions:
+    """Observe-mode audit events use CALL_WOULD_DENY / CALL_ALLOWED actions."""
 
-    async def test_shadow_pass_uses_call_allowed(self, tmp_path):
+    async def test_observe_pass_uses_call_allowed(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
 
-        # A call that passes both enforced and shadow
+        # A call that passes both enforced and observe-mode
         await guard.run(
             "some_tool",
             {"data": "safe"},
             lambda data: "ok",
         )
 
-        # Shadow events that pass should use CALL_ALLOWED
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        # The new-shadow-only contract matches tool="*" but only triggers on rm -rf
-        # So it should pass and produce a CALL_ALLOWED shadow event
-        assert any(e.action == AuditAction.CALL_ALLOWED for e in shadow_events)
+        # Observe-mode events that pass should use CALL_ALLOWED
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        # The new-observe-only contract matches tool="*" but only triggers on rm -rf
+        # So it should pass and produce a CALL_ALLOWED observe-mode event
+        assert any(e.action == AuditAction.CALL_ALLOWED for e in observe_events)
 
-    async def test_shadow_fail_uses_call_would_deny(self, tmp_path):
+    async def test_observe_fail_uses_call_would_deny(self, tmp_path):
         enforced_path, candidate_path = _write_bundles(tmp_path)
         sink = _CaptureSink()
         guard = Edictum.from_yaml(enforced_path, candidate_path, audit_sink=sink)
 
-        # Trigger the shadow but not the enforced
+        # Trigger the observe-mode contract but not the enforced
         await guard.run(
             "read_file",
             {"path": "/home/app.secret"},
             lambda path: "data",
         )
 
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        assert any(e.action == AuditAction.CALL_WOULD_DENY for e in shadow_events)
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        assert any(e.action == AuditAction.CALL_WOULD_DENY for e in observe_events)
 
 
 class TestNormalContractsRegression:
@@ -264,11 +264,11 @@ class TestNormalContractsRegression:
         )
         assert result == "contents of /home/readme.md"
 
-        # No shadow events when there's no candidate bundle
-        shadow_events = [e for e in sink.events if e.mode == "observe"]
-        assert len(shadow_events) == 0
+        # No observe-mode events when there's no candidate bundle
+        observe_events = [e for e in sink.events if e.mode == "observe"]
+        assert len(observe_events) == 0
 
-    async def test_no_shadow_lists_without_candidate(self, tmp_path):
+    async def test_no_observe_lists_without_candidate(self, tmp_path):
         enforced_path = tmp_path / "enforced.yaml"
         enforced_path.write_text(ENFORCED_BUNDLE)
         guard = Edictum.from_yaml(enforced_path)

--- a/tests/test_yaml_engine/test_composer.py
+++ b/tests/test_yaml_engine/test_composer.py
@@ -14,6 +14,7 @@ from edictum.yaml_engine.composer import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _base_bundle(**overrides) -> dict:
     """Minimal valid bundle dict."""
     b = {
@@ -242,7 +243,7 @@ class TestObservabilityMerge:
 
 
 class TestObserveAlongside:
-    def test_shadow_contracts_added_with_candidate_suffix(self):
+    def test_observe_contracts_added_with_candidate_suffix(self):
         base = _base_bundle(contracts=[_contract("pharma")])
         candidate = _base_bundle(contracts=[_contract("pharma")])
         candidate["observe_alongside"] = True
@@ -253,17 +254,18 @@ class TestObserveAlongside:
         assert "pharma:candidate" in ids
         assert len(ids) == 2
 
-    def test_shadow_contract_forced_to_observe_mode(self):
+    def test_observe_contract_forced_to_observe_mode(self):
         base = _base_bundle(contracts=[_contract("pharma")])
         candidate = _base_bundle(contracts=[_contract("pharma")])
         candidate["observe_alongside"] = True
 
         result = compose_bundles((base, "base"), (candidate, "candidate"))
-        shadow = [c for c in result.bundle["contracts"] if c["id"] == "pharma:candidate"][0]
-        assert shadow["mode"] == "observe"
-        assert shadow["_shadow"] is True
+        # Internal _shadow field stays as-is (internal attribute)
+        observe = [c for c in result.bundle["contracts"] if c["id"] == "pharma:candidate"][0]
+        assert observe["mode"] == "observe"
+        assert observe["_shadow"] is True
 
-    def test_shadow_contract_report(self):
+    def test_observe_contract_report(self):
         base = _base_bundle(contracts=[_contract("pharma")])
         candidate = _base_bundle(contracts=[_contract("pharma")])
         candidate["observe_alongside"] = True
@@ -375,7 +377,7 @@ class TestComposerEdgeCases:
         assert ids == ["new-rule"]
 
     def test_observe_alongside_with_empty_contracts(self):
-        """observe_alongside bundle with no contracts — no shadows, no crash."""
+        """observe_alongside bundle with no contracts -- no observe-mode contracts, no crash."""
         base = _base_bundle(contracts=[_contract("a")])
         candidate = _base_bundle(contracts=[])
         candidate["observe_alongside"] = True


### PR DESCRIPTION
## Summary

- Harden `check-terminology.py` pre-commit hook to catch standalone `shadow` with a smart allowlist for internal field names (`_edictum_shadow`, `shadow_preconditions`, `get_shadow_*`, `/etc/shadow`, etc.)
- Fix all 96 violations across `src/`, `tests/`, and `CHANGELOG.md`
- Internal attribute/field names unchanged — only prose (comments, docstrings, strings, variable names, test names) updated

### Files changed (12)
- `scripts/check-terminology.py` — new `SHADOW_PATTERN` + `SHADOW_ALLOWLIST`
- `src/edictum/pipeline.py` — 11 comments/strings/logger messages
- `src/edictum/_guard.py`, `composer.py`, `cli/main.py` — 5 comments/strings
- 6 test files — class names, method names, variables, docstrings, contract IDs
- `CHANGELOG.md` — 3 release note entries

## Test plan

- [x] `check-terminology.py` reports 0 violations (was 96)
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ -v` — 2134 passed, 3 skipped
- [x] Pre-commit hooks pass (ruff, ruff-format, check-terminology)