### PR TITLE
fix: 7 verified bugs — security, pipeline, server SDK

### DIFF
--- a/src/edictum/approval.py
+++ b/src/edictum/approval.py
@@ -75,6 +75,9 @@ class LocalApprovalBackend:
 
     def __init__(self) -> None:
         self._pending: dict[str, ApprovalRequest] = {}
+        from edictum.audit import RedactionPolicy
+
+        self._redaction = RedactionPolicy()
 
     async def request_approval(
         self,
@@ -101,7 +104,7 @@ class LocalApprovalBackend:
         self._pending[approval_id] = request
         print(f"[APPROVAL REQUIRED] {message}")
         print(f"  Tool: {tool_name}")
-        print(f"  Args: {tool_args}")
+        print(f"  Args: {self._redaction.redact_args(tool_args)}")
         print(f"  ID:   {approval_id}")
         sys.stdout.flush()
         return request

--- a/src/edictum/audit.py
+++ b/src/edictum/audit.py
@@ -154,7 +154,10 @@ class RedactionPolicy:
 
     def _is_sensitive_key(self, key: str) -> bool:
         k = key.lower()
-        return k in self._keys or any(s in k for s in ("token", "key", "secret", "password", "credential"))
+        if k in self._keys:
+            return True
+        parts = re.split(r"[_\-]", k)
+        return any(p in ("token", "key", "secret", "password", "credential") for p in parts)
 
     def _looks_like_secret(self, value: str) -> bool:
         for pattern in self.SECRET_VALUE_PATTERNS:

--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -385,7 +385,34 @@ class GovernancePipeline:
                         f"\u26a0\ufe0f {verdict.message} Tool already executed \u2014 assess before proceeding."
                     )
 
-        # 2. After hooks (Fix 5: catch exceptions)
+        # 2. Observe-mode postconditions (from observe_alongside bundles)
+        for contract in self._guard.get_shadow_postconditions(envelope):
+            try:
+                verdict = contract(envelope, tool_response)
+                if asyncio.iscoroutine(verdict):
+                    verdict = await verdict
+            except Exception as exc:
+                logger.exception(
+                    "Observe-mode postcondition %s raised",
+                    getattr(contract, "__name__", "anonymous"),
+                )
+                verdict = Verdict.fail(f"Observe-mode postcondition error: {exc}", policy_error=True)
+
+            contract_record = {
+                "name": getattr(contract, "__name__", "anonymous"),
+                "type": "postcondition",
+                "passed": verdict.passed,
+                "message": verdict.message,
+                "observed": True,
+            }
+            if verdict.metadata:
+                contract_record["metadata"] = verdict.metadata
+            contracts_evaluated.append(contract_record)
+
+            if not verdict.passed:
+                warnings.append(f"\u26a0\ufe0f [observe] {verdict.message}")
+
+        # 3. After hooks (Fix 5: catch exceptions)
         for hook_reg in self._guard.get_hooks("after", envelope):
             if hook_reg.when and not hook_reg.when(envelope):
                 continue

--- a/src/edictum/server/audit_sink.py
+++ b/src/edictum/server/audit_sink.py
@@ -91,6 +91,8 @@ class ServerAuditSink:
 
     async def _flush(self) -> None:
         """Thread-safe flush: grab buffer under lock, send outside lock."""
+        from edictum.server.client import EdictumServerError
+
         with self._lock:
             if not self._buffer:
                 return
@@ -98,7 +100,17 @@ class ServerAuditSink:
             self._buffer.clear()
         try:
             await self._client.post("/api/v1/events", {"events": events})
-        except Exception:
+        except Exception as exc:
+            # Non-retryable client errors (4xx except 429): raise immediately.
+            # Auth errors (401/403) will never succeed on retry — surfacing them
+            # prevents silent credential failure and infinite buffer growth.
+            if isinstance(exc, EdictumServerError) and 400 <= exc.status_code < 500 and exc.status_code != 429:
+                logger.error(
+                    "Audit flush failed with non-retryable error (HTTP %d): %s",
+                    exc.status_code,
+                    exc.detail,
+                )
+                raise
             logger.warning("Failed to flush %d audit events, keeping in buffer for retry", len(events))
             self._restore_events(events)
         except BaseException:

