### PR TITLE
fix(ci): harden review workflow — gate, exhaustive pass, auto-issues

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,7 +7,9 @@ on:
 
 concurrency:
   group: review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Fixes #130: don't kill mid-flight reviews on re-push.
+  # The last run to complete wins the sticky comment.
+  cancel-in-progress: false
 
 jobs:
   review:
@@ -17,7 +19,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write  # Fixes #135: auto-create issues for warnings
 
     steps:
       - name: Checkout repository
@@ -57,6 +59,12 @@ jobs:
       - name: Install review tools (NOT the project)
         run: pip install ruff
 
+      - name: Ensure review label exists
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh label create "review" --color "d4c5f9" --description "Auto-created by code review workflow" 2>/dev/null || true
+
       - name: Run Code Review
         id: review
         uses: anthropics/claude-code-action@9469d113c6afd29550c402740f22d1a97dd1209b # v1
@@ -64,7 +72,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           model: claude-sonnet-4-6
-          claude_args: '--max-turns 30 --allowedTools "Bash(git diff:*),Bash(git log:*),Bash(gh pr comment:*),Bash(gh api:*),Bash(cat:*),Bash(ruff:*),Read,Glob,Grep,Write"'
+          # SECURITY: Claude writes /tmp/review.md only — no direct comment posting (#128).
+          # gh issue create/list added for auto-issue creation on warnings (#135).
+          claude_args: '--max-turns 30 --allowedTools "Bash(git diff:*),Bash(git log:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(cat:*),Bash(ruff:*),Read,Glob,Grep,Write"'
           prompt: |
             You are an adversarial code reviewer for Edictum — a **security product** (runtime contract enforcement for AI agent tool calls). A single vulnerability destroys the credibility of a startup that sells trust. Think like an attacker first, reviewer second.
 
@@ -80,9 +90,10 @@ jobs:
                - `/tmp/governance/review-instructions.md` — comment formatting rules
                - `/tmp/governance/review-template.md` — the template to fill in
 
-            2. Get the diff:
+            2. Get the FULL diff against main — review ALL accumulated changes across ALL commits in this PR, not just the latest push:
                - `git diff origin/main...HEAD --name-only` for changed files
                - `git diff origin/main...HEAD` for full diff
+               - `git log origin/main...HEAD --oneline` for commit history
 
             3. Route checks by file type:
                - `src/edictum/**` → code quality, tier boundary, contract correctness, API design, security, agentic engineering
@@ -104,12 +115,27 @@ jobs:
                - It's NOT something ruff would catch
                - Include a concrete fix with code, not just "consider doing X"
 
-            6. Fill in the template from `/tmp/governance/review-template.md` per `/tmp/governance/review-instructions.md`. Write to `/tmp/review.md`.
+            6. **Severity classification** — assign carefully, the CI gate depends on this:
+               - **Critical** (STATUS: fail, blocks merge): injection, fail-open, data corruption, secrets leaking, deny bypass, tier boundary violation — concrete exploitable attack path
+               - **Warning** (STATUS: warn, does NOT block merge): defense-in-depth gaps, missing tests, terminology violations, docs-code drift, adapter parity gaps — real findings without an immediate exploitable path
+               - **Suggestion**: naming, file size, minor improvements
+               Use `fail` ONLY for issues with a concrete, exploitable attack path. Warnings are tracked as GitHub issues automatically.
 
-            7. Post inline review comments on specific lines:
+            7. **Be exhaustive in ONE pass.** Find ALL issues in this single review — 5, 10, 20, however many exist. Do NOT stop at 2-3 and wait for another round. There will be no second pass. Use this checklist to ensure completeness:
+               - [ ] Input validation on every trust boundary (user input, external data, storage keys)
+               - [ ] Defensive copies where shared mutable state crosses function boundaries
+               - [ ] Filter predicates match the documented behavior (off-by-one, negation errors)
+               - [ ] Every resource opened is closed on every exit path (spans, clients, files)
+               - [ ] Every exception handler fails closed, not open
+               - [ ] Audit events accurately reflect what happened
+               Batch same-class findings (e.g., "5 instances of missing input validation" with all locations).
+
+            8. Fill in the template from `/tmp/governance/review-template.md` per `/tmp/governance/review-instructions.md`. Write to `/tmp/review.md`.
+
+            9. Write inline review comments to `/tmp/review-payload.json` (the workflow will post them):
                - For each finding, note the exact file path and line number in the HEAD commit
-               - ONLY include comments for lines that appear in the diff (added or modified lines). Lines outside the diff will cause the API call to fail.
-               - Write the review payload to `/tmp/review-payload.json`:
+               - ONLY include comments for lines that appear in the diff (added or modified lines)
+               - Format:
                  ```json
                  {
                    "commit_id": "${{ github.event.pull_request.head.sha }}",
@@ -119,23 +145,86 @@ jobs:
                      {
                        "path": "src/edictum/example.py",
                        "line": 42,
-                       "body": "🔴 **Critical:** Description of the issue.\n\n**Attack path:** An attacker could...\n\n**Fix:**\n```python\ncode fix here\n```"
+                       "body": "🔴 **Critical:** Description.\n\n**Attack path:** ...\n\n**Fix:**\n```python\ncode\n```"
                      }
                    ]
                  }
                  ```
