### PR TITLE
fix(server): handle 405 in batch_get fallback

### DIFF
--- a/src/edictum/server/backend.py
+++ b/src/edictum/server/backend.py
@@ -60,9 +60,10 @@ class ServerBackend:
         """Retrieve multiple session values in a single HTTP call.
 
         Falls back to individual get() calls if the server returns 404
-        (endpoint not available on older servers).
+        or 405 (endpoint not available on older servers, or route pattern
+        matches a catch-all that doesn't support POST).
 
-        Fail-closed: non-404 errors propagate so the pipeline denies
+        Fail-closed: other errors propagate so the pipeline denies
         rather than silently allowing with missing data.
         """
         if not keys:


### PR DESCRIPTION
## Summary
- `ServerBackend.batch_get()` now falls back to individual GET calls on both 404 **and** 405
- Fixes compatibility with console servers that don't have `POST /sessions/batch` yet

## Root cause
PR #115 added `batch_get` calling `POST /api/v1/sessions/batch`. The fallback was 404-only, but FastAPI-based servers return **405** when the `/{key}` catch-all matches `key="batch"` (which only allows GET/PUT/DELETE). This broke all 6 adapter demos against the live console.

## Test plan
- [ ] Run adapter demos with `--console` against a server without `/sessions/batch` — should silently fall back to individual GETs
- [ ] Run adapter demos against a server **with** `/sessions/batch` (edictum-console#52) — should use batch endpoint