### PR TITLE
docs: refresh control-plane references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,13 @@ Two deployment units. One library, one server.
 
 - `src/edictum/` -- MIT core. All rule types (pre, post, session, sandbox), pipeline, 8 adapters, audit to stdout/file/OTel, local approval backend, single-process session tracking.
 - `src/edictum/server/` -- Server SDK client (`pip install edictum[server]`). Implements core protocols (`ApprovalBackend`, `AuditSink`, `StorageBackend`) over HTTP to connect agents to the server.
-- `edictum-server` -- A separate deployment (coming soon, open source). Centralized approval workflows, audit dashboards, distributed sessions, hot-reload rules, RBAC.
+- Hosted control plane (`edictum-api` + `edictum-app`) -- Separate deployment for centralized approval workflows, audit dashboards, distributed sessions, and hot-reload rules.
 
 ## THE ONE RULE
 
-**Core code (src/edictum/) runs fully standalone. The server SDK (src/edictum/server/) imports from core. The server itself is a separate deployment.**
+**Core code (src/edictum/) runs fully standalone. The server SDK (src/edictum/server/) imports from core. The control plane itself is a separate deployment.**
 
-Core provides protocols and interfaces. The server SDK provides HTTP-backed implementations. The server provides the coordination infrastructure.
+Core provides protocols and interfaces. The server SDK provides HTTP-backed implementations. The control plane provides the coordination infrastructure.
 
 ## Core (MIT)
 
@@ -33,11 +33,11 @@ Core provides protocols and interfaces. The server SDK provides HTTP-backed impl
 - OTel span instrumentation + GovernanceTelemetry
 - Violation classification (`findings.py`, `Finding`) with pii_detected, secret_detected, policy_violation types
 
-## Server (edictum-server)
+## Server
 
-The server is a separate deployment, coming soon as open source. It provides:
+The control plane is a separate deployment. It provides:
 
-- Production approval workflows (ServerApprovalBackend connects to webhooks, Slack/Teams, review dashboard)
+- Production approval workflows (ServerApprovalBackend connects to Telegram, Slack, Discord, webhook, and review UI)
 - Centralized audit ingestion and governance dashboard (block rates, rule drift, sandbox violations)
 - Distributed session state for multi-agent tracking across processes
 - Hot-reload rules via SSE push (ServerContractSource) without restarting agents
@@ -53,8 +53,8 @@ The split follows one rule: **evaluation = core library, coordination = server.*
 - Persistence beyond local files, networking, coordination across processes -- server
 - Stdout + File (.jsonl) sinks for dev/local audit -- core. Centralized audit dashboards and alerting -- server
 - OTel instrumentation (emitting spans) -- core. Governance dashboards -- server
-- Session (MemoryBackend) for single-process -- core. Multi-process session state via edictum-server -- server
-- LocalApprovalBackend for development approval -- core. Production approval workflows (webhooks, Slack, review UI) -- server
+- Session (MemoryBackend) for single-process -- core. Multi-process session state via the hosted control plane -- server
+- LocalApprovalBackend for development approval -- core. Production approval workflows (Telegram, Slack, Discord, review UI) -- server
 
 ## Dropped Features (do NOT implement)
 - **Python CLI** — removed entirely. Go binary is the canonical CLI.
@@ -93,7 +93,7 @@ The split follows one rule: **evaluation = core library, coordination = server.*
 
 ## Session Model
 
-MemoryBackend stores counters in a Python dict -- one process, one agent. This covers the vast majority of use cases. For multi-agent coordination across processes, edictum-server handles centralized session tracking. There is no DIY Redis/DynamoDB path.
+MemoryBackend stores counters in a Python dict -- one process, one agent. This covers the vast majority of use cases. For multi-agent coordination across processes, the hosted control plane handles centralized session tracking. There is no DIY Redis/DynamoDB path.
 
 ## Build & Test
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Runtime rule enforcement for AI agent tool calls.
 
 **Prompts are suggestions. Rules are enforcement.** The LLM cannot talk its way past a rule.
 