-               - Post it: `gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --input /tmp/review-payload.json`
-               - If there are ZERO findings, skip this step entirely — do not create an empty review.
-               - If the API call fails (e.g., a line wasn't in the diff), fall back to the summary comment only.
+               - If there are ZERO findings, do NOT create the file.
 
-            8. Post the sticky summary comment (authoritative record of all findings):
-               - Check for existing: `gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --jq '.[] | select(.body | contains("<!-- edictum-review -->")) | .id'`
-               - If found, update: `gh api "repos/${{ github.repository }}/issues/comments/COMMENT_ID" -X PATCH -f body=@/tmp/review.md`
-               - If not found, create: `gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review.md`
+            10. **Auto-create issues for warnings** (only when STATUS is `warn`):
+                For each warning-level finding, create a tracking issue unless one already exists:
+                ```
+                gh issue list --search "review: <short description>" --state open --limit 1
+                # Only create if no existing match:
+                gh issue create --title "review: <short description>" --body "<details with file, line, fix>" --label "review"
+                ```
+                This ensures warnings are tracked without blocking merge.
 
             ## Rules
-            - One pass. If the PR is clean, say so and stop. Do NOT re-scan looking for nitpicks.
+            - One exhaustive pass. Find ALL issues, then stop. Do NOT re-scan looking for nitpicks.
             - A clean PR with zero findings is a good outcome — don't manufacture findings to justify the review.
             - Do NOT flag style/formatting (linters handle that)
             - ALWAYS include the attack path for security issues: "An attacker could... by..."
             - ALWAYS include file path + line number + concrete fix with code
+            - Do NOT post comments directly — write to /tmp/review.md and /tmp/review-payload.json only. The workflow will post them.
+
+      # SECURITY: Validate review file before posting (#128).
+      # Prevents corrupt/garbage output from overwriting a good review.
+      - name: Validate review output
+        id: validate
+        run: |
+          if [ ! -f /tmp/review.md ]; then
+            echo "::warning::Review file not found — Claude may have exhausted turns"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! head -1 /tmp/review.md | grep -q '<!-- edictum-review -->'; then
+            echo "::warning::Review file missing edictum-review marker — corrupt output"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+
+      # Post review from validated file — Claude cannot post directly (#128).
+      # Reads local file, immune to comment injection race condition.
+      - name: Post review comment
+        if: steps.validate.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          EXISTING_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("<!-- edictum-review -->"))] | last | .id // empty')
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_ID}" \
+              -X PATCH -f body=@/tmp/review.md
+          else
+            gh pr comment "${PR_NUMBER}" --body-file /tmp/review.md
+          fi
+
+      # Post inline comments if Claude produced them.
+      - name: Post inline comments
+        if: steps.validate.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -f /tmp/review-payload.json ]; then
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --input /tmp/review-payload.json || echo "::warning::Inline comments failed — some lines may not be in the diff"
+          fi
+
+      # CI gate: fail on critical findings (#125).
+      # Reads local /tmp/review.md, NOT the API — immune to comment injection (#128).
+      # Only STATUS: fail blocks; warn/pass do not (#135).
+      - name: Fail on critical findings
+        run: |
+          if [ ! -f /tmp/review.md ]; then
+            echo "::warning::No review file — skipping gate"
+            exit 0
+          fi
+          if grep -q '<!-- STATUS: fail -->' /tmp/review.md; then
+            echo "::error::Code review found critical issues. See PR comment for details."
+            exit 1
+          fi
+          echo "Code review passed."


### PR DESCRIPTION
## Summary

Fixes #125, #128, #130, #135 — four interrelated review workflow issues.

### Changes

- **CI gate** (#125): New step reads `/tmp/review.md` locally and exits 1 on `<!-- STATUS: fail -->`. Only critical findings block merge.
- **Comment injection prevention** (#128): Removed `gh pr comment` and `gh api` from Claude's allowed tools. Claude writes `/tmp/review.md` only. Workflow validates the file (edictum-review marker check) before posting. Gate reads the local file, not the API — immune to attacker-injected comments.
- **No cancel-in-progress** (#130): Set `cancel-in-progress: false` so mid-flight reviews survive re-push. Prompt explicitly instructs full-diff review (`git diff origin/main...HEAD` across ALL commits) with an exhaustive single-pass checklist.
- **Warn vs fail separation** (#135): Only `STATUS: fail` blocks CI. Warnings auto-create GitHub issues via `gh issue create` (with dedup). Classification guidance in prompt: `fail` = concrete exploitable attack path only.

### Security model

```
Claude (sandboxed)          Workflow (trusted)
─────────────────           ──────────────────
writes /tmp/review.md  →    validates marker
writes /tmp/review-payload  →    posts if valid
gh issue create        →    (direct, for warnings only)
                            reads local file for gate
                            (never re-fetches from API)
```

## Test plan

- [ ] Open a PR with a real security bug — verify `STATUS: fail` blocks CI
- [ ] Open a clean PR — verify `STATUS: pass` does not block
- [ ] Open a PR with minor issues — verify `STATUS: warn` creates issues but does not block
- [ ] Push again to an open PR — verify previous review is not cancelled
- [ ] Verify Claude cannot post comments directly (gh pr comment / gh api not in allowed tools)