### PR TITLE
test: add missing tool_name validation tests

### DIFF
--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -218,6 +218,22 @@ class TestToolNameValidation:
         with pytest.raises(ValueError, match="Invalid tool_name"):
             create_envelope("path/to/tool", {})
 
+    def test_tool_name_with_backslash_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("path\\to\\tool", {})
+
+    def test_tool_name_with_carriage_return_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil\rtool", {})
+
+    def test_tool_name_with_tab_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil\ttool", {})
+
+    def test_tool_name_with_delete_char_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            create_envelope("evil\x7ftool", {})
+
     def test_tool_name_empty_string_rejected(self):
         with pytest.raises(ValueError, match="Invalid tool_name"):
             create_envelope("", {})


### PR DESCRIPTION
## Summary
- Both #85 (backslash not rejected) and #99 (control chars \r, \t, \x7f not rejected) are **already fixed** in `_validate_tool_name()` — the validation at `envelope.py:64` correctly rejects all ASCII control characters and backslash
- The `test_envelope_behavior.py` tests cover these via `ToolEnvelope` direct construction, but `TestToolNameValidation` in `test_envelope.py` was missing explicit `create_envelope()` tests for backslash, `\r`, `\t`, and `\x7f`
- Adds 4 new tests to close the gap

## Test plan
- [x] All 2166 tests pass, 0 failures
- [x] Ruff lint clean
- [x] Manual verification: `create_envelope()` rejects `\r`, `\t`, `\x7f`, and `\` as expected

Closes #85
Closes #99