### PR TITLE
docs: update agency control positioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Audit Python dependencies
         # CVE-2026-4539: pygments 2.19.2 — no upstream fix available yet (latest on PyPI).
         # Transitive dep from pdoc, pytest, rich. Remove ignore when patched version ships.
-        run: pip-audit --ignore-vuln CVE-2026-4539
+        # CVE-2026-3219: pip 26.0.1 — no upstream fix available yet (latest on PyPI).
+        # Installed by the CI Python toolchain. Remove ignore when patched version ships.
+        run: pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
       - name: Security boundary tests
         run: pytest -m security -v --tb=short

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
 [![Downloads](https://img.shields.io/pypi/dm/edictum)](https://pypi.org/project/edictum/)
 [![arXiv](https://img.shields.io/badge/arXiv-2602.16943-b31b1b.svg)](https://arxiv.org/abs/2602.16943)
 
-Runtime rule enforcement for AI agent tool calls.
+Edictum is the runtime control layer for AI agent behavior.
 
-**Prompts are suggestions. Rules are enforcement.** The LLM cannot talk its way past a rule.
+It turns an agent's declared profile into executable boundaries: what tools it can call, what data it can touch, what workflow stage it is in, what evidence is required, and when human approval is needed.
+
+For production teams, Edictum is the agency control layer for production AI agents.
+
+**Agent frameworks build the agent. Edictum bounds the agency.**
 
 **55us overhead** · **18 adapters across Python, TypeScript, Go** · **Zero runtime deps** · **Fail-closed by default**
 
@@ -20,10 +24,12 @@ pip install edictum[yaml]
 
 ## Quick Start
 
-Deny first -- see enforcement before writing YAML:
+Start with the first primitive: a single tool-call boundary.
+
+Block first -- see enforcement before writing YAML:
 
 ```python
-from edictum import Edictum, EdictumDenied
+from edictum import Edictum
 
 guard = Edictum.from_template("file-agent")
 result = guard.evaluate("read_file", {"path": ".env"})
@@ -31,15 +37,14 @@ print(result.decision)         # "block"
 print(result.block_reasons[0])  # "Sensitive file '.env' blocked."
 ```
 
-Full path -- your rule, your enforcement:
+Full path -- your rule, your boundary:
 
 ```python
 guard = Edictum.from_yaml("rules.yaml")
 
-try:
-    result = await guard.run("read_file", {"path": ".env"}, read_file)
-except EdictumDenied as e:
-    print(e.reason)  # "Sensitive file '.env' blocked."
+result = guard.evaluate("read_file", {"path": ".env"})
+print(result.decision)         # "block"
+print(result.block_reasons[0])  # "Sensitive file '.env' blocked."
 ```
 
 `rules.yaml`:
@@ -63,7 +68,7 @@ rules:
       message: "Sensitive file '{args.path}' blocked."
 ```
 
-Rules are YAML. Enforcement is deterministic -- no LLM in the evaluation path, just pattern matching against tool names and arguments. The agent cannot bypass a matched rule. Rule errors, type mismatches, and missing fields all fail closed (block). Tool calls with no matching rules are allowed by default -- add a catch-all `tool: "*"` rule for block-by-default.
+Rules are YAML. Enforcement is deterministic -- no LLM in the evaluation path, just pattern matching against tool names and arguments. The agent cannot bypass a matched rule. Rule errors, type mismatches, and missing fields all fail closed with a block decision. Tool calls with no matching rules are allowed by default -- add a catch-all `tool: "*"` rule for block-by-default.
 
 ## The Problem
 
@@ -71,31 +76,30 @@ An agent says "I won't read sensitive files" -- then calls `read_file(".env")` a
 
 A DevOps agent recognizes a jailbreak attempt, writes "I should NOT comply" in its reasoning -- then reads four production database credentials in the next tool call.
 
-Prompt engineering doesn't fix this. You need enforcement at the tool-call layer.
+Prompt engineering doesn't fix this. Production agents need executable agency boundaries at runtime.
 
-## Works With Your Framework
+## Bound Agency, Not Frameworks
 
-| Framework | Adapter | Integration |
-|-----------|---------|-------------|
-| LangChain + LangGraph | `LangChainAdapter` | `as_tool_wrapper()` / `as_middleware()` |
-| OpenAI Agents SDK | `OpenAIAgentsAdapter` | `as_guardrails()` |
-| Claude Agent SDK | `ClaudeAgentSDKAdapter` | `to_hook_callables()` |
-| CrewAI | `CrewAIAdapter` | `register()` |
-| Agno | `AgnoAdapter` | `as_tool_hook()` |
-| Semantic Kernel | `SemanticKernelAdapter` | `register()` |
-| Google ADK | `GoogleADKAdapter` | `as_plugin()` / `as_agent_callbacks()` |
-| Nanobot | `NanobotAdapter` | `wrap_registry()` |
+Agent frameworks build the agent. Edictum bounds the agency.
+
+Use your existing framework as the composition layer, then attach Edictum where tool calls, outputs, workflow evidence, and approvals cross the runtime boundary. Edictum works with LangChain, LangGraph, OpenAI Agents, CrewAI, Claude SDK, Google ADK, Semantic Kernel, Agno, and Nanobot.
+
+| Framework | Adapter | Integration point |
+|-----------|---------|-------------------|
+| LangChain + LangGraph | `LangChainAdapter` | Tool wrappers and middleware |
+| OpenAI Agents SDK | `OpenAIAgentsAdapter` | SDK boundary hooks |
+| Claude Agent SDK | `ClaudeAgentSDKAdapter` | Agent hook callables |
+| CrewAI | `CrewAIAdapter` | Tool registration |
+| Agno | `AgnoAdapter` | Tool hook |
+| Semantic Kernel | `SemanticKernelAdapter` | Kernel filter |
+| Google ADK | `GoogleADKAdapter` | Plugin and agent callbacks |
+| Nanobot | `NanobotAdapter` | Tool registry wrapper |
 
 ```python
 # LangChain
 from edictum.adapters.langchain import LangChainAdapter
 adapter = LangChainAdapter(guard)
 tool = adapter.as_tool_wrapper(tool)
-
-# OpenAI Agents SDK
-from edictum.adapters.openai_agents import OpenAIAgentsAdapter
-adapter = OpenAIAgentsAdapter(guard)
-input_gr, output_gr = adapter.as_guardrails()
 
 # Claude Agent SDK
 from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
@@ -108,16 +112,63 @@ adapter = GoogleADKAdapter(guard)
 plugin = adapter.as_plugin()
 ```
 
-See [Adapter docs](https://docs.edictum.ai/docs/adapters/overview) for all 8 frameworks.
+See [Adapter docs](https://docs.edictum.ai/docs/adapters/overview) for all 8 Python framework adapters.
+
+## Enterprise Agent Profiles
+
+Enterprises do not just need "more autonomous" or "less autonomous" agents. They need declared profiles that can survive review:
+
+- **Low agency** -- read-only tools, narrow data scope, no external side effects
+- **Medium agency** -- scoped writes, ticket-bound actions, workflow stages, evidence, and approval on higher-risk transitions
+- **High agency** -- broader write authority, production actions, stricter runtime evidence, approval, audit, and rollback requirements
+
+Every profile has a read scope, a write scope, tool authority, approval requirements, and process obligations. Edictum makes that declared profile executable.
+
+Edictum turns documented agent profiles into executable runtime boundaries.
+
+Medium Agency is the common enterprise starting point right now because it maps to practical internal assistants: agents that can read, draft, edit, file tickets, open PRs, or prepare changes, but need boundaries before production-impacting action. That is the demand center, not the product boundary. Edictum makes any agency level defensible.
+
+## Workflow Gates
+
+Rulesets are one primitive. Workflow Gates enforce ordered process with evidence and approvals: which stage the agent is in, which tools are allowed there, what evidence must exist before moving forward, and when a human must approve the next action.
+
+```yaml
+apiVersion: edictum/v1
+kind: Workflow
+metadata:
+  name: read-before-edit
+stages:
+  - id: read-context
+    tools: [Read]
+    exit:
+      - condition: file_read("spec.md")
+        message: Read the spec before editing
+  - id: implement
+    entry:
+      - condition: stage_complete("read-context")
+    tools: [Edit]
+    approval:
+      message: Human approval required before implementation
+```
+
+Attach a workflow alongside rules:
+
+```python
+guard = Edictum.from_yaml("rules.yaml", workflow_path="workflow.yaml")
+```
+
+Now an `Edit` call is blocked until the agent has successfully read `spec.md`, moved into the `implement` stage, and satisfied the configured approval.
 
 ## What You Can Do
 
-**Rules** -- four types covering the full tool call lifecycle:
+**Rulesets** -- four rule types covering tool calls, outputs, sessions, and sandbox scope:
 
 - **Preconditions** block dangerous calls before execution
 - **Postconditions** scan tool output -- warn, redact PII, or block
 - **Session rules** cap total calls, per-tool calls, and retry attempts
 - **Sandbox rules** allowlist file paths, commands, and domains
+
+**Workflow Gates** -- ordered runtime stages with allowed tools, entry conditions, exit conditions, recorded evidence, terminal stages, and human approval.
 
 **Principal-aware enforcement** -- role-gate tools with claims and `env.*` context. `set_principal()` for mid-session role changes.
 
@@ -143,6 +194,19 @@ See [Adapter docs](https://docs.edictum.ai/docs/adapters/overview) for all 8 fra
 - Secret values auto-redacted in audit events
 - File, stdout, and composite sinks
 
+## Measurement Boundary
+
+Edictum measures behavioral conformance to a declared agent profile. It tells you whether the agent stayed inside runtime boundaries:
+
+- Blocked actions
+- Approval rate
+- Workflow completion
+- Stuck stages
+- Missing evidence
+- Profile drift
+
+Edictum does not replace output-quality evals. It does not grade answer accuracy, relevance, coherence, writing quality, or whether the final response is correct. Use output-quality evals for that. Use Edictum to prove what the agent was allowed to do, what it tried to do, what was blocked, what was approved, and which workflow evidence existed at runtime.
+
 ## Built-in Templates
 
 ```python
@@ -161,7 +225,7 @@ guard = Edictum.from_template("nanobot-agent")
 
 ## Edictum Gate
 
-Pre-execution governance for coding assistants. Sits between the assistant and the OS, evaluating every tool call against rules.
+Pre-execution control for coding assistants. Sits between the assistant and the OS, evaluating every tool call against rules.
 
 ```bash
 pip install edictum[gate]
@@ -169,13 +233,13 @@ pip install edictum[gate]
 
 The Python package ships the Gate library and integrations. For command-line workflows, use the Go binary in [edictum-go](https://github.com/edictum-ai/edictum-go) -- that is the canonical Edictum CLI.
 
-Supports Claude Code, Cursor, Copilot CLI, Gemini CLI, and OpenCode. Self-protection rules prevent the assistant from disabling governance. Optional sync to the [Edictum Control Plane](https://docs.edictum.ai/docs/control-plane) for centralized audit.
+Supports Claude Code, Cursor, Copilot CLI, Gemini CLI, and OpenCode. Self-protection rules prevent the assistant from disabling runtime checks. Optional sync to the [Edictum Control Plane](https://docs.edictum.ai/docs/control-plane) for centralized audit.
 
 See the [Gate guide](https://docs.edictum.ai/docs/guides/gate) for setup.
 
 ## Edictum Control Plane
 
-Optional hosted control plane for governed agents. Ruleset management, live hot-reload via SSE, human-in-the-loop approvals, audit event feeds, and fleet monitoring.
+Optional hosted control plane for production agents. Ruleset management, live hot-reload via SSE, human-in-the-loop approvals, audit event feeds, and fleet monitoring.
 
 ```python
 guard = await Edictum.from_server(
@@ -205,7 +269,7 @@ Requires Python 3.11+.
 pip install edictum              # core (zero deps)
 pip install edictum[yaml]        # + YAML rule parsing
 pip install edictum[otel]        # + OpenTelemetry span emission
-pip install edictum[gate]        # + coding assistant governance library
+pip install edictum[gate]        # + coding assistant runtime control library
 pip install edictum[verified]    # + Ed25519 bundle signature verification
 pip install edictum[server]      # + server SDK (connect to the Edictum Control Plane)
 pip install edictum[all]         # everything in this Python package
@@ -217,17 +281,17 @@ For CLI workflows, use the Go binary in [edictum-go](https://github.com/edictum-
 
 | Approach | Scope | Runtime enforcement | Audit trail |
 |---|---|---|---|
-| Prompt/output guardrails | Input/output text | No -- advisory only | No |
+| Prompt/output filters | Input/output text | No -- advisory only | No |
 | API gateways / MCP proxies | Network transport | Yes -- at the proxy | Partial |
 | Security scanners | Post-hoc analysis | No -- detection only | Yes |
 | Manual if-statements | Per-tool, ad hoc | Yes -- scattered logic | No |
-| **Edictum** | **Tool call rules** | **Yes -- deterministic pipeline** | **Yes -- structured + redacted** |
+| **Edictum** | **Agency boundaries: tools, data, stages, evidence, approvals** | **Yes -- deterministic pipeline** | **Yes -- structured + redacted** |
 
 ## Use Cases
 
 | Domain | What Edictum enforces |
 |--------|----------------------|
-| Coding agents | Secret protection, destructive command denial, write scope ([Gate guide](https://docs.edictum.ai/docs/guides/gate)) |
+| Coding agents | Secret protection, destructive command blocking, write scope ([Gate guide](https://docs.edictum.ai/docs/guides/gate)) |
 | Healthcare | Patient data access control, role-gated queries |
 | Finance | PII redaction in query results, transaction limits |
 | DevOps | Production deploy gates, ticket requirements, bash safety |
@@ -241,7 +305,7 @@ For CLI workflows, use the Go binary in [edictum-go](https://github.com/edictum-
 | [edictum](https://github.com/edictum-ai/edictum) | Python | Core library -- this repo |
 | [edictum-ts](https://github.com/edictum-ai/edictum-ts) | TypeScript | Core + adapters (Claude SDK, LangChain, OpenAI Agents, OpenClaw, Vercel AI) |
 | [edictum-go](https://github.com/edictum-ai/edictum-go) | Go | Core + adapters (ADK Go, Anthropic, Eino, Genkit, LangChain Go) |
-| [Control-plane docs](https://docs.edictum.ai/docs/control-plane) | Docs | Hosted control plane: approvals, audit, policies, fleet monitoring |
+| [Control-plane docs](https://docs.edictum.ai/docs/control-plane) | Docs | Hosted control plane: approvals, audit, rules, fleet monitoring |
 | [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | JSON Schema | Rule bundle schema + cross-SDK conformance fixtures |
 | [edictum-demo](https://github.com/edictum-ai/edictum-demo) | Python | Scenario demos, adversarial tests, benchmarks, Grafana observability |
 | [Documentation](https://docs.edictum.ai) | MDX | Full docs site |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "edictum"
 version = "0.18.0"
-description = "Runtime safety for AI agents. Stop agents before they break things."
+description = "Agency control layer for production AI agents."
 readme = "README.md"
 license = "MIT"
 authors = [

--- a/src/edictum/__init__.py
+++ b/src/edictum/__init__.py
@@ -1,4 +1,4 @@
-"""Edictum — Runtime safety for AI agents."""
+"""Edictum -- runtime control layer for AI agent behavior."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Repositions the README around Edictum as the runtime control layer and agency control layer for production AI agents.
- Keeps the developer quickstart while framing it as the first single tool-call boundary primitive.
- Adds Workflow Gates, Enterprise Agent Profiles, and Measurement Boundary sections.
- Updates package-facing wording in pyproject metadata and the package docstring.

## Validation

- uv run pytest tests/test_docs_sync.py -v
- uv run ruff check src/edictum/__init__.py
- rg README stale terminology search
- commit hooks: ruff, ruff format, check-terminology