### PR TITLE
refactor: rename shadow_* to observe_* per terminology guide

### DIFF
--- a/scripts/check-terminology.py
+++ b/scripts/check-terminology.py
@@ -36,24 +36,24 @@ BLOCKED_ALLOWLIST = {
 }
 
 # "shadow" needs special handling — internal code uses shadow_* field names
-# in _CompiledState and _edictum_shadow attribute, but prose should say
+# in _CompiledState and _edictum_observe attribute, but prose should say
 # "observe mode" / "observe-mode".
 SHADOW_PATTERN = re.compile(r"\bshadow\b", re.IGNORECASE)
 SHADOW_ALLOWLIST = {
     # _CompiledState frozen dataclass fields
-    "shadow_preconditions",
-    "shadow_postconditions",
-    "shadow_session_contracts",
-    "shadow_sandbox_contracts",
+    "observe_preconditions",
+    "observe_postconditions",
+    "observe_session_contracts",
+    "observe_sandbox_contracts",
     # Internal attribute on contract callables
-    "_edictum_shadow",
+    "_edictum_observe",
     # Local variable reading the attribute
-    "is_shadow",
+    "is_observe",
     # Getter methods on Edictum
-    "get_shadow_preconditions",
-    "get_shadow_postconditions",
-    "get_shadow_sandbox_contracts",
-    "get_shadow_session_contracts",
+    "get_observe_preconditions",
+    "get_observe_postconditions",
+    "get_observe_sandbox_contracts",
+    "get_observe_session_contracts",
     # Real file path in sandbox tests (with and without leading slash)
     "/etc/shadow",
     '"etc" / "shadow"',

--- a/src/edictum/_factory.py
+++ b/src/edictum/_factory.py
@@ -401,22 +401,22 @@ def _from_multiple(cls: type[Edictum], guards: list[Edictum]) -> Edictum:
     merged.tool_registry = first.tool_registry
 
     regular_attrs = ("preconditions", "postconditions", "session_contracts", "sandbox_contracts")
-    shadow_attrs = (
-        "shadow_preconditions",
-        "shadow_postconditions",
-        "shadow_session_contracts",
-        "shadow_sandbox_contracts",
+    observe_attrs = (
+        "observe_preconditions",
+        "observe_postconditions",
+        "observe_session_contracts",
+        "observe_sandbox_contracts",
     )
 
     seen_regular_ids: set[str] = set()
-    seen_shadow_ids: set[str] = set()
+    seen_observe_ids: set[str] = set()
 
-    collected: dict[str, list] = {a: [] for a in (*regular_attrs, *shadow_attrs)}
+    collected: dict[str, list] = {a: [] for a in (*regular_attrs, *observe_attrs)}
 
     for guard in guards:
         for attr, seen in (
             *((a, seen_regular_ids) for a in regular_attrs),
-            *((a, seen_shadow_ids) for a in shadow_attrs),
+            *((a, seen_observe_ids) for a in observe_attrs),
         ):
             for contract in getattr(guard._state, attr):
                 cid = getattr(contract, "_edictum_id", None)
@@ -432,10 +432,10 @@ def _from_multiple(cls: type[Edictum], guards: list[Edictum]) -> Edictum:
         postconditions=tuple(collected["postconditions"]),
         session_contracts=tuple(collected["session_contracts"]),
         sandbox_contracts=tuple(collected["sandbox_contracts"]),
-        shadow_preconditions=tuple(collected["shadow_preconditions"]),
-        shadow_postconditions=tuple(collected["shadow_postconditions"]),
-        shadow_session_contracts=tuple(collected["shadow_session_contracts"]),
-        shadow_sandbox_contracts=tuple(collected["shadow_sandbox_contracts"]),
+        observe_preconditions=tuple(collected["observe_preconditions"]),
+        observe_postconditions=tuple(collected["observe_postconditions"]),
+        observe_session_contracts=tuple(collected["observe_session_contracts"]),
+        observe_sandbox_contracts=tuple(collected["observe_sandbox_contracts"]),
         limits=merged._state.limits,
         policy_version=merged._state.policy_version,
     )

--- a/src/edictum/_guard.py
+++ b/src/edictum/_guard.py
@@ -46,10 +46,10 @@ class _CompiledState:
     postconditions: tuple = ()
     session_contracts: tuple = ()
     sandbox_contracts: tuple = ()
-    shadow_preconditions: tuple = ()
-    shadow_postconditions: tuple = ()
-    shadow_session_contracts: tuple = ()
-    shadow_sandbox_contracts: tuple = ()
+    observe_preconditions: tuple = ()
+    observe_postconditions: tuple = ()
+    observe_session_contracts: tuple = ()
+    observe_sandbox_contracts: tuple = ()
     limits: OperationLimits = field(default_factory=OperationLimits)
     policy_version: str | None = None
 
@@ -124,9 +124,9 @@ class Edictum:
 
         for item in contracts or []:
             contract_type = getattr(item, "_edictum_type", None)
-            is_shadow = getattr(item, "_edictum_shadow", False)
+            is_observe = getattr(item, "_edictum_observe", False)
 
-            if is_shadow:
+            if is_observe:
                 if contract_type == "precondition":
                     s_pre.append(item)
                 elif contract_type == "postcondition":
@@ -153,10 +153,10 @@ class Edictum:
             postconditions=tuple(post),
             session_contracts=tuple(session),
             sandbox_contracts=tuple(sandbox),
-            shadow_preconditions=tuple(s_pre),
-            shadow_postconditions=tuple(s_post),
-            shadow_session_contracts=tuple(s_session),
-            shadow_sandbox_contracts=tuple(s_sandbox),
+            observe_preconditions=tuple(s_pre),
+            observe_postconditions=tuple(s_post),
+            observe_session_contracts=tuple(s_session),
+            observe_sandbox_contracts=tuple(s_sandbox),
             limits=limits or OperationLimits(),
             policy_version=policy_version,
         )
