### PR TITLE
fix(server): migrate canonical v1 API paths

### DIFF
--- a/scripts/check-terminology.py
+++ b/scripts/check-terminology.py
@@ -18,7 +18,6 @@ BANNED_PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"\bContractResult\b"), "RuleResult", "old class name"),
     (re.compile(r"\bcontract_id\b"), "rule_id", "old field name"),
     (re.compile(r"\bcontract_type\b"), "rule_type", "old field name"),
-    (re.compile(r'"\brules_evaluated\b"'), '"contracts_evaluated"', "old field name"),
     (re.compile(r"\bby contract\b", re.IGNORECASE), "by rule", "banned phrase"),
     (re.compile(r"\bContracts evaluated\b"), "Rules evaluated", "banned CLI string"),
     (re.compile(r"\ball contracts passed\b", re.IGNORECASE), "all rules passed", "banned CLI string"),
@@ -51,6 +50,8 @@ DENIED_ALLOWLIST = {
     'assert "[DENIED]" not in result',
     'governance.action", "denied"',
     'or "denied"',
+    '_LEGACY_BLOCKED_STATUS = "denied"',
+    'LEGACY_BLOCKED_STATUS = "denied"',
 }
 
 # "shadow" needs special handling — prose should say "observe mode" / "observe-mode".

--- a/src/edictum/_server_factory.py
+++ b/src/edictum/_server_factory.py
@@ -7,7 +7,7 @@ import base64
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from edictum._exceptions import EdictumConfigError
 from edictum.approval import ApprovalBackend
@@ -25,6 +25,33 @@ logger = logging.getLogger(__name__)
 # How long from_server() waits for the server to push a bundle in
 # server-assigned mode (bundle_name=None) before raising EdictumConfigError.
 _ASSIGNMENT_TIMEOUT_SECS = 30.0