--- a/src/edictum/server/contract_source.py
+++ b/src/edictum/server/contract_source.py
@@ -71,6 +71,11 @@ class ServerContractSource:
                     "GET",
                     "/api/v1/stream",
                     params=params,
+                    # Separate connect timeout from stream idle timeout.
+                    # The default client timeout (30s) applies to all phases —
+                    # including read, which would kill SSE streams that are idle
+                    # longer than 30s between events.
+                    timeout=httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0),
                 ) as event_source:
                     self._connected = True
                     connected_at = time.monotonic()

--- a/src/edictum/server/verification.py
+++ b/src/edictum/server/verification.py
@@ -50,6 +50,11 @@ def verify_bundle_signature(
     except ValueError as exc:
         raise BundleVerificationError(f"Invalid public key hex encoding: {exc}") from exc
 
+    if len(public_key_bytes) != 32:
+        raise BundleVerificationError(
+            f"Invalid public key length: expected 32 bytes (Ed25519), got {len(public_key_bytes)}"
+        )
+
     try:
         signature_bytes = base64.b64decode(signature_b64, validate=True)
     except Exception as exc:

--- a/src/edictum/session.py
+++ b/src/edictum/session.py
@@ -2,7 +2,21 @@
 
 from __future__ import annotations
 
+from edictum.envelope import _validate_tool_name
 from edictum.storage import StorageBackend
+
+
+def _validate_session_id(session_id: str) -> None:
+    """Validate session_id: reject empty, control chars, colons, path separators.
+
+    Colons are storage key delimiters (``s:{sid}:attempts``). Allowing them
+    in session_id enables key collision attacks.
+    """
+    if not session_id:
+        raise ValueError(f"Invalid session_id: {session_id!r}")
+    for ch in session_id:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F or ch in ("/", "\\", ":"):
+            raise ValueError(f"Invalid session_id: {session_id!r}")
 
 
 class Session:
@@ -18,6 +32,7 @@ class Session:
     """
 
     def __init__(self, session_id: str, backend: StorageBackend):
+        _validate_session_id(session_id)
         self._sid = session_id
         self._backend = backend
 
@@ -34,6 +49,7 @@ class Session:
 
     async def record_execution(self, tool_name: str, success: bool) -> None:
         """Record a tool execution. Called in PostToolUse."""
+        _validate_tool_name(tool_name)
         await self._backend.increment(f"s:{self._sid}:execs")
         await self._backend.increment(f"s:{self._sid}:tool:{tool_name}")
 
@@ -46,6 +62,7 @@ class Session:
         return int(await self._backend.get(f"s:{self._sid}:execs") or 0)
 
     async def tool_execution_count(self, tool: str) -> int:
+        _validate_tool_name(tool)
         return int(await self._backend.get(f"s:{self._sid}:tool:{tool}") or 0)
 
     async def consecutive_failures(self) -> int:
@@ -72,6 +89,7 @@ class Session:
         key_labels = ["attempts", "execs"]
 
         if include_tool is not None:
+            _validate_tool_name(include_tool)
             keys.append(f"s:{self._sid}:tool:{include_tool}")
             key_labels.append(f"tool:{include_tool}")
 

--- a/tests/test_behavior/test_approval_redaction_behavior.py
+++ b/tests/test_behavior/test_approval_redaction_behavior.py
@@ -1,0 +1,45 @@
+"""Behavior tests for LocalApprovalBackend redaction.
+
+Proves that tool_args are redacted before printing to stdout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum.approval import LocalApprovalBackend
+
+
+class TestLocalApprovalRedaction:
+    """LocalApprovalBackend must redact sensitive args in stdout output."""
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_sensitive_args_redacted_in_stdout(self, capsys):
+        """tool_args containing api_key must be redacted in stdout."""
+        backend = LocalApprovalBackend()
+        await backend.request_approval(
+            "dangerous_tool",
+            {"api_key": "sk-secret123", "query": "SELECT 1"},
+            "Approve this?",
+        )
+        captured = capsys.readouterr()
+        assert "sk-secret123" not in captured.out
+        assert "[REDACTED]" in captured.out
+        # Non-sensitive args should still be visible
+        assert "SELECT 1" in captured.out
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_password_redacted_in_stdout(self, capsys):
+        """tool_args containing password must be redacted."""
+        backend = LocalApprovalBackend()
+        await backend.request_approval(
+            "connect_db",
+            {"password": "hunter2", "host": "localhost"},
+            "Approve?",
+        )
+        captured = capsys.readouterr()
+        assert "hunter2" not in captured.out
+        assert "[REDACTED]" in captured.out
+        assert "localhost" in captured.out

--- a/tests/test_behavior/test_audit_sink_auth_behavior.py
+++ b/tests/test_behavior/test_audit_sink_auth_behavior.py
@@ -1,0 +1,99 @@
+"""Behavior tests for ServerAuditSink auth error handling.
+
+Proves that non-retryable HTTP errors (401, 403) are raised
+immediately instead of silently buffered for retry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from edictum.audit import AuditAction, AuditEvent
+from edictum.server.audit_sink import ServerAuditSink
+from edictum.server.client import EdictumServerError
+
+
+def _make_client_mock():
+    client = MagicMock()
+    client.agent_id = "test-agent"
+    client.env = "production"
+    client.bundle_name = "default"
+    return client
+
+
+def _make_event():
+    return AuditEvent(
+        tool_name="TestTool",
+        call_id="call-1",
+        action=AuditAction.CALL_ALLOWED,
+    )
+
+
+class TestAuthErrorNotBuffered:
+    """4xx client errors (except 429) must be raised, not buffered."""
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_401_raises_immediately(self):
+        """HTTP 401 is raised, not silently buffered for retry."""
+        client = _make_client_mock()
+        client.post = AsyncMock(side_effect=EdictumServerError(401, "Unauthorized"))
+        sink = ServerAuditSink(client, batch_size=100)
+
+        # Manually add event to buffer and flush — 401 must raise, not buffer
+        sink._buffer.append(sink._map_event(_make_event()))
+        with pytest.raises(EdictumServerError, match="401"):
+            await sink.flush()
+        # Buffer must NOT be restored (event is lost, not retried)
+        assert len(sink._buffer) == 0
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_403_raises_immediately(self):
+        """HTTP 403 is raised, not silently buffered for retry."""
+        client = _make_client_mock()
+        client.post = AsyncMock(side_effect=EdictumServerError(403, "Forbidden"))
+        sink = ServerAuditSink(client, batch_size=100)
+
+        sink._buffer.append(sink._map_event(_make_event()))
+        with pytest.raises(EdictumServerError, match="403"):
+            await sink.flush()
+
+    @pytest.mark.asyncio
+    async def test_429_is_buffered_for_retry(self):
+        """HTTP 429 (rate limit) should be buffered for retry, not raised."""
+        client = _make_client_mock()
+        client.post = AsyncMock(side_effect=EdictumServerError(429, "Too Many Requests"))
+        sink = ServerAuditSink(client, batch_size=100)
+
+        event_payload = sink._map_event(_make_event())
+        sink._buffer.append(event_payload)
+        # Should not raise — events buffered for retry
+        await sink.flush()
+        assert len(sink._buffer) == 1  # Event restored to buffer
+
+    @pytest.mark.asyncio
+    async def test_500_is_buffered_for_retry(self):
+        """HTTP 500 should be buffered for retry."""
+        client = _make_client_mock()
+        client.post = AsyncMock(side_effect=EdictumServerError(500, "Internal Server Error"))
+        sink = ServerAuditSink(client, batch_size=100)
+
+        event_payload = sink._map_event(_make_event())
+        sink._buffer.append(event_payload)
+        await sink.flush()
+        assert len(sink._buffer) == 1  # Event restored to buffer
+
+    @pytest.mark.asyncio
+    async def test_network_error_is_buffered_for_retry(self):
+        """Network errors should be buffered for retry."""
+        client = _make_client_mock()
+        client.post = AsyncMock(side_effect=ConnectionError("Network unreachable"))
+        sink = ServerAuditSink(client, batch_size=100)
+
+        event_payload = sink._map_event(_make_event())
+        sink._buffer.append(event_payload)
+        await sink.flush()
+        assert len(sink._buffer) == 1

--- a/tests/test_behavior/test_bundle_verification_behavior.py
+++ b/tests/test_behavior/test_bundle_verification_behavior.py
@@ -213,6 +213,22 @@ class TestInvalidEncodings:
         with pytest.raises(BundleVerificationError, match="empty"):
             verify_bundle_signature(VALID_BUNDLE_YAML, "", public_key_hex)
 
+    @pytest.mark.security
+    def test_wrong_length_public_key_rejected(self, key_pair):
+        """Non-32-byte public key raises BundleVerificationError with clear message."""
+        sk, _vk = key_pair
+        signature_b64 = _sign(VALID_BUNDLE_YAML, sk)
+
+        # 16 bytes instead of 32
+        short_key_hex = "aa" * 16
+        with pytest.raises(BundleVerificationError, match="expected 32 bytes"):
+            verify_bundle_signature(VALID_BUNDLE_YAML, signature_b64, short_key_hex)
+
+        # 64 bytes instead of 32
+        long_key_hex = "bb" * 64
+        with pytest.raises(BundleVerificationError, match="expected 32 bytes"):
+            verify_bundle_signature(VALID_BUNDLE_YAML, signature_b64, long_key_hex)
+
 
 class TestSSEVerification:
     """SSE updates are verified when verify_signatures is enabled."""

--- a/tests/test_behavior/test_observe_postcondition_behavior.py
+++ b/tests/test_behavior/test_observe_postcondition_behavior.py
@@ -1,0 +1,95 @@
+"""Behavior tests for observe-mode postcondition evaluation.
+
+Proves that postconditions from observe_alongside bundles are
+evaluated in post_execute and produce audit events + warnings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, Verdict, postcondition
+from edictum.audit import AuditAction
+from edictum.storage import MemoryBackend
+from tests.conftest import CapturingAuditSink
+
+
+def _make_observe_postcondition(name: str):
+    """Create a postcondition marked as observe-mode (observe_alongside)."""
+
+    @postcondition("*")
+    def check(envelope, response):
+        if "sensitive" in str(response):
+            return Verdict.fail(f"Observe-mode detected sensitive output [{name}]")
+        return Verdict.pass_()
+
+    check.__name__ = name
+    check._edictum_shadow = True
+    return check
+
+
+def _make_guard_with_shadow_postconditions(sink):
+    """Build a guard with observe-mode postconditions injected."""
+    guard = Edictum(
+        environment="test",
+        audit_sink=sink,
+        backend=MemoryBackend(),
+    )
+    # Inject observe-mode postconditions into compiled state
+    observe_post = _make_observe_postcondition("pii_check")
+    from dataclasses import replace
+
+    guard._state = replace(
+        guard._state,
+        shadow_postconditions=guard._state.shadow_postconditions + (observe_post,),
+    )
+    return guard
+
+
+class TestObserveModePostconditionsEvaluated:
+    """observe_alongside postconditions must be evaluated in post_execute."""
+
+    @pytest.mark.asyncio
+    async def test_shadow_postcondition_produces_warning(self):
+        """A failing observe-mode postcondition produces a warning, not a deny."""
+        sink = CapturingAuditSink()
+        guard = _make_guard_with_shadow_postconditions(sink)
+
+        # The tool "succeeds" but returns sensitive data
+        result = await guard.run("TestTool", {}, lambda: "sensitive data here")
+        # Tool call allowed (observe mode doesn't deny)
+        assert result == "sensitive data here"
+
+    @pytest.mark.asyncio
+    async def test_shadow_postcondition_emits_audit_event(self):
+        """Observe-mode postcondition failure appears in audit contracts_evaluated."""
+        sink = CapturingAuditSink()
+        guard = _make_guard_with_shadow_postconditions(sink)
+
+        await guard.run("TestTool", {}, lambda: "sensitive data here")
+
+        # Find the post-execution audit event
+        post_events = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert len(post_events) == 1
+
+        # The observe-mode postcondition should appear in contracts_evaluated
+        contracts = post_events[0].contracts_evaluated
+        observe_contracts = [c for c in contracts if c.get("observed")]
+        assert len(observe_contracts) == 1
+        assert observe_contracts[0]["name"] == "pii_check"
+        assert observe_contracts[0]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_shadow_postcondition_passing_no_warning(self):
+        """A passing observe-mode postcondition produces no warning."""
+        sink = CapturingAuditSink()
+        guard = _make_guard_with_shadow_postconditions(sink)
+
+        result = await guard.run("TestTool", {}, lambda: "clean data")
+        assert result == "clean data"
+
+        post_events = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        contracts = post_events[0].contracts_evaluated
+        observe_contracts = [c for c in contracts if c.get("observed")]
+        assert len(observe_contracts) == 1
+        assert observe_contracts[0]["passed"] is True

--- a/tests/test_behavior/test_sensitive_key_boundary_behavior.py
+++ b/tests/test_behavior/test_sensitive_key_boundary_behavior.py
@@ -1,0 +1,79 @@
+"""Behavior tests for _is_sensitive_key word-boundary matching.
+
+Proves that whole-word matching prevents false positives on fields
+like 'monkey' and 'hockey' while still catching 'api_key' and 'auth-token'.
+"""
+
+from __future__ import annotations
+
+from edictum.audit import RedactionPolicy
+
+
+class TestSensitiveKeyFalsePositives:
+    """Words containing 'key' as a substring must NOT be redacted."""
+
+    def test_monkey_not_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"monkey": "banana"})
+        assert result["monkey"] == "banana"
+
+    def test_hockey_not_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"hockey": "puck"})
+        assert result["hockey"] == "puck"
+
+    def test_donkey_not_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"donkey": "shrek"})
+        assert result["donkey"] == "shrek"
+
+    def test_jockey_not_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"jockey": "rider"})
+        assert result["jockey"] == "rider"
+
+    def test_turkey_not_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"turkey": "gobble"})
+        assert result["turkey"] == "gobble"
+
+
+class TestSensitiveKeyTruePositives:
+    """Real sensitive keys must still be caught."""
+
+    def test_api_key_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"api_key": "secret"})
+        assert result["api_key"] == "[REDACTED]"
+
+    def test_auth_token_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"auth-token": "secret"})
+        assert result["auth-token"] == "[REDACTED]"
+
+    def test_user_password_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"user_password": "secret"})
+        assert result["user_password"] == "[REDACTED]"
+
+    def test_client_secret_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"client_secret": "secret"})
+        assert result["client_secret"] == "[REDACTED]"
+
+    def test_access_credential_redacted(self):
+        policy = RedactionPolicy()
+        result = policy.redact_args({"access-credential": "secret"})
+        assert result["access-credential"] == "[REDACTED]"
+
+    def test_exact_match_still_works(self):
+        """Keys in DEFAULT_SENSITIVE_KEYS still match (e.g., 'apikey')."""
+        policy = RedactionPolicy()
+        result = policy.redact_args({"apikey": "secret"})
+        assert result["apikey"] == "[REDACTED]"
+
+    def test_bare_key_redacted(self):
+        """The word 'key' alone should be redacted."""
+        policy = RedactionPolicy()
+        result = policy.redact_args({"key": "secret"})
+        assert result["key"] == "[REDACTED]"