@@ -223,22 +223,22 @@ class Edictum:
         post: list = []
         session: list = []
         sandbox: list = []
-        shadow_pre: list = []
-        shadow_post: list = []
-        shadow_session: list = []
-        shadow_sandbox: list = []
+        observe_pre: list = []
+        observe_post: list = []
+        observe_session: list = []
+        observe_sandbox: list = []
         for contract in all_contracts:
             ctype = getattr(contract, "_edictum_type", None)
-            is_shadow = getattr(contract, "_edictum_shadow", False)
-            if is_shadow:
+            is_observe = getattr(contract, "_edictum_observe", False)
+            if is_observe:
                 if ctype == "precondition":
-                    shadow_pre.append(contract)
+                    observe_pre.append(contract)
                 elif ctype == "postcondition":
-                    shadow_post.append(contract)
+                    observe_post.append(contract)
                 elif ctype == "session_contract":
-                    shadow_session.append(contract)
+                    observe_session.append(contract)
                 elif ctype == "sandbox":
-                    shadow_sandbox.append(contract)
+                    observe_sandbox.append(contract)
             elif ctype == "precondition":
                 pre.append(contract)
             elif ctype == "postcondition":
@@ -253,10 +253,10 @@ class Edictum:
             postconditions=tuple(post),
             session_contracts=tuple(session),
             sandbox_contracts=tuple(sandbox),
-            shadow_preconditions=tuple(shadow_pre),
-            shadow_postconditions=tuple(shadow_post),
-            shadow_session_contracts=tuple(shadow_session),
-            shadow_sandbox_contracts=tuple(shadow_sandbox),
+            observe_preconditions=tuple(observe_pre),
+            observe_postconditions=tuple(observe_post),
+            observe_session_contracts=tuple(observe_session),
+            observe_sandbox_contracts=tuple(observe_sandbox),
             limits=compiled.limits,
             policy_version=str(bundle_hash),
         )
@@ -328,20 +328,20 @@ class Edictum:
     def get_session_contracts(self) -> list:
         return list(self._state.session_contracts)
 
-    def get_shadow_preconditions(self, envelope: ToolEnvelope) -> list:
-        return self._filter_by_tool(self._state.shadow_preconditions, envelope)
+    def get_observe_preconditions(self, envelope: ToolEnvelope) -> list:
+        return self._filter_by_tool(self._state.observe_preconditions, envelope)
 
-    def get_shadow_postconditions(self, envelope: ToolEnvelope) -> list:
-        return self._filter_by_tool(self._state.shadow_postconditions, envelope)
+    def get_observe_postconditions(self, envelope: ToolEnvelope) -> list:
+        return self._filter_by_tool(self._state.observe_postconditions, envelope)
 
     def get_sandbox_contracts(self, envelope: ToolEnvelope) -> list:
         return self._filter_sandbox(self._state.sandbox_contracts, envelope)
 
-    def get_shadow_sandbox_contracts(self, envelope: ToolEnvelope) -> list:
-        return self._filter_sandbox(self._state.shadow_sandbox_contracts, envelope)
+    def get_observe_sandbox_contracts(self, envelope: ToolEnvelope) -> list:
+        return self._filter_sandbox(self._state.observe_sandbox_contracts, envelope)
 
-    def get_shadow_session_contracts(self) -> list:
-        return list(self._state.shadow_session_contracts)
+    def get_observe_session_contracts(self) -> list:
+        return list(self._state.observe_session_contracts)
 
     # --- Delegated methods (implementation in separate modules) ---
 