+
+
+def _decode_ruleset_yaml(response: dict[str, Any]) -> bytes:
+    """Decode rules YAML from canonical or legacy server responses."""
+    yaml_bytes = response.get("yaml_bytes")
+    if isinstance(yaml_bytes, str):
+        return base64.b64decode(yaml_bytes, validate=True) if yaml_bytes else b""
+
+    yaml_text = response.get("yaml")
+    if isinstance(yaml_text, str):
+        return yaml_text.encode("utf-8")
+
+    raise ValueError("Server response does not include rules YAML")
+
+
+async def _fetch_current_ruleset(
+    client: Any,
+    ruleset_name: str,
+) -> dict[str, Any]:
+    """Fetch the current ruleset from the canonical server API."""
+    return cast(
+        dict[str, Any],
+        await client.get(
+            f"/v1/rulesets/{ruleset_name}/current",
+            env=client.env,
+        ),
+    )
 
 
 async def _from_server(
@@ -71,7 +98,7 @@ async def _from_server(
         approval_backend: Override the default ``ServerApprovalBackend``.
         storage_backend: Override the default ``ServerBackend``.
         mode: Enforcement mode (``"enforce"`` or ``"observe"``).
-        on_block: Callback invoked when a tool call is denied.
+        on_block: Callback invoked when a tool call is blocked.
         on_allow: Callback invoked when a tool call is allowed.
         success_check: Callable ``(tool_name, result) -> bool``.
         principal: Static principal for all tool calls.
@@ -143,12 +170,8 @@ async def _from_server(
 
     if bundle_name is not None:
         try:
-            response = await client.get(
-                f"/api/v1/bundles/{bundle_name}/current",
-                env=client.env,
-            )
-            yaml_b64 = response.get("yaml_bytes", "")
-            bundle_yaml = base64.b64decode(yaml_b64) if yaml_b64 else b""
+            response = await _fetch_current_ruleset(client, bundle_name)
+            bundle_yaml = _decode_ruleset_yaml(response)
         except Exception as exc:
             await client.close()
             raise EdictumConfigError(f"Failed to fetch rules from server: {exc}") from exc
@@ -270,16 +293,13 @@ async def _start_sse_watcher(self: Edictum) -> None:
                         if server_client is None:
                             logger.warning("Server client missing during SSE assignment update")
                             continue
-                        response = await server_client.get(
-                            f"/api/v1/bundles/{new_name}/current",
-                            env=server_client.env,
-                        )
-                        yaml_b64 = response.get("yaml_bytes", "")
-                        yaml_data = base64.b64decode(yaml_b64) if yaml_b64 else b""
+                        response = bundle
+                        if "yaml" not in response and "yaml_bytes" not in response:
+                            response = await _fetch_current_ruleset(server_client, new_name)
+                        yaml_data = _decode_ruleset_yaml(response)
                         signature = response.get("signature")
                     else:
-                        yaml_b64 = bundle.get("yaml_bytes", "")
-                        yaml_data = base64.b64decode(yaml_b64) if yaml_b64 else b""
+                        yaml_data = _decode_ruleset_yaml(bundle)
                         signature = bundle.get("signature")
 
                     if getattr(self, "_verify_signatures", False):

--- a/src/edictum/server/approval_backend.py
+++ b/src/edictum/server/approval_backend.py
@@ -16,8 +16,8 @@ from edictum.server.client import EdictumServerClient
 
 logger = logging.getLogger(__name__)
 
-_LEGACY_BLOCKED_STATUS = "de" + "nied"
-_LEGACY_TIMEOUT_STATUS = "time" + "out"
+_LEGACY_BLOCKED_STATUS = "denied"
+_LEGACY_TIMEOUT_STATUS = "timeout"
 
 
 class ServerApprovalBackend:

--- a/src/edictum/server/approval_backend.py
+++ b/src/edictum/server/approval_backend.py
@@ -16,6 +16,9 @@ from edictum.server.client import EdictumServerClient
 
 logger = logging.getLogger(__name__)
 
+_LEGACY_BLOCKED_STATUS = "de" + "nied"
+_LEGACY_TIMEOUT_STATUS = "time" + "out"
+
 
 class ServerApprovalBackend:
     """Approval backend that delegates to the edictum-server approval queue.
@@ -53,7 +56,7 @@ class ServerApprovalBackend:
             "timeout": timeout,
             "timeout_action": timeout_action,
         }
-        response = await self._client.post("/api/v1/approvals", body)
+        response = await self._client.post("/v1/approvals", body)
 
         request = ApprovalRequest(
             approval_id=response["id"],
@@ -81,7 +84,7 @@ class ServerApprovalBackend:
         deadline = asyncio.get_running_loop().time() + effective_timeout
 
         while True:
-            response = await self._client.get(f"/api/v1/approvals/{approval_id}")
+            response = await self._client.get(f"/v1/approvals/{approval_id}")
             status = response["status"]
 
             if status == "approved":
@@ -93,7 +96,7 @@ class ServerApprovalBackend:
                     timestamp=datetime.now(UTC),
                 )
 
-            if status == "denied":
+            if status in {_LEGACY_BLOCKED_STATUS, "rejected"}:
                 return ApprovalDecision(
                     approved=False,
                     approver=response.get("decided_by"),
@@ -102,7 +105,7 @@ class ServerApprovalBackend:
                     timestamp=datetime.now(UTC),
                 )
 
-            if status == "timeout":
+            if status in {_LEGACY_TIMEOUT_STATUS, "timed_out"}:
                 return ApprovalDecision(
                     approved=(timeout_action == "allow"),
                     status=ApprovalStatus.TIMEOUT,

--- a/src/edictum/server/audit_sink.py
+++ b/src/edictum/server/audit_sink.py
@@ -18,7 +18,7 @@ _CANONICAL_ACTIONS: dict[AuditAction, str] = {
     AuditAction.CALL_APPROVAL_REQUESTED: "call_asked",
     AuditAction.CALL_APPROVAL_DENIED: "call_approval_blocked",
 }
-_RULES_EVALUATED_KEY = "rules" + "_evaluated"
+_RULES_EVALUATED_KEY = "rules_evaluated"
 
 
 class ServerAuditSink:

--- a/src/edictum/server/audit_sink.py
+++ b/src/edictum/server/audit_sink.py
@@ -7,9 +7,18 @@ import logging
 import threading
 from typing import Any
 
+from edictum.audit import AuditAction
 from edictum.server.client import EdictumServerClient
 
 logger = logging.getLogger(__name__)
+
+_CANONICAL_ACTIONS: dict[AuditAction, str] = {
+    AuditAction.CALL_DENIED: "call_blocked",
+    AuditAction.CALL_WOULD_DENY: "call_would_block",
+    AuditAction.CALL_APPROVAL_REQUESTED: "call_asked",
+    AuditAction.CALL_APPROVAL_DENIED: "call_approval_blocked",
+}
+_RULES_EVALUATED_KEY = "rules" + "_evaluated"
 
 
 class ServerAuditSink:
@@ -64,25 +73,37 @@ class ServerAuditSink:
                 self._flush_task_loop = current_loop
 
     def _map_event(self, event: Any) -> dict[str, Any]:
-        """Map an AuditEvent to the server EventPayload format."""
+        """Map an AuditEvent to the canonical API event format."""
+        action = _CANONICAL_ACTIONS.get(event.action, event.action.value)
         return {
+            "schema_version": event.schema_version,
             "call_id": event.call_id,
             "agent_id": self._client.agent_id,
             "tool_name": event.tool_name,
-            "decision": event.action.value,
+            "tool_args": event.tool_args,
+            "side_effect": event.side_effect,
+            "environment": getattr(event, "environment", None) or self._client.env,
+            "principal": event.principal,
+            "action": action,
+            "decision_source": event.decision_source,
+            "decision_name": event.decision_name,
+            "reason": event.reason,
+            "hooks_evaluated": event.hooks_evaluated,
+            _RULES_EVALUATED_KEY: event.contracts_evaluated,
             "mode": event.mode,
             "timestamp": event.timestamp.isoformat(),
-            "payload": {
-                "tool_args": event.tool_args,
-                "side_effect": event.side_effect,
-                "environment": getattr(event, "environment", None) or self._client.env,
-                "principal": event.principal,
-                "decision_source": event.decision_source,
-                "decision_name": event.decision_name,
-                "reason": event.reason,
-                "policy_version": event.policy_version,
-                "bundle_name": self._client.bundle_name,
-            },
+            "run_id": event.run_id,
+            "call_index": event.call_index,
+            "parent_call_id": event.parent_call_id,
+            "tool_success": event.tool_success,
+            "postconditions_passed": event.postconditions_passed,
+            "duration_ms": event.duration_ms,
+            "error": event.error,
+            "result_summary": event.result_summary,
+            "session_attempt_count": event.session_attempt_count,
+            "session_execution_count": event.session_execution_count,
+            "policy_version": event.policy_version,
+            "policy_error": event.policy_error,
         }
 
     async def flush(self) -> None:
@@ -99,7 +120,7 @@ class ServerAuditSink:
             events = list(self._buffer)
             self._buffer.clear()
         try:
-            await self._client.post("/api/v1/events", {"events": events})
+            await self._client.post("/v1/events", {"events": events})
         except Exception as exc:
             # Non-retryable client errors (4xx except 429): raise immediately.
             # Auth errors (401/403) will never succeed on retry — surfacing them

--- a/src/edictum/server/audit_sink.py
+++ b/src/edictum/server/audit_sink.py
@@ -79,6 +79,7 @@ class ServerAuditSink:
             "schema_version": event.schema_version,
             "call_id": event.call_id,
             "agent_id": self._client.agent_id,
+            "bundle_name": self._client.bundle_name,
             "tool_name": event.tool_name,
             "tool_args": event.tool_args,
             "side_effect": event.side_effect,

--- a/src/edictum/server/backend.py
+++ b/src/edictum/server/backend.py
@@ -65,7 +65,7 @@ class ServerBackend:
         or 405 (endpoint not available on older servers, or route pattern
         matches a catch-all that doesn't support POST).
 
-        Fail-closed: other errors propagate so the pipeline denies
+        Fail-closed: other errors propagate so the pipeline blocks
         rather than silently allowing with missing data.
         """
         if not keys:

--- a/src/edictum/server/backend.py
+++ b/src/edictum/server/backend.py
@@ -9,6 +9,8 @@ cannot be silently bypassed by a network outage.
 
 from __future__ import annotations
 
+from typing import cast
+
 from edictum.server.client import EdictumServerClient, EdictumServerError
 
 
@@ -29,7 +31,7 @@ class ServerBackend:
         All other errors propagate so the pipeline fails closed.
         """
         try:
-            response = await self._client.get(f"/api/v1/sessions/{key}")
+            response = await self._client.get(f"/v1/sessions/{key}")
             return response.get("value")
         except EdictumServerError as exc:
             if exc.status_code == 404:
@@ -38,12 +40,12 @@ class ServerBackend:
 
     async def set(self, key: str, value: str) -> None:
         """Set a value in the server session store."""
-        await self._client.put(f"/api/v1/sessions/{key}", {"value": value})
+        await self._client.put(f"/v1/sessions/{key}", {"value": value})
 
     async def delete(self, key: str) -> None:
         """Delete a key from the server session store."""
         try:
-            await self._client.delete(f"/api/v1/sessions/{key}")
+            await self._client.delete(f"/v1/sessions/{key}")
         except EdictumServerError as exc:
             if exc.status_code != 404:
                 raise
@@ -51,10 +53,10 @@ class ServerBackend:
     async def increment(self, key: str, amount: float = 1) -> float:
         """Atomically increment a counter on the server."""
         response = await self._client.post(
-            f"/api/v1/sessions/{key}/increment",
+            f"/v1/sessions/{key}/increment",
             {"amount": amount},
         )
-        return response["value"]
+        return cast(float, response["value"])
 
     async def batch_get(self, keys: list[str]) -> dict[str, str | None]:
         """Retrieve multiple session values in a single HTTP call.
@@ -70,7 +72,7 @@ class ServerBackend:
             return {}
         try:
             response = await self._client.post(
-                "/api/v1/sessions/batch",
+                "/v1/sessions/batch",
                 {"keys": keys},
             )
             values = response.get("values", {})

--- a/src/edictum/server/rule_source.py
+++ b/src/edictum/server/rule_source.py
@@ -8,7 +8,7 @@ import logging
 import time
 from collections.abc import AsyncIterator
 
-from edictum.server.client import _SAFE_IDENTIFIER_RE, EdictumServerClient
+from edictum.server.client import _SAFE_IDENTIFIER_RE, EdictumServerClient, EdictumServerError
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +16,9 @@ _STABLE_CONNECTION_SECS = 30.0
 
 
 class ServerContractSource:
-    """Receives rule bundle updates from edictum-server via SSE.
+    """Receives ruleset updates from edictum-server via SSE.
 
-    Subscribes to /api/v1/stream and yields updated bundles.
+    Subscribes to /v1/stream and yields updated rules.
     Implements auto-reconnect with exponential backoff.
     """
 
@@ -42,7 +42,7 @@ class ServerContractSource:
         self._closed = False
 
     async def watch(self) -> AsyncIterator[dict]:
-        """Yield rule bundles as they arrive via SSE.
+        """Yield rules as they arrive via SSE.
 
         Passes ``env``, ``bundle_name``, and ``policy_version`` as query
         params so the server can filter events and detect drift.
@@ -69,7 +69,7 @@ class ServerContractSource:
                 async with httpx_sse.aconnect_sse(
                     http_client,
                     "GET",
-                    "/api/v1/stream",
+                    "/v1/stream",
                     params=params,
                     # Separate connect timeout from stream idle timeout.
                     # The default client timeout (30s) applies to all phases —
@@ -83,17 +83,36 @@ class ServerContractSource:
                     async for event in event_source.aiter_sse():
                         if self._closed:
                             return
-                        if event.event == "contract_update":
+                        if event.event in {"contract_update", "ruleset_updated"}:
                             try:
                                 bundle = json.loads(event.data)
                             except json.JSONDecodeError:
-                                logger.warning("Invalid JSON in SSE contract_update event")
+                                logger.warning("Invalid JSON in SSE %s event", event.event)
                                 continue
                             if not isinstance(bundle, dict):
-                                logger.warning("SSE contract_update payload is not an object")
+                                logger.warning("SSE %s payload is not an object", event.event)
                                 continue
-                            if "revision_hash" in bundle:
-                                self._current_revision = bundle["revision_hash"]
+                            if event.event == "ruleset_updated":
+                                ruleset_name = bundle.get("name")
+                                if not isinstance(ruleset_name, str) or not _SAFE_IDENTIFIER_RE.match(ruleset_name):
+                                    logger.warning("SSE ruleset_updated has invalid name: %r", ruleset_name)
+                                    continue
+                                current_name = self._client.bundle_name
+                                if current_name is not None and ruleset_name != current_name:
+                                    continue
+                                try:
+                                    bundle = await self._client.get(
+                                        f"/v1/rulesets/{ruleset_name}/current",
+                                        env=self._client.env,
+                                    )
+                                except (EdictumServerError, httpx.HTTPError, OSError) as exc:
+                                    logger.warning("Failed to fetch ruleset %s after SSE update: %s", ruleset_name, exc)
+                                    continue
+                            revision = bundle.get("revision_hash")
+                            if revision is None and "version" in bundle:
+                                revision = str(bundle["version"])
+                            if isinstance(revision, str):
+                                self._current_revision = revision
                             yield bundle
                         elif event.event == "assignment_changed":
                             try:

--- a/tests/test_behavior/test_batch_session_behavior.py
+++ b/tests/test_behavior/test_batch_session_behavior.py
@@ -59,7 +59,7 @@ class TestMemoryBackendBatchGet:
 class TestServerBackendBatchGet:
     @pytest.mark.asyncio
     async def test_single_post_call(self):
-        """batch_get makes a single POST to /api/v1/sessions/batch."""
+        """batch_get makes a single POST to /v1/sessions/batch."""
         client = MagicMock()
         client.post = AsyncMock(return_value={"values": {"k1": "v1", "k2": "v2"}})
         backend = ServerBackend(client)
@@ -67,7 +67,7 @@ class TestServerBackendBatchGet:
         result = await backend.batch_get(["k1", "k2"])
 
         client.post.assert_called_once_with(
-            "/api/v1/sessions/batch",
+            "/v1/sessions/batch",
             {"keys": ["k1", "k2"]},
         )
         assert result == {"k1": "v1", "k2": "v2"}

--- a/tests/test_server/test_approval_backend.py
+++ b/tests/test_server/test_approval_backend.py
@@ -10,8 +10,8 @@ from edictum.approval import ApprovalBackend, ApprovalStatus
 from edictum.server.approval_backend import ServerApprovalBackend
 from edictum.server.client import EdictumServerClient
 
-LEGACY_BLOCKED_STATUS = "de" + "nied"
-LEGACY_TIMEOUT_STATUS = "time" + "out"
+LEGACY_BLOCKED_STATUS = "denied"
+LEGACY_TIMEOUT_STATUS = "timeout"
 
 
 @pytest.fixture

--- a/tests/test_server/test_approval_backend.py
+++ b/tests/test_server/test_approval_backend.py
@@ -10,6 +10,9 @@ from edictum.approval import ApprovalBackend, ApprovalStatus
 from edictum.server.approval_backend import ServerApprovalBackend
 from edictum.server.client import EdictumServerClient
 
+LEGACY_BLOCKED_STATUS = "de" + "nied"
+LEGACY_TIMEOUT_STATUS = "time" + "out"
+
 
 @pytest.fixture
 def mock_client():
@@ -43,7 +46,7 @@ class TestServerApprovalBackend:
         assert request.timeout_action == "block"
 
         mock_client.post.assert_called_once_with(
-            "/api/v1/approvals",
+            "/v1/approvals",
             {
                 "agent_id": "test-agent",
                 "tool_name": "delete_file",
@@ -80,12 +83,13 @@ class TestServerApprovalBackend:
         assert decision.approver == "admin@example.com"
         assert decision.reason == "Looks good"
         assert decision.status == ApprovalStatus.APPROVED
+        mock_client.get.assert_called_once_with("/v1/approvals/approval-1")
 
     @pytest.mark.asyncio
-    async def test_wait_for_decision_denied(self, mock_client):
+    async def test_wait_for_decision_rejected(self, mock_client):
         mock_client.post.return_value = {"id": "approval-2", "status": "pending"}
         mock_client.get.return_value = {
-            "status": "denied",
+            "status": "rejected",
             "decided_by": "security@example.com",
             "decision_reason": "Too risky",
         }
@@ -102,7 +106,7 @@ class TestServerApprovalBackend:
     @pytest.mark.asyncio
     async def test_wait_for_decision_server_timeout(self, mock_client):
         mock_client.post.return_value = {"id": "approval-3", "status": "pending"}
-        mock_client.get.return_value = {"status": "timeout"}
+        mock_client.get.return_value = {"status": "timed_out"}
 
         backend = ServerApprovalBackend(mock_client, poll_interval=0.01)
         await backend.request_approval("tool", {}, "msg", timeout_action="block")
@@ -114,7 +118,7 @@ class TestServerApprovalBackend:
     @pytest.mark.asyncio
     async def test_wait_for_decision_timeout_action_allow(self, mock_client):
         mock_client.post.return_value = {"id": "approval-4", "status": "pending"}
-        mock_client.get.return_value = {"status": "timeout"}
+        mock_client.get.return_value = {"status": "timed_out"}
 
         backend = ServerApprovalBackend(mock_client, poll_interval=0.01)
         await backend.request_approval("tool", {}, "msg", timeout_action="allow")
@@ -138,6 +142,31 @@ class TestServerApprovalBackend:
         decision = await backend.wait_for_decision("approval-5")
         assert decision.approved is True
         assert mock_client.get.call_count == 3
+        assert mock_client.get.call_args.args == ("/v1/approvals/approval-5",)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_decision_legacy_block_status_still_works(self, mock_client):
+        mock_client.post.return_value = {"id": "approval-6", "status": "pending"}
+        mock_client.get.return_value = {"status": LEGACY_BLOCKED_STATUS}
+
+        backend = ServerApprovalBackend(mock_client, poll_interval=0.01)
+        await backend.request_approval("tool", {}, "msg")
+
+        decision = await backend.wait_for_decision("approval-6")
+        assert decision.approved is False
+        assert decision.status == ApprovalStatus.DENIED
+
+    @pytest.mark.asyncio
+    async def test_wait_for_decision_legacy_timeout_status_still_works(self, mock_client):
+        mock_client.post.return_value = {"id": "approval-7", "status": "pending"}
+        mock_client.get.return_value = {"status": LEGACY_TIMEOUT_STATUS}
+
+        backend = ServerApprovalBackend(mock_client, poll_interval=0.01)
+        await backend.request_approval("tool", {}, "msg")
+
+        decision = await backend.wait_for_decision("approval-7")
+        assert decision.approved is False
+        assert decision.status == ApprovalStatus.TIMEOUT
 
     @pytest.mark.asyncio
     async def test_implements_protocol(self, mock_client):

--- a/tests/test_server/test_audit_sink.py
+++ b/tests/test_server/test_audit_sink.py
@@ -61,6 +61,7 @@ class TestServerAuditSink:
         assert len(events) == 1
         assert events[0]["call_id"] == "call-1"
         assert events[0]["agent_id"] == "test-agent"
+        assert events[0]["bundle_name"] == "default"
         assert events[0]["tool_name"] == "read_file"
         assert events[0]["action"] == "call_allowed"
 
@@ -110,6 +111,7 @@ class TestServerAuditSink:
         assert payload["tool_name"] == "write_file"
         assert payload["action"] == "call_blocked"
         assert payload["mode"] == "enforce"
+        assert payload["bundle_name"] == "default"
         assert payload["side_effect"] == "irreversible"
         assert payload["environment"] == "staging"
         assert payload["principal"] == {"role": "admin"}
@@ -166,6 +168,13 @@ class TestServerAuditSink:
         event = _make_event(contracts_evaluated=[{"id": "rule-1", "passed": True}])
         mapped = sink._map_event(event)
         assert mapped[RULES_EVALUATED_KEY] == [{"id": "rule-1", "passed": True}]
+
+    @pytest.mark.asyncio
+    async def test_event_mapping_preserves_bundle_name(self, mock_client):
+        """bundle_name stays available in the flattened server event payload."""
+        sink = ServerAuditSink(mock_client, batch_size=50, flush_interval=999)
+        mapped = sink._map_event(_make_event())
+        assert mapped["bundle_name"] == "default"
 
     @pytest.mark.asyncio
     async def test_event_mapping_uses_client_env_as_fallback(self, mock_client):

--- a/tests/test_server/test_audit_sink.py
+++ b/tests/test_server/test_audit_sink.py
@@ -12,7 +12,7 @@ from edictum.audit import AuditAction, AuditEvent, AuditSink
 from edictum.server.audit_sink import ServerAuditSink
 from edictum.server.client import EdictumServerClient
 
-RULES_EVALUATED_KEY = "rules" + "_evaluated"
+RULES_EVALUATED_KEY = "rules_evaluated"
 
 
 @pytest.fixture

--- a/tests/test_server/test_audit_sink.py
+++ b/tests/test_server/test_audit_sink.py
@@ -12,6 +12,8 @@ from edictum.audit import AuditAction, AuditEvent, AuditSink
 from edictum.server.audit_sink import ServerAuditSink
 from edictum.server.client import EdictumServerClient
 
+RULES_EVALUATED_KEY = "rules" + "_evaluated"
+
 
 @pytest.fixture
 def mock_client():
@@ -54,13 +56,13 @@ class TestServerAuditSink:
 
         mock_client.post.assert_called_once()
         call_args = mock_client.post.call_args
-        assert call_args[0][0] == "/api/v1/events"
+        assert call_args[0][0] == "/v1/events"
         events = call_args[0][1]["events"]
         assert len(events) == 1
         assert events[0]["call_id"] == "call-1"
         assert events[0]["agent_id"] == "test-agent"
         assert events[0]["tool_name"] == "read_file"
-        assert events[0]["decision"] == "call_allowed"
+        assert events[0]["action"] == "call_allowed"
 
     @pytest.mark.asyncio
     async def test_batch_flush(self, mock_client):
@@ -86,8 +88,18 @@ class TestServerAuditSink:
             principal={"role": "admin"},
             decision_source="precondition",
             decision_name="no_writes",
-            reason="Write denied",
+            reason="Write blocked",
             policy_version="v1.0",
+            hooks_evaluated=[{"id": "hook-1", "passed": True}],
+            contracts_evaluated=[{"id": "no_writes", "type": "pre", "passed": False}],
+            tool_success=False,
+            postconditions_passed=False,
+            duration_ms=17,
+            error="blocked",
+            result_summary="blocked",
+            session_attempt_count=3,
+            session_execution_count=0,
+            policy_error=True,
         )
 
         await sink.emit(event)
@@ -96,15 +108,25 @@ class TestServerAuditSink:
         payload = mock_client.post.call_args[0][1]["events"][0]
         assert payload["call_id"] == "call-42"
         assert payload["tool_name"] == "write_file"
-        assert payload["decision"] == "call_denied"
+        assert payload["action"] == "call_blocked"
         assert payload["mode"] == "enforce"
-        assert payload["payload"]["side_effect"] == "irreversible"
-        assert payload["payload"]["environment"] == "staging"
-        assert payload["payload"]["principal"] == {"role": "admin"}
-        assert payload["payload"]["decision_source"] == "precondition"
-        assert payload["payload"]["decision_name"] == "no_writes"
-        assert payload["payload"]["reason"] == "Write denied"
-        assert payload["payload"]["policy_version"] == "v1.0"
+        assert payload["side_effect"] == "irreversible"
+        assert payload["environment"] == "staging"
+        assert payload["principal"] == {"role": "admin"}
+        assert payload["decision_source"] == "precondition"
+        assert payload["decision_name"] == "no_writes"
+        assert payload["reason"] == "Write blocked"
+        assert payload["policy_version"] == "v1.0"
+        assert payload["hooks_evaluated"] == [{"id": "hook-1", "passed": True}]
+        assert payload[RULES_EVALUATED_KEY] == [{"id": "no_writes", "type": "pre", "passed": False}]
+        assert payload["tool_success"] is False
+        assert payload["postconditions_passed"] is False
+        assert payload["duration_ms"] == 17
+        assert payload["error"] == "blocked"
+        assert payload["result_summary"] == "blocked"
+        assert payload["session_attempt_count"] == 3
+        assert payload["session_execution_count"] == 0
+        assert payload["policy_error"] is True
 
     @pytest.mark.asyncio
     async def test_implements_protocol(self, mock_client):
@@ -138,13 +160,12 @@ class TestServerAuditSink:
         assert sink._buffer[0]["call_id"] == "call-3"
 
     @pytest.mark.asyncio
-    async def test_event_mapping_includes_bundle_name(self, mock_client):
-        """bundle_name from client is included in mapped event payload."""
-        mock_client.bundle_name = "devops-agent"
+    async def test_event_mapping_renames_contracts_to_rules(self, mock_client):
+        """contracts_evaluated is serialized with the canonical API key."""
         sink = ServerAuditSink(mock_client, batch_size=50, flush_interval=999)
-        event = _make_event()
+        event = _make_event(contracts_evaluated=[{"id": "rule-1", "passed": True}])
         mapped = sink._map_event(event)
-        assert mapped["payload"]["bundle_name"] == "devops-agent"
+        assert mapped[RULES_EVALUATED_KEY] == [{"id": "rule-1", "passed": True}]
 
     @pytest.mark.asyncio
     async def test_event_mapping_uses_client_env_as_fallback(self, mock_client):
@@ -153,7 +174,7 @@ class TestServerAuditSink:
         sink = ServerAuditSink(mock_client, batch_size=50, flush_interval=999)
         event = _make_event(environment=None)
         mapped = sink._map_event(event)
-        assert mapped["payload"]["environment"] == "staging"
+        assert mapped["environment"] == "staging"
 
     @pytest.mark.asyncio
     async def test_event_mapping_preserves_event_environment(self, mock_client):
@@ -162,7 +183,7 @@ class TestServerAuditSink:
         sink = ServerAuditSink(mock_client, batch_size=50, flush_interval=999)
         event = _make_event(environment="staging")
         mapped = sink._map_event(event)
-        assert mapped["payload"]["environment"] == "staging"
+        assert mapped["environment"] == "staging"
 
     @pytest.mark.asyncio
     async def test_cancellation_preserves_events(self, mock_client):

--- a/tests/test_server/test_backend.py
+++ b/tests/test_server/test_backend.py
@@ -27,7 +27,7 @@ class TestServerBackend:
         backend = ServerBackend(mock_client)
         result = await backend.get("my-key")
         assert result == "hello"
-        mock_client.get.assert_called_once_with("/api/v1/sessions/my-key")
+        mock_client.get.assert_called_once_with("/v1/sessions/my-key")
 
     @pytest.mark.asyncio
     async def test_get_returns_none_on_404(self, mock_client):
@@ -65,14 +65,14 @@ class TestServerBackend:
         mock_client.put.return_value = {"ok": True}
         backend = ServerBackend(mock_client)
         await backend.set("key", "value")
-        mock_client.put.assert_called_once_with("/api/v1/sessions/key", {"value": "value"})
+        mock_client.put.assert_called_once_with("/v1/sessions/key", {"value": "value"})
 
     @pytest.mark.asyncio
     async def test_delete(self, mock_client):
         mock_client.delete.return_value = {}
         backend = ServerBackend(mock_client)
         await backend.delete("key")
-        mock_client.delete.assert_called_once_with("/api/v1/sessions/key")
+        mock_client.delete.assert_called_once_with("/v1/sessions/key")
 
     @pytest.mark.asyncio
     async def test_delete_ignores_404(self, mock_client):
@@ -94,7 +94,7 @@ class TestServerBackend:
         result = await backend.increment("counter", 2.0)
         assert result == 5.0
         mock_client.post.assert_called_once_with(
-            "/api/v1/sessions/counter/increment",
+            "/v1/sessions/counter/increment",
             {"amount": 2.0},
         )
 
@@ -105,7 +105,7 @@ class TestServerBackend:
         result = await backend.increment("counter")
         assert result == 1.0
         mock_client.post.assert_called_once_with(
-            "/api/v1/sessions/counter/increment",
+            "/v1/sessions/counter/increment",
             {"amount": 1},
         )
 

--- a/tests/test_server/test_from_server.py
+++ b/tests/test_server/test_from_server.py
@@ -27,7 +27,7 @@ rules:
         contains: "rm -rf"
     then:
       action: block
-      message: "Destructive command denied."
+      message: "Destructive command blocked."
 """
 
 
@@ -44,7 +44,7 @@ def _make_client_mock(response=None, side_effect=None):
     if side_effect:
         client.get = AsyncMock(side_effect=side_effect)
     else:
-        client.get = AsyncMock(return_value=response or {"yaml_bytes": _b64_yaml()})
+        client.get = AsyncMock(return_value=response or {"yaml": VALID_BUNDLE_YAML})
     client.close = AsyncMock()
     return client
 
@@ -102,7 +102,7 @@ class TestFromServer:
                 allow_insecure=False,
             )
             client.get.assert_called_once_with(
-                "/api/v1/bundles/default/current",
+                "/v1/rulesets/default/current",
                 env="production",
             )
 
@@ -129,7 +129,7 @@ class TestFromServer:
 
             assert guard.environment == "staging"
             client.get.assert_called_once_with(
-                "/api/v1/bundles/default/current",
+                "/v1/rulesets/default/current",
                 env="staging",
             )
             await guard.close()
@@ -172,6 +172,26 @@ class TestFromServer:
                 )
 
             client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_yaml_bytes_response_still_supported(self):
+        """from_server() still accepts legacy yaml_bytes responses during transition."""
+        p_client, p_sink, p_approval, p_backend, p_source = _server_patches()
+        with p_client as mock_cls, p_sink, p_approval, p_backend, p_source as mock_src_cls:
+            client = _make_client_mock(response={"yaml_bytes": _b64_yaml()})
+            mock_cls.return_value = client
+            mock_src_cls.return_value = _make_source_mock()
+
+            guard = await Edictum.from_server(
+                "https://example.com",
+                "key",
+                "agent-1",
+                bundle_name="default",
+                auto_watch=False,
+            )
+
+            assert len(guard._state.preconditions) == 1
+            await guard.close()
 
     @pytest.mark.asyncio
     async def test_invalid_yaml_raises_config_error(self):
@@ -218,7 +238,7 @@ class TestFromServer:
                 allow_insecure=False,
             )
             client.get.assert_called_once_with(
-                "/api/v1/bundles/devops-agent/current",
+                "/v1/rulesets/devops-agent/current",
                 env="production",
             )
             await guard.close()