-**55us overhead** · **18 adapters across Python, TypeScript, Go** · **Zero runtime deps** · **Fail-closed by default**
+**55us overhead** · **Python, TypeScript, and Go SDKs** · **Zero runtime deps** · **Fail-closed by default**
 
 ```bash
 pip install edictum[yaml]
@@ -169,7 +169,7 @@ pip install edictum[gate]
 
 The Python package ships the Gate library and integrations. For command-line workflows, use the Go binary in [edictum-go](https://github.com/edictum-ai/edictum-go) -- that is the canonical Edictum CLI.
 
-Supports Claude Code, Cursor, Copilot CLI, Gemini CLI, and OpenCode. Self-protection rules prevent the assistant from disabling governance. Optional sync to [Edictum Console](https://github.com/edictum-ai/edictum-console) for centralized audit.
+Supports Claude Code, Cursor, Copilot CLI, Gemini CLI, and OpenCode. Self-protection rules prevent the assistant from disabling governance. Optional sync to the hosted control plane for centralized audit.
 
 See the [Gate guide](https://docs.edictum.ai/docs/guides/gate) for setup.
 
@@ -185,7 +185,7 @@ guard = await Edictum.from_server(
 )
 ```
 
-See [edictum-console](https://github.com/edictum-ai/edictum-console) for deployment.
+See the [console docs](https://docs.edictum.ai/docs/console) for the current control-plane surface.
 
 ## Research & Real-World Impact
 
@@ -239,9 +239,10 @@ For CLI workflows, use the Go binary in [edictum-go](https://github.com/edictum-
 | Repo | Language | What it does |
 |------|----------|-------------|
 | [edictum](https://github.com/edictum-ai/edictum) | Python | Core library -- this repo |
-| [edictum-ts](https://github.com/edictum-ai/edictum-ts) | TypeScript | Core + adapters (Claude SDK, LangChain, OpenAI Agents, OpenClaw, Vercel AI) |
+| [edictum-ts](https://github.com/edictum-ai/edictum-ts) | TypeScript | Core + adapters (Claude SDK, LangChain, OpenAI Agents, Vercel AI) |
 | [edictum-go](https://github.com/edictum-ai/edictum-go) | Go | Core + adapters (ADK Go, Anthropic, Eino, Genkit, LangChain Go) |
-| [edictum-console](https://github.com/edictum-ai/edictum-console) | Python + React | Self-hostable ops console: HITL, audit, fleet monitoring |
+| [edictum-api](https://github.com/edictum-ai/edictum-api) | Go | Hosted control-plane API: runs, approvals, notifications, audit |
+| [edictum-app](https://github.com/edictum-ai/edictum-app) | React | Hosted control-plane UI: runs, approvals, policies, settings |
 | [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema | Rule bundle schema + cross-SDK conformance fixtures |
 | [edictum-demo](https://github.com/edictum-ai/edictum-demo) | Python | Scenario demos, adversarial tests, benchmarks, Grafana observability |
 | [Documentation](https://docs.edictum.ai) | MDX | Full docs site |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,8 @@ This policy covers:
 
 - **edictum** -- core Python library (this repo, [PyPI](https://pypi.org/project/edictum/))
 - **edictum gate** -- coding assistant governance layer (`pip install edictum[gate]`)
-- **edictum-console** -- self-hostable operations console ([GitHub](https://github.com/edictum-ai/edictum-console))
+- **edictum-api** -- hosted control-plane API ([GitHub](https://github.com/edictum-ai/edictum-api))
+- **edictum-app** -- hosted control-plane frontend ([GitHub](https://github.com/edictum-ai/edictum-app))
 
 ## Safe Harbor
 


### PR DESCRIPTION
## Summary
- replace stale console/server repo references with the current hosted control-plane docs
- refresh the ecosystem table to point at edictum-api and edictum-app
- update SECURITY.md scope to cover the active control-plane repos