--- a/src/edictum/_runner.py
+++ b/src/edictum/_runner.py
@@ -210,10 +210,10 @@ async def _run(
             span.set_attribute("governance.action", "allowed")
 
         # Emit observe-mode audit events (never affect the real decision)
-        for sr in pre.shadow_results:
-            shadow_action = AuditAction.CALL_WOULD_DENY if not sr["passed"] else AuditAction.CALL_ALLOWED
-            shadow_event = AuditEvent(
-                action=shadow_action,
+        for sr in pre.observe_results:
+            observe_action = AuditAction.CALL_WOULD_DENY if not sr["passed"] else AuditAction.CALL_ALLOWED
+            observe_event = AuditEvent(
+                action=observe_action,
                 run_id=envelope.run_id,
                 call_id=envelope.call_id,
                 tool_name=envelope.tool_name,
@@ -227,8 +227,8 @@ async def _run(
                 mode="observe",
                 policy_version=self.policy_version,
             )
-            await self.audit_sink.emit(shadow_event)
-            _emit_otel_governance_span(self, shadow_event)
+            await self.audit_sink.emit(observe_event)
+            _emit_otel_governance_span(self, observe_event)
 
         # Execute tool
         try:

--- a/src/edictum/cli/main.py
+++ b/src/edictum/cli/main.py
@@ -28,8 +28,8 @@ from edictum.yaml_engine.loader import load_bundle
 
 
 def _print_composition_report(report: Any) -> None:
-    """Print composition report (overrides and shadows)."""
-    if not report.overridden_contracts and not report.shadow_contracts:
+    """Print composition report (overrides and observe-mode contracts)."""
+    if not report.overridden_contracts and not report.observe_contracts:
         return
 
     _console.print("\n[bold]Composition report:[/bold]")
@@ -38,7 +38,7 @@ def _print_composition_report(report: Any) -> None:
             f"  \u21c4 {escape(o.contract_id)} \u2014 overridden by "
             f"{escape(o.overridden_by)} (was in {escape(o.original_source)})"
         )
-    for s in report.shadow_contracts:
+    for s in report.observe_contracts:
         _console.print(
             f"  \u2295 {escape(s.contract_id)} \u2014 observe-mode from "
             f"{escape(s.observed_source)} (enforced in {escape(s.enforced_source)})"
@@ -199,7 +199,7 @@ def _count_contracts(bundle_data: dict) -> dict[str, int]:
 
 def _composition_report_to_dict(report: Any) -> dict:
     """Convert a composition report to a JSON-serializable dict."""
-    result: dict[str, list] = {"overrides": [], "shadows": []}
+    result: dict[str, list] = {"overrides": [], "observe_contracts": []}
     for o in report.overridden_contracts:
         result["overrides"].append(
             {
@@ -208,8 +208,8 @@ def _composition_report_to_dict(report: Any) -> dict:
                 "original_source": o.original_source,
             }
         )
-    for s in report.shadow_contracts:
-        result["shadows"].append(
+    for s in report.observe_contracts:
+        result["observe_contracts"].append(
             {
                 "contract_id": s.contract_id,
                 "observed_source": s.observed_source,
@@ -513,7 +513,7 @@ def diff(files: tuple[str, ...], json_output: bool) -> None:
     composed = compose_bundles(*loaded)
     report = composed.report
 
-    if report.overridden_contracts or report.shadow_contracts:
+    if report.overridden_contracts or report.observe_contracts:
         # For 3+ files (no standard diff), composition is the primary output
         if len(files) > 2:
             has_changes = True

--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -30,7 +30,7 @@ class PreDecision:
     contracts_evaluated: list[dict] = field(default_factory=list)
     observed: bool = False
     policy_error: bool = False
-    shadow_results: list[dict] = field(default_factory=list)
+    observe_results: list[dict] = field(default_factory=list)
     approval_timeout: int = 300
     approval_timeout_effect: str = "deny"
     approval_message: str | None = None
@@ -299,7 +299,7 @@ class GovernancePipeline:
         pe = any(c.get("metadata", {}).get("policy_error") for c in contracts_evaluated)
 
         # 7. Observe-mode contract evaluation (never affects the decision)
-        shadow_results = await self._evaluate_shadow_contracts(envelope, session)
+        observe_results = await self._evaluate_observe_contracts(envelope, session)
 
         return PreDecision(
             action="allow",
@@ -307,7 +307,7 @@ class GovernancePipeline:
             contracts_evaluated=contracts_evaluated,
             observed=has_observed_deny,
             policy_error=pe,
-            shadow_results=shadow_results,
+            observe_results=observe_results,
         )
 
     async def post_execute(
@@ -386,7 +386,7 @@ class GovernancePipeline:
                     )
 
         # 2. Observe-mode postconditions (from observe_alongside bundles)
-        for contract in self._guard.get_shadow_postconditions(envelope):
+        for contract in self._guard.get_observe_postconditions(envelope):
             try:
                 verdict = contract(envelope, tool_response)
                 if asyncio.iscoroutine(verdict):
@@ -436,20 +436,20 @@ class GovernancePipeline:
             output_suppressed=output_suppressed,
         )
 
-    async def _evaluate_shadow_contracts(
+    async def _evaluate_observe_contracts(
         self,
         envelope: ToolEnvelope,
         session: Session,
     ) -> list[dict]:
         """Evaluate observe-mode contracts without affecting the real decision.
 
-        Observe-mode contracts are identified by ``_edictum_shadow = True``.
+        Observe-mode contracts are identified by ``_edictum_observe = True``.
         Results are returned as dicts for audit emission but never block calls.
         """
         results: list[dict] = []
 
         # Observe-mode preconditions
-        for contract in self._guard.get_shadow_preconditions(envelope):
+        for contract in self._guard.get_observe_preconditions(envelope):
             try:
                 verdict = contract(envelope)
                 if asyncio.iscoroutine(verdict):
@@ -469,7 +469,7 @@ class GovernancePipeline:
             )
 
         # Observe-mode sandbox contracts
-        for contract in self._guard.get_shadow_sandbox_contracts(envelope):
+        for contract in self._guard.get_observe_sandbox_contracts(envelope):
             try:
                 verdict = contract(envelope)
                 if asyncio.iscoroutine(verdict):
@@ -489,7 +489,7 @@ class GovernancePipeline:
             )
 
         # Observe-mode session contracts — evaluate against the real session
-        for contract in self._guard.get_shadow_session_contracts():
+        for contract in self._guard.get_observe_session_contracts():
             try:
                 verdict = contract(session)
                 if asyncio.iscoroutine(verdict):

--- a/src/edictum/yaml_engine/__init__.py
+++ b/src/edictum/yaml_engine/__init__.py
@@ -10,7 +10,7 @@ from edictum.yaml_engine.composer import (
     ComposedBundle,
     CompositionOverride,
     CompositionReport,
-    ShadowContract,
+    ObserveContract,
     compose_bundles,
 )
 from edictum.yaml_engine.loader import BundleHash
@@ -43,7 +43,7 @@ __all__ = [
     "ComposedBundle",
     "CompositionOverride",
     "CompositionReport",
-    "ShadowContract",
+    "ObserveContract",
     "compile_contracts",
     "compose_bundles",
     "load_bundle",

--- a/src/edictum/yaml_engine/compiler.py
+++ b/src/edictum/yaml_engine/compiler.py
@@ -115,8 +115,8 @@ def compile_contracts(
             fn = _compile_sandbox(contract, contract_mode)
             sandbox_contracts.append(fn)
         elif contract_type == "session":
-            is_shadow = contract.get("_shadow", False)
-            if not is_shadow:
+            is_observe = contract.get("_observe", False)
+            if not is_observe:
                 limits = _merge_session_limits(contract, limits)
             fn = _compile_session(contract, contract_mode, limits)
             session_contracts.append(fn)
@@ -218,8 +218,8 @@ def _compile_pre(
     precondition_fn._edictum_effect = then.get("effect", "deny")
     precondition_fn._edictum_timeout = then.get("timeout", 300)
     precondition_fn._edictum_timeout_effect = then.get("timeout_effect", "deny")
-    if contract.get("_shadow"):
-        precondition_fn._edictum_shadow = True
+    if contract.get("_observe"):
+        precondition_fn._edictum_observe = True
 
     return precondition_fn
 
@@ -323,8 +323,8 @@ def _compile_post(
     postcondition_fn._edictum_source = "yaml_postcondition"
     postcondition_fn._edictum_effect = effect
     postcondition_fn._edictum_redact_patterns = _extract_output_patterns(when_expr)
-    if contract.get("_shadow"):
-        postcondition_fn._edictum_shadow = True
+    if contract.get("_observe"):
+        postcondition_fn._edictum_observe = True
 
     return postcondition_fn
 
@@ -357,8 +357,8 @@ def _compile_session(contract: dict, mode: str, limits: OperationLimits) -> Any:
     session_contract_fn._edictum_tags = tags
     session_contract_fn._edictum_then_metadata = then_metadata
     session_contract_fn._edictum_source = "yaml_session"
-    if contract.get("_shadow"):
-        session_contract_fn._edictum_shadow = True
+    if contract.get("_observe"):
+        session_contract_fn._edictum_observe = True
 
     return session_contract_fn
 

--- a/src/edictum/yaml_engine/composer.py
+++ b/src/edictum/yaml_engine/composer.py
@@ -16,7 +16,7 @@ class CompositionOverride:
 
 
 @dataclass(frozen=True)
-class ShadowContract:
+class ObserveContract:
     """Records a contract added as an observe-mode copy (observe_alongside)."""
 
     contract_id: str
@@ -29,7 +29,7 @@ class CompositionReport:
     """Report of what happened during composition."""
 
     overridden_contracts: list[CompositionOverride] = field(default_factory=list)
-    shadow_contracts: list[ShadowContract] = field(default_factory=list)
+    observe_contracts: list[ObserveContract] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -63,7 +63,7 @@ def compose_bundles(*bundles: tuple[dict[str, Any], str]) -> ComposedBundle:
         return ComposedBundle(bundle=_deep_copy_bundle(data), report=CompositionReport())
 
     overrides: list[CompositionOverride] = []
-    shadows: list[ShadowContract] = []
+    observes: list[ObserveContract] = []
 
     # Start with a copy of the first bundle
     first_data, first_label = bundles[0]
@@ -78,7 +78,7 @@ def compose_bundles(*bundles: tuple[dict[str, Any], str]) -> ComposedBundle:
         is_observe_alongside = data.get("observe_alongside", False)
 
         if is_observe_alongside:
-            _merge_observe_alongside(merged, data, label, contract_sources, shadows)
+            _merge_observe_alongside(merged, data, label, contract_sources, observes)
         else:
             _merge_standard(merged, data, label, contract_sources, overrides)
 
@@ -86,7 +86,7 @@ def compose_bundles(*bundles: tuple[dict[str, Any], str]) -> ComposedBundle:
         bundle=merged,
         report=CompositionReport(
             overridden_contracts=overrides,
-            shadow_contracts=shadows,
+            observe_contracts=observes,
         ),
     )
 
@@ -171,23 +171,23 @@ def _merge_observe_alongside(
     layer: dict[str, Any],
     label: str,
     contract_sources: dict[str, str],
-    shadows: list[ShadowContract],
+    observes: list[ObserveContract],
 ) -> None:
     """Merge an observe_alongside layer — contracts become observe-mode copies."""
     for contract in layer.get("contracts", []):
         cid = contract["id"]
-        shadow_id = f"{cid}:candidate"
+        observe_id = f"{cid}:candidate"
 
-        shadow_contract = _deep_copy_bundle(contract)
-        shadow_contract["id"] = shadow_id
-        shadow_contract["mode"] = "observe"
-        shadow_contract["_shadow"] = True
+        observe_contract = _deep_copy_bundle(contract)
+        observe_contract["id"] = observe_id
+        observe_contract["mode"] = "observe"
+        observe_contract["_observe"] = True
 
-        merged.setdefault("contracts", []).append(shadow_contract)
+        merged.setdefault("contracts", []).append(observe_contract)
 
         enforced_source = contract_sources.get(cid, "")
-        shadows.append(
-            ShadowContract(
+        observes.append(
+            ObserveContract(
                 contract_id=cid,
                 enforced_source=enforced_source,
                 observed_source=label,

--- a/src/edictum/yaml_engine/sandbox_compiler.py
+++ b/src/edictum/yaml_engine/sandbox_compiler.py
@@ -256,7 +256,7 @@ def _compile_sandbox(contract: dict, mode: str) -> Any:
     sandbox_fn._edictum_effect = outside
     sandbox_fn._edictum_timeout = timeout
     sandbox_fn._edictum_timeout_effect = timeout_effect
-    if contract.get("_shadow"):
-        sandbox_fn._edictum_shadow = True
+    if contract.get("_observe"):
+        sandbox_fn._edictum_observe = True
 
     return sandbox_fn

--- a/tests/test_behavior/test_factory_behavior.py
+++ b/tests/test_behavior/test_factory_behavior.py
@@ -13,7 +13,7 @@ class _NullSink:
 
 def _make_observe(fn):
     """Mark a contract function as observe-mode."""
-    fn._edictum_shadow = True
+    fn._edictum_observe = True
     return fn
 
 
@@ -40,7 +40,7 @@ class TestFromMultipleObserveModeContracts:
 
         merged = Edictum.from_multiple([g1, g2])
 
-        ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_preconditions]
+        ids = [getattr(c, "_edictum_id", None) for c in merged._state.observe_preconditions]
         assert len(ids) == 2
         assert "observe-pre-a" in ids
         assert "observe-pre-b" in ids
@@ -67,7 +67,7 @@ class TestFromMultipleObserveModeContracts:
 
         merged = Edictum.from_multiple([g1, g2])
 
-        ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_postconditions]
+        ids = [getattr(c, "_edictum_id", None) for c in merged._state.observe_postconditions]
         assert len(ids) == 2
         assert "observe-post-a" in ids
         assert "observe-post-b" in ids
@@ -96,8 +96,8 @@ class TestFromMultipleObserveModeContracts:
         assert len(merged._state.preconditions) == 1
         assert getattr(merged._state.preconditions[0], "_edictum_id", None) == "enforced-pre"
 
-        assert len(merged._state.shadow_preconditions) == 1
-        assert getattr(merged._state.shadow_preconditions[0], "_edictum_id", None) == "observe-pre"
+        assert len(merged._state.observe_preconditions) == 1
+        assert getattr(merged._state.observe_preconditions[0], "_edictum_id", None) == "observe-pre"
 
     def test_observe_dedup_by_id(self):
         """Duplicate observe-mode contract IDs are deduplicated (first wins)."""
@@ -121,7 +121,7 @@ class TestFromMultipleObserveModeContracts:
 
         merged = Edictum.from_multiple([g1, g2])
 
-        assert len(merged._state.shadow_preconditions) == 1
+        assert len(merged._state.observe_preconditions) == 1
 
     def test_observe_session_contracts_merged(self):
         """Observe-mode session contracts from both guards appear in merged guard."""
@@ -147,7 +147,7 @@ class TestFromMultipleObserveModeContracts:
 
         merged = Edictum.from_multiple([g1, g2])
 
-        ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_session_contracts]
+        ids = [getattr(c, "_edictum_id", None) for c in merged._state.observe_session_contracts]
         assert len(ids) == 2
         assert "observe-sess-a" in ids
         assert "observe-sess-b" in ids
@@ -178,7 +178,7 @@ class TestFromMultipleObserveModeContracts:
 
         merged = Edictum.from_multiple([g1, g2])
 
-        ids = [getattr(c, "_edictum_id", None) for c in merged._state.shadow_sandbox_contracts]
+        ids = [getattr(c, "_edictum_id", None) for c in merged._state.observe_sandbox_contracts]
         assert len(ids) == 2
         assert "observe-sb-a" in ids
         assert "observe-sb-b" in ids
@@ -205,4 +205,4 @@ class TestFromMultipleObserveModeContracts:
         merged = Edictum.from_multiple([g1, g2])
 
         assert len(merged._state.preconditions) == 1
-        assert len(merged._state.shadow_preconditions) == 1
+        assert len(merged._state.observe_preconditions) == 1

--- a/tests/test_behavior/test_guard_behavior.py
+++ b/tests/test_behavior/test_guard_behavior.py
@@ -71,7 +71,7 @@ def _make_observe_precondition(contract_id: str) -> object:
     fn._edictum_id = contract_id
     fn._edictum_source = "yaml_precondition"
     fn._edictum_effect = "deny"
-    fn._edictum_shadow = True
+    fn._edictum_observe = True
     return fn
 
 
@@ -89,7 +89,7 @@ def _make_observe_postcondition(contract_id: str) -> object:
     fn._edictum_id = contract_id
     fn._edictum_source = "yaml_postcondition"
     fn._edictum_effect = "warn"
-    fn._edictum_shadow = True
+    fn._edictum_observe = True
     return fn
 
 
@@ -104,7 +104,7 @@ def _make_observe_session_contract(contract_id: str) -> object:
     fn._edictum_mode = "observe"
     fn._edictum_id = contract_id
     fn._edictum_source = "yaml_session"
-    fn._edictum_shadow = True
+    fn._edictum_observe = True
     return fn
 
 
@@ -121,7 +121,7 @@ def _make_observe_sandbox(contract_id: str) -> object:
     fn._edictum_id = contract_id
     fn._edictum_source = "yaml_sandbox"
     fn._edictum_effect = "deny"
-    fn._edictum_shadow = True
+    fn._edictum_observe = True
     return fn
 
 
@@ -135,13 +135,13 @@ async def test_reload_clears_stale_observe_preconditions():
     observe = _make_observe_precondition("old-observe-pre")
     guard._state = replace(
         guard._state,
-        shadow_preconditions=guard._state.shadow_preconditions + (observe,),
+        observe_preconditions=guard._state.observe_preconditions + (observe,),
     )
-    assert len(guard.get_shadow_preconditions(env)) == 1
+    assert len(guard.get_observe_preconditions(env)) == 1
 
     await guard.reload(_BUNDLE_B)
 
-    assert guard.get_shadow_preconditions(env) == []
+    assert guard.get_observe_preconditions(env) == []
 
 
 @pytest.mark.asyncio
@@ -153,13 +153,13 @@ async def test_reload_clears_stale_observe_postconditions():
     observe = _make_observe_postcondition("old-observe-post")
     guard._state = replace(
         guard._state,
-        shadow_postconditions=guard._state.shadow_postconditions + (observe,),
+        observe_postconditions=guard._state.observe_postconditions + (observe,),
     )
-    assert len(guard.get_shadow_postconditions(env)) == 1
+    assert len(guard.get_observe_postconditions(env)) == 1
 
     await guard.reload(_BUNDLE_B)
 
-    assert guard.get_shadow_postconditions(env) == []
+    assert guard.get_observe_postconditions(env) == []
 
 
 @pytest.mark.asyncio
@@ -170,13 +170,13 @@ async def test_reload_clears_stale_observe_session_contracts():
     observe = _make_observe_session_contract("old-observe-session")
     guard._state = replace(
         guard._state,
-        shadow_session_contracts=guard._state.shadow_session_contracts + (observe,),
+        observe_session_contracts=guard._state.observe_session_contracts + (observe,),
     )
-    assert len(guard.get_shadow_session_contracts()) == 1
+    assert len(guard.get_observe_session_contracts()) == 1
 
     await guard.reload(_BUNDLE_B)
 
-    assert guard.get_shadow_session_contracts() == []
+    assert guard.get_observe_session_contracts() == []
 
 
 @pytest.mark.asyncio
@@ -188,13 +188,13 @@ async def test_reload_clears_stale_observe_sandbox_contracts():
     observe = _make_observe_sandbox("old-observe-sandbox")
     guard._state = replace(
         guard._state,
-        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (observe,),
+        observe_sandbox_contracts=guard._state.observe_sandbox_contracts + (observe,),
     )
-    assert len(guard.get_shadow_sandbox_contracts(env)) == 1
+    assert len(guard.get_observe_sandbox_contracts(env)) == 1
 
     await guard.reload(_BUNDLE_B)
 
-    assert guard.get_shadow_sandbox_contracts(env) == []
+    assert guard.get_observe_sandbox_contracts(env) == []
 
 
 @pytest.mark.asyncio
@@ -206,23 +206,23 @@ async def test_reload_clears_all_four_observe_lists_simultaneously():
     # Populate all four observe-mode lists via frozen state replacement
     guard._state = replace(
         guard._state,
-        shadow_preconditions=guard._state.shadow_preconditions + (_make_observe_precondition("sp"),),
-        shadow_postconditions=guard._state.shadow_postconditions + (_make_observe_postcondition("spo"),),
-        shadow_session_contracts=guard._state.shadow_session_contracts + (_make_observe_session_contract("ss"),),
-        shadow_sandbox_contracts=guard._state.shadow_sandbox_contracts + (_make_observe_sandbox("ssb"),),
+        observe_preconditions=guard._state.observe_preconditions + (_make_observe_precondition("sp"),),
+        observe_postconditions=guard._state.observe_postconditions + (_make_observe_postcondition("spo"),),
+        observe_session_contracts=guard._state.observe_session_contracts + (_make_observe_session_contract("ss"),),
+        observe_sandbox_contracts=guard._state.observe_sandbox_contracts + (_make_observe_sandbox("ssb"),),
     )
 
-    assert len(guard.get_shadow_preconditions(env)) == 1
-    assert len(guard.get_shadow_postconditions(env)) == 1
-    assert len(guard.get_shadow_session_contracts()) == 1
-    assert len(guard.get_shadow_sandbox_contracts(env)) == 1
+    assert len(guard.get_observe_preconditions(env)) == 1
+    assert len(guard.get_observe_postconditions(env)) == 1
+    assert len(guard.get_observe_session_contracts()) == 1
+    assert len(guard.get_observe_sandbox_contracts(env)) == 1
 
     await guard.reload(_BUNDLE_B)
 
-    assert guard.get_shadow_preconditions(env) == []
-    assert guard.get_shadow_postconditions(env) == []
-    assert guard.get_shadow_session_contracts() == []
-    assert guard.get_shadow_sandbox_contracts(env) == []
+    assert guard.get_observe_preconditions(env) == []
+    assert guard.get_observe_postconditions(env) == []
+    assert guard.get_observe_session_contracts() == []
+    assert guard.get_observe_sandbox_contracts(env) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_behavior/test_observe_postcondition_behavior.py
+++ b/tests/test_behavior/test_observe_postcondition_behavior.py
@@ -24,11 +24,11 @@ def _make_observe_postcondition(name: str):
         return Verdict.pass_()
 
     check.__name__ = name
-    check._edictum_shadow = True
+    check._edictum_observe = True
     return check
 
 
-def _make_guard_with_shadow_postconditions(sink):
+def _make_guard_with_observe_postconditions(sink):
     """Build a guard with observe-mode postconditions injected."""
     guard = Edictum(
         environment="test",
@@ -41,7 +41,7 @@ def _make_guard_with_shadow_postconditions(sink):
 
     guard._state = replace(
         guard._state,
-        shadow_postconditions=guard._state.shadow_postconditions + (observe_post,),
+        observe_postconditions=guard._state.observe_postconditions + (observe_post,),
     )
     return guard
 
@@ -50,10 +50,10 @@ class TestObserveModePostconditionsEvaluated:
     """observe_alongside postconditions must be evaluated in post_execute."""
 
     @pytest.mark.asyncio
-    async def test_shadow_postcondition_produces_warning(self):
+    async def test_observe_postcondition_produces_warning(self):
         """A failing observe-mode postcondition produces a warning, not a deny."""
         sink = CapturingAuditSink()
-        guard = _make_guard_with_shadow_postconditions(sink)
+        guard = _make_guard_with_observe_postconditions(sink)
 
         # The tool "succeeds" but returns sensitive data
         result = await guard.run("TestTool", {}, lambda: "sensitive data here")
@@ -61,10 +61,10 @@ class TestObserveModePostconditionsEvaluated:
         assert result == "sensitive data here"
 
     @pytest.mark.asyncio
-    async def test_shadow_postcondition_emits_audit_event(self):
+    async def test_observe_postcondition_emits_audit_event(self):
         """Observe-mode postcondition failure appears in audit contracts_evaluated."""
         sink = CapturingAuditSink()
-        guard = _make_guard_with_shadow_postconditions(sink)
+        guard = _make_guard_with_observe_postconditions(sink)
 
         await guard.run("TestTool", {}, lambda: "sensitive data here")
 
@@ -80,10 +80,10 @@ class TestObserveModePostconditionsEvaluated:
         assert observe_contracts[0]["passed"] is False
 
     @pytest.mark.asyncio
-    async def test_shadow_postcondition_passing_no_warning(self):
+    async def test_observe_postcondition_passing_no_warning(self):
         """A passing observe-mode postcondition produces no warning."""
         sink = CapturingAuditSink()
-        guard = _make_guard_with_shadow_postconditions(sink)
+        guard = _make_guard_with_observe_postconditions(sink)
 
         result = await guard.run("TestTool", {}, lambda: "clean data")
         assert result == "clean data"

--- a/tests/test_behavior/test_reload_behavior.py
+++ b/tests/test_behavior/test_reload_behavior.py
@@ -152,7 +152,7 @@ class TestReloadWipesInitObserveContracts:
             return Verdict.fail("Observe-mode deny.")
 
         # Mark it as an observe-mode contract (as the composer does)
-        observe_pre._edictum_shadow = True
+        observe_pre._edictum_observe = True
 
         guard = Edictum(
             mode="enforce",
@@ -160,13 +160,13 @@ class TestReloadWipesInitObserveContracts:
             audit_sink=_NullSink(),
         )
 
-        assert len(guard._state.shadow_preconditions) == 1
+        assert len(guard._state.observe_preconditions) == 1
         assert len(guard._state.preconditions) == 0
 
         await guard.reload(BUNDLE_V1)
 
         # reload() replaces _state entirely — init-time Python contracts are wiped
-        assert len(guard._state.shadow_preconditions) == 0
+        assert len(guard._state.observe_preconditions) == 0
         # Enforce contracts come from the new bundle
         assert len(guard._state.preconditions) == 1
 

--- a/tests/test_cli/test_cli_json.py
+++ b/tests/test_cli/test_cli_json.py
@@ -414,4 +414,4 @@ class TestDiffJson:
         # Composition report should be present since bundles share contract IDs
         if "composition" in parsed:
             assert "overrides" in parsed["composition"]
-            assert "shadows" in parsed["composition"]
+            assert "observe_contracts" in parsed["composition"]

--- a/tests/test_from_yaml_multi.py
+++ b/tests/test_from_yaml_multi.py
@@ -217,8 +217,8 @@ class TestObserveAlongside:
         guard, report = Edictum.from_yaml(base, candidate, return_report=True)
 
         # Observe-mode contract should be in the report
-        assert len(report.shadow_contracts) == 1
-        assert report.shadow_contracts[0].contract_id == "block-sensitive-reads"
+        assert len(report.observe_contracts) == 1
+        assert report.observe_contracts[0].contract_id == "block-sensitive-reads"
 
     def test_observe_contracts_in_observe_mode(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)
@@ -232,12 +232,12 @@ class TestObserveAlongside:
         # Observe-mode contracts are routed to separate lists
         env = create_envelope("read_file", {"path": "test.key"})
         preconditions = guard.get_preconditions(env)
-        observe_preconditions = guard.get_shadow_preconditions(env)
+        observe_preconditions = guard.get_observe_preconditions(env)
         # Original precondition in main list
         assert len(preconditions) == 1
         # Observe-mode :candidate in observe list
         assert len(observe_preconditions) == 1
-        assert getattr(observe_preconditions[0], "_edictum_shadow", False) is True
+        assert getattr(observe_preconditions[0], "_edictum_observe", False) is True
 
 
 class TestReturnReport:
@@ -264,7 +264,7 @@ class TestReturnReport:
         assert isinstance(guard, Edictum)
         assert isinstance(report, CompositionReport)
         assert report.overridden_contracts == []
-        assert report.shadow_contracts == []
+        assert report.observe_contracts == []
 
     def test_without_return_report(self, tmp_path):
         base = _write_yaml(tmp_path, "base.yaml", BASE_BUNDLE)

--- a/tests/test_observe_alongside.py
+++ b/tests/test_observe_alongside.py
@@ -272,6 +272,6 @@ class TestNormalContractsRegression:
         enforced_path = tmp_path / "enforced.yaml"
         enforced_path.write_text(ENFORCED_BUNDLE)
         guard = Edictum.from_yaml(enforced_path)
-        assert guard._state.shadow_preconditions == ()
-        assert guard._state.shadow_postconditions == ()
-        assert guard._state.shadow_session_contracts == ()
+        assert guard._state.observe_preconditions == ()
+        assert guard._state.observe_postconditions == ()
+        assert guard._state.observe_session_contracts == ()

--- a/tests/test_yaml_engine/test_composer.py
+++ b/tests/test_yaml_engine/test_composer.py
@@ -263,7 +263,7 @@ class TestObserveAlongside:
         # Internal _shadow field stays as-is (internal attribute)
         observe = [c for c in result.bundle["contracts"] if c["id"] == "pharma:candidate"][0]
         assert observe["mode"] == "observe"
-        assert observe["_shadow"] is True
+        assert observe["_observe"] is True
 
     def test_observe_contract_report(self):
         base = _base_bundle(contracts=[_contract("pharma")])
@@ -271,8 +271,8 @@ class TestObserveAlongside:
         candidate["observe_alongside"] = True
 
         result = compose_bundles((base, "base"), (candidate, "candidate"))
-        assert len(result.report.shadow_contracts) == 1
-        sc = result.report.shadow_contracts[0]
+        assert len(result.report.observe_contracts) == 1
+        sc = result.report.observe_contracts[0]
         assert sc.contract_id == "pharma"
         assert sc.enforced_source == "base"
         assert sc.observed_source == "candidate"
@@ -297,7 +297,7 @@ class TestObserveAlongside:
         assert "existing" in ids
         assert "brand-new:candidate" in ids
 
-        sc = result.report.shadow_contracts[0]
+        sc = result.report.observe_contracts[0]
         assert sc.contract_id == "brand-new"
         assert sc.enforced_source == ""  # no enforced counterpart
 
@@ -321,7 +321,7 @@ class TestObserveAlongside:
         ids = [c["id"] for c in result.bundle["contracts"]]
         assert ids == ["a", "b", "b:candidate"]
         assert len(result.report.overridden_contracts) == 1
-        assert len(result.report.shadow_contracts) == 1
+        assert len(result.report.observe_contracts) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +354,7 @@ class TestComposerEdgeCases:
         ids = [c["id"] for c in result.bundle["contracts"]]
         assert ids == ["x"]
         assert result.bundle["contracts"][0]["then"]["message"] == "new"
-        assert len(result.report.shadow_contracts) == 0
+        assert len(result.report.observe_contracts) == 0
         assert len(result.report.overridden_contracts) == 1
 
     def test_empty_contracts_list_in_overlay(self):
@@ -385,7 +385,7 @@ class TestComposerEdgeCases:
         result = compose_bundles((base, "base"), (candidate, "candidate"))
         ids = [c["id"] for c in result.bundle["contracts"]]
         assert ids == ["a"]
-        assert len(result.report.shadow_contracts) == 0
+        assert len(result.report.observe_contracts) == 0
 
     def test_observe_alongside_as_first_bundle(self):
         """observe_alongside as the first bundle (unusual but valid)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1004,6 +1004,7 @@ all = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "pynacl" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "semantic-kernel" },
@@ -1020,6 +1021,7 @@ crewai = [
 dev = [
     { name = "coverage" },
     { name = "httpx" },
+    { name = "pynacl" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -1049,6 +1051,9 @@ server = [
     { name = "httpx" },
     { name = "httpx-sse" },
 ]
+verified = [
+    { name = "pynacl" },
+]
 yaml = [
     { name = "jsonschema" },
     { name = "pyyaml" },
@@ -1062,7 +1067,7 @@ requires-dist = [
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80" },
     { name = "edictum", extras = ["yaml"], marker = "extra == 'cli'" },
     { name = "edictum", extras = ["yaml", "cli"], marker = "extra == 'gate'" },
-    { name = "edictum", extras = ["yaml", "otel", "cli", "server", "gate", "langchain", "crewai", "agno", "semantic-kernel", "openai-agents"], marker = "extra == 'all'" },
+    { name = "edictum", extras = ["yaml", "otel", "cli", "server", "gate", "verified", "langchain", "crewai", "agno", "semantic-kernel", "openai-agents"], marker = "extra == 'all'" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'gate'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'server'", specifier = ">=0.27" },
@@ -1073,6 +1078,8 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20.0" },
+    { name = "pynacl", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "pynacl", marker = "extra == 'verified'", specifier = ">=1.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
@@ -1080,7 +1087,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "semantic-kernel", marker = "extra == 'semantic-kernel'", specifier = ">=1.39.4" },
 ]
-provides-extras = ["yaml", "otel", "langchain", "crewai", "agno", "semantic-kernel", "openai-agents", "server", "cli", "gate", "all", "dev"]
+provides-extras = ["yaml", "otel", "langchain", "crewai", "agno", "semantic-kernel", "openai-agents", "server", "verified", "cli", "gate", "all", "dev"]
 
 [[package]]
 name = "et-xmlfile"
@@ -3453,6 +3460,41 @@ name = "pymeta3"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/af/409edba35fc597f1e386e3860303791ab5a28d6cc9a8aecbc567051b19a9/PyMeta3-0.5.1.tar.gz", hash = "sha256:18bda326d9a9bbf587bfc0ee0bc96864964d78b067288bcf55d4d98681d05bcb", size = 29566, upload-time = "2015-02-22T16:30:06.858Z" }
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
 
 [[package]]
 name = "pyopenssl"


### PR DESCRIPTION
## Summary

Fixes #126. Renames all `shadow_*` identifiers to `observe_*` across 17 files (115 patterns).

### Key renames
- `_edictum_shadow` → `_edictum_observe`
- `shadow_{preconditions,postconditions,session_contracts,sandbox_contracts}` → `observe_*`
- `get_shadow_*` → `get_observe_*`
- `_evaluate_shadow_contracts` → `_evaluate_observe_contracts`
- `ShadowContract` → `ObserveContract`
- CLI JSON key `"shadows"` → `"observe_contracts"`

### Not renamed
- `/etc/shadow` in `sandbox_compiler.py` (Linux password file, not terminology)

## Test plan

- [x] 2220 tests pass, 0 failures
- [x] `ruff check` clean
- [x] Terminology check passes (check-terminology pre-commit hook)
- [x] No remaining `shadow` references in `src/edictum/` (except `/etc/shadow`)