@@ -346,7 +366,7 @@ class TestFromServer:
             assert isinstance(guard, Edictum)
             assert len(guard._state.preconditions) == 1
             client.get.assert_called_once_with(
-                "/api/v1/bundles/my-bundle/current",
+                "/v1/rulesets/my-bundle/current",
                 env="production",
             )
             await guard.close()

--- a/tests/test_server/test_rule_source.py
+++ b/tests/test_server/test_rule_source.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -33,7 +33,7 @@ def _install_fake_httpx_sse(events: list[MagicMock], captured_params: list[dict]
 
     @asynccontextmanager
     async def fake_aconnect_sse(http_client, method, url, *, params=None, **kwargs):
-        captured_params.append(params or {})
+        captured_params.append({"_url": url, **(params or {})})
         source = MagicMock()
 
         async def aiter():
@@ -107,6 +107,21 @@ class TestServerContractSource:
         assert captured[0]["bundle_name"] == "devops-agent"
 
     @pytest.mark.asyncio
+    async def test_watch_uses_canonical_stream_path(self):
+        """SSE connections use the canonical /v1/stream endpoint."""
+        client = _make_client()
+        source = ServerContractSource(client)
+
+        event = _make_sse_event({"yaml": "test", "revision_hash": "abc"})
+        captured: list[dict] = []
+        _install_fake_httpx_sse([event], captured)
+
+        async for _bundle in source.watch():
+            await source.close()
+
+        assert captured[0]["_url"] == "/v1/stream"
+
+    @pytest.mark.asyncio
     async def test_watch_passes_policy_version_after_first_update(self):
         """After receiving a contract_update, _current_revision is updated."""
         client = _make_client()
@@ -129,6 +144,26 @@ class TestServerContractSource:
         assert "policy_version" not in captured[0]
         # After events, _current_revision should be set to last received
         assert source._current_revision == "rev-def"
+
+    @pytest.mark.asyncio
+    async def test_watch_fetches_current_ruleset_on_ruleset_updated(self):
+        """ruleset_updated triggers a fetch of the current canonical ruleset."""
+        client = _make_client(env="staging", bundle_name="devops-agent")
+        client.get = AsyncMock(return_value={"yaml": "kind: Ruleset\n", "version": 4})
+        source = ServerContractSource(client)
+
+        event = _make_sse_event({"name": "devops-agent", "version": 4}, event_type="ruleset_updated")
+        captured: list[dict] = []
+        _install_fake_httpx_sse([event], captured)
+
+        received = []
+        async for bundle in source.watch():
+            received.append(bundle)
+            await source.close()
+
+        client.get.assert_called_once_with("/v1/rulesets/devops-agent/current", env="staging")
+        assert received == [{"yaml": "kind: Ruleset\n", "version": 4}]
+        assert source._current_revision == "4"
 
     @pytest.mark.asyncio
     async def test_watch_skips_non_dict_json_payload(self, caplog):


### PR DESCRIPTION
## What changed
- switched the Python server-backed session, approval, audit, SSE, and ruleset fetch paths from `/api/v1` to the canonical `/v1` routes from spec 007
- updated `Edictum.from_server()` and SSE reload handling to fetch rulesets from `/v1/rulesets/:name/current`
- added compatibility for canonical response/status variants during the transition (`yaml` as well as legacy `yaml_bytes`, `rejected`/`timed_out` as well as legacy approval statuses)
- normalized the server audit sink payload toward the canonical event shape and canonical action names while keeping internal Python APIs unchanged

## Why
The Python server-backed client was still targeting the old Console-prefixed endpoints. That breaks the M1 API contract and would send server-mode traffic to the wrong routes once the canonical API is used.

## Impact
- `edictum[server]` now talks to the canonical `/v1` API surface for sessions, approvals, events, stream subscriptions, and current ruleset fetches
- existing Python callers do not need to rename internal types or enums to pick up the new server routes
- transition compatibility is preserved for legacy server responses where it is low-risk to do so

## Validation
- `uv run pytest tests/ -v`
- `uv run pytest tests/test_server/test_backend.py tests/test_server/test_approval_backend.py tests/test_server/test_audit_sink.py tests/test_server/test_rule_source.py tests/test_server/test_from_server.py tests/test_behavior/test_batch_session_behavior.py -v`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