--- a/tests/test_behavior/test_session_validation_behavior.py
+++ b/tests/test_behavior/test_session_validation_behavior.py
@@ -1,0 +1,87 @@
+"""Behavior tests for session_id and tool_name validation in Session.
+
+Tests that invalid identifiers are rejected at construction and in
+methods that use them as storage key components.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum.session import Session
+from edictum.storage import MemoryBackend
+
+
+class TestSessionIdValidation:
+    """Session rejects session_ids that could cause storage key injection."""
+
+    def test_valid_session_id_accepted(self):
+        """Normal alphanumeric session_id is accepted."""
+        session = Session("my-session-123", MemoryBackend())
+        assert session.session_id == "my-session-123"
+
+    @pytest.mark.security
+    def test_empty_session_id_rejected(self):
+        """Empty string is rejected."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("", MemoryBackend())
+
+    @pytest.mark.security
+    def test_colon_in_session_id_rejected(self):
+        """Colons are storage key delimiters — allowing them enables key collision."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("real-session:execs", MemoryBackend())
+
+    @pytest.mark.security
+    def test_null_byte_in_session_id_rejected(self):
+        """Null bytes cause truncation in C-backed storage."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("sess\x00injected", MemoryBackend())
+
+    @pytest.mark.security
+    def test_newline_in_session_id_rejected(self):
+        """Control characters are rejected."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("sess\ninjected", MemoryBackend())
+
+    @pytest.mark.security
+    def test_path_separator_in_session_id_rejected(self):
+        """Path separators are rejected."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("sess/injected", MemoryBackend())
+
+    @pytest.mark.security
+    def test_backslash_in_session_id_rejected(self):
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("sess\\injected", MemoryBackend())
+
+    @pytest.mark.security
+    def test_del_in_session_id_rejected(self):
+        """DEL (0x7F) control character is rejected."""
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            Session("sess\x7finjected", MemoryBackend())
+
+
+class TestToolNameValidationInSession:
+    """Session methods that accept tool_name validate it."""
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_record_execution_rejects_invalid_tool_name(self):
+        session = Session("valid-session", MemoryBackend())
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            await session.record_execution("tool\x00name", True)
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_tool_execution_count_rejects_invalid_tool_name(self):
+        session = Session("valid-session", MemoryBackend())
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            await session.tool_execution_count("tool/name")
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_batch_get_counters_rejects_invalid_tool_name(self):
+        session = Session("valid-session", MemoryBackend())
+        with pytest.raises(ValueError, match="Invalid tool_name"):
+            await session.batch_get_counters(include_tool="tool\x00name")

--- a/tests/test_behavior/test_sse_timeout_behavior.py
+++ b/tests/test_behavior/test_sse_timeout_behavior.py
@@ -1,0 +1,67 @@
+"""Behavior tests for SSE connection timeout separation.
+
+Proves that the SSE stream uses a different read timeout than
+the connection timeout, preventing premature stream termination.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+httpx_sse = pytest.importorskip("httpx_sse")
+
+from edictum.server.contract_source import ServerContractSource  # noqa: E402
+
+
+class TestSSETimeoutSeparation:
+    """SSE connection must use separate connect and read timeouts."""
+
+    @pytest.mark.asyncio
+    async def test_sse_uses_extended_read_timeout(self):
+        """The SSE stream passes a timeout with read > connect to aconnect_sse."""
+        client = MagicMock()
+        client.env = "test"
+        client.bundle_name = "test-bundle"
+        client.tags = None
+
+        mock_http_client = MagicMock()
+        client._ensure_client.return_value = mock_http_client
+
+        source = ServerContractSource(client)
+        source._connected = True
+
+        captured_kwargs = {}
+
+        # Patch aconnect_sse to capture the timeout kwarg
+        class MockEventSource:
+            async def aiter_sse(self):
+                return
+                yield  # make it an async generator
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        def capture_aconnect(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            # Close the source to break the loop after capture
+            source._closed = True
+            return MockEventSource()
+
+        with patch.object(httpx_sse, "aconnect_sse", side_effect=capture_aconnect):
+            async for _ in source.watch():
+                pass  # pragma: no cover
+
+        assert "timeout" in captured_kwargs, "SSE connection must pass explicit timeout"
+        timeout = captured_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 30.0
+        assert timeout.read == 300.0, (
+            f"SSE read timeout should be 300s (5min), got {timeout.read}. "
+            "A 30s read timeout kills SSE streams between events."
+        )

--- a/tests/test_server/test_contract_source.py
+++ b/tests/test_server/test_contract_source.py
@@ -32,7 +32,7 @@ def _install_fake_httpx_sse(events: list[MagicMock], captured_params: list[dict]
     """Install a fake httpx_sse module that captures params and yields events."""
 
     @asynccontextmanager
-    async def fake_aconnect_sse(http_client, method, url, *, params=None):
+    async def fake_aconnect_sse(http_client, method, url, *, params=None, **kwargs):
         captured_params.append(params or {})
         source = MagicMock()
 
@@ -187,7 +187,7 @@ class TestServerContractSource:
         source = ServerContractSource(client)
 
         @asynccontextmanager
-        async def buggy_sse(http_client, method, url, *, params=None):
+        async def buggy_sse(http_client, method, url, *, params=None, **kwargs):
             source_mock = MagicMock()
 
             async def aiter():
@@ -215,7 +215,7 @@ class TestServerContractSource:
         sleep_delays: list[float] = []
 
         @asynccontextmanager
-        async def failing_sse(http_client, method, url, *, params=None):
+        async def failing_sse(http_client, method, url, *, params=None, **kwargs):
             nonlocal call_count
             call_count += 1
             # Simulate connection established then immediate drop
@@ -253,7 +253,7 @@ class TestServerContractSource:
         sleep_delays: list[float] = []
 
         @asynccontextmanager
-        async def sse_with_stable_then_drop(http_client, method, url, *, params=None):
+        async def sse_with_stable_then_drop(http_client, method, url, *, params=None, **kwargs):
             source_mock = MagicMock()
 
             async def aiter():
@@ -296,7 +296,7 @@ class TestServerContractSource:
         source = ServerContractSource(client, reconnect_delay=1.0)
 
         @asynccontextmanager
-        async def failing_sse(http_client, method, url, *, params=None):
+        async def failing_sse(http_client, method, url, *, params=None, **kwargs):
             raise ConnectionError("server unreachable")
             yield  # noqa: RET503
 
@@ -324,7 +324,7 @@ class TestServerContractSource:
         source = ServerContractSource(client, reconnect_delay=1.0)
 
         @asynccontextmanager
-        async def failing_sse(http_client, method, url, *, params=None):
+        async def failing_sse(http_client, method, url, *, params=None, **kwargs):
             raise ConnectionError("timeout")
             yield  # noqa: RET503
 
@@ -363,7 +363,7 @@ class TestServerContractSource:
         sleep_delays: list[float] = []
 
         @asynccontextmanager
-        async def sse_then_fail(http_client, method, url, *, params=None):
+        async def sse_then_fail(http_client, method, url, *, params=None, **kwargs):
             nonlocal attempt
             attempt += 1
             source_mock = MagicMock()
@@ -423,7 +423,7 @@ class TestServerContractSource:
         connected_during_sleep: list[bool] = []
 
         @asynccontextmanager
-        async def failing_sse(http_client, method, url, *, params=None):
+        async def failing_sse(http_client, method, url, *, params=None, **kwargs):
             source_mock = MagicMock()
 
             async def aiter():
@@ -458,7 +458,7 @@ class TestServerContractSource:
         connected_between_iterations: list[bool] = []
 
         @asynccontextmanager
-        async def sse_clean_then_check(http_client, method, url, *, params=None):
+        async def sse_clean_then_check(http_client, method, url, *, params=None, **kwargs):
             nonlocal attempt
             attempt += 1
 
@@ -495,7 +495,7 @@ class TestServerContractSource:
         sleep_delays: list[float] = []
 
         @asynccontextmanager
-        async def mixed_sse(http_client, method, url, *, params=None):
+        async def mixed_sse(http_client, method, url, *, params=None, **kwargs):
             nonlocal attempt
             attempt += 1
             source_mock = MagicMock()


### PR DESCRIPTION
## Summary

Triaged all 13 open issues. Closed #121 as false positive (AWS example key). Fixes #123, #124, #127, #129, #132, #133, #134. Leaves #126 (terminology rename) for a follow-up PR.

### Security fixes
- **#123** Session storage key injection: `_validate_session_id()` rejects colons (key delimiter), control chars, path separators. Tool names validated in `record_execution`/`tool_execution_count`.
- **#124** `LocalApprovalBackend` prints unredacted `tool_args` to stdout: now applies `RedactionPolicy.redact_args()` before printing.

### Bug fixes
- **#127** `_is_sensitive_key` substring matching causes false positives (`monkey` → `key`): switched to word-boundary matching (split on `_`/`-`, match whole segments).
- **#129** `observe_alongside` postconditions compiled but never evaluated: added observe-mode postcondition evaluation in `post_execute()` (needs `tool_response`, so can't run in `_evaluate_shadow_contracts`).
- **#132** `ServerAuditSink._flush()` swallows 401/403 auth errors, buffering forever: now raises non-retryable 4xx (except 429) immediately.
- **#133** SSE uses single 30s timeout for connect and read, killing idle streams: passes `httpx.Timeout(connect=30, read=300)` to `aconnect_sse`.
- **#134** Ed25519 key length not validated: adds explicit 32-byte check with clear `BundleVerificationError`.

### Tests
35 new behavior tests across 6 new test files + 1 addition to existing file. Updated existing SSE test fakes to accept `**kwargs`.

## Test plan

- [x] 2220 tests pass, 0 failures
- [x] `ruff check` clean
- [x] Terminology check passes
- [ ] Verify session validation doesn't break existing adapters
- [ ] Verify LocalApprovalBackend redaction shows enough context for approval decisions