### PR TITLE
fix: emit valid Claude SDK block decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Security
 - **The Python gate's Claude Code format did not enforce — it is removed.** The Claude Code format wrote Edictum's internal word `block` straight into `permissionDecision`. Claude Code's `PreToolUse` hook only accepts `allow`, `deny`, or `ask`, so it threw the message away and ran the tool. (The Copilot CLI format used the same wire value; its host was not separately verified.) Every code path hit this: error paths (no rules found, unreadable rules, invalid stdin, internal errors) and normal policy blocks. The Python gate blocked nothing on Claude Code.
+- **The Claude Agent SDK adapter did not block on the documented `ClaudeSDKClient` bridge path — fixed.** `ClaudeAgentSDKAdapter` emitted the same invalid `permissionDecision: "block"` value, and the documented bridge returned that payload to the SDK unchanged. The CLI rejected it and ran the tool. The separate manual agent-loop path that interpreted the adapter response itself was not affected. The adapter now emits the SDK's accepted `deny` value.
 
 ### Removed
-- **Python gate (`src/edictum/gate/`) and the `edictum[gate]` extra.** Breaking removal. If you wired `edictum[gate]` or `python -m edictum.gate.check` into a Claude Code `PreToolUse` hook, you were running a gate that did not block — switch to the Go CLI in [edictum-go](https://github.com/edictum-ai/edictum-go), which emits the correct `deny` value and exits non-zero.
+- **Python gate (`src/edictum/gate/`) and the `edictum[gate]` extra.** Breaking removal. If you wired `edictum[gate]` or `python -m edictum.gate.check` into a Claude Code `PreToolUse` hook, you were running a gate that did not block — switch to [edictum-go v0.6.0](https://github.com/edictum-ai/edictum-go/releases/tag/v0.6.0), which emits the correct `deny` value and exits non-zero.
 - **Gate-only rules in the `coding-assistant-base` template.** Removed the scope-enforcement note and the four Gate Self-Protection rules from `src/edictum/yaml_engine/templates/coding-assistant-base.yaml` — they referenced the deleted gate. The template's secret, destructive-command, git, system, and package rules remain.
 
 ## 0.18.0

--- a/examples/demo_claude_agent_sdk.py
+++ b/examples/demo_claude_agent_sdk.py
@@ -89,7 +89,7 @@ async def run_with_guard(client: OpenAI) -> None:
 
     The Claude SDK uses pre/post tool hooks that return dicts:
     - {} means allow
-    - {"hookSpecificOutput": {"permissionDecision": "block", ...}} means block
+    - {"hookSpecificOutput": {"permissionDecision": "deny", ...}} means block
     """
     from rules import ALL_CONTRACTS
 
@@ -123,7 +123,7 @@ async def run_with_guard(client: OpenAI) -> None:
     print()
 
     call_count = 0
-    denied_count = 0
+    blocked_count = 0
 
     for _ in range(30):
         llm_start = now_s()
@@ -151,12 +151,12 @@ async def run_with_guard(client: OpenAI) -> None:
             # Route through Claude Agent SDK adapter
             pre_result = await hooks["pre_tool_use"](fn_name, args, tool_use_id)
 
-            # Check if denied: non-empty dict with permissionDecision == "block"
+            # Check if blocked: non-empty dict with permissionDecision == "deny"
             hook_output = pre_result.get("hookSpecificOutput", {})
-            if hook_output.get("permissionDecision") == "block":
-                denied_count += 1
-                reason = hook_output.get("permissionDecisionReason", "denied")
-                result = f"DENIED: {reason}"
+            if hook_output.get("permissionDecision") == "deny":
+                blocked_count += 1
+                reason = hook_output.get("permissionDecisionReason", "blocked")
+                result = f"BLOCKED: {reason}"
                 print(f"  ** EDICTUM: {result}\n")
             else:
                 tool_start = now_s()
@@ -169,11 +169,11 @@ async def run_with_guard(client: OpenAI) -> None:
             messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})
 
     print(f"\n{'─' * 60}")
-    print(f"Total calls: {call_count}  |  Denied: {denied_count}  |  Audit: {audit_path}")
+    print(f"Total calls: {call_count}  |  Blocked: {blocked_count}  |  Audit: {audit_path}")
     write_metrics_summary(
         metrics,
         metrics_path,
-        {"mode": "with_guard", "denied": denied_count, "audit": audit_path},
+        {"mode": "with_guard", "blocked": blocked_count, "audit": audit_path},
     )
     _print_audit(audit_path)
 

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -483,7 +483,7 @@ class ClaudeAgentSDKAdapter:
         return {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
-                "permissionDecision": "block",
+                "permissionDecision": "deny",
                 "permissionDecisionReason": reason,
             }
         }

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -13,6 +13,7 @@ from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
+# claude-agent-sdk 0.2.135 adds "defer" to stop a run with a resumable tool call.
 CLAUDE_PRE_TOOL_USE_DECISIONS = frozenset({"allow", "deny", "ask", "defer"})
 
 

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -13,6 +13,8 @@ from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
+CLAUDE_PRE_TOOL_USE_DECISIONS = frozenset({"allow", "deny", "ask", "defer"})
+
 
 def make_guard(**kwargs):
     defaults = {
@@ -35,10 +37,11 @@ class TestClaudeAgentSDKAdapter:
         )
         assert result == {}
 
-    async def test_deny_returns_sdk_format(self):
+    @pytest.mark.security
+    async def test_block_emits_supported_sdk_wire_value(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("denied")
+            return Decision.fail("blocked")
 
         guard = make_guard(rules=[always_deny])
         adapter = ClaudeAgentSDKAdapter(guard)
@@ -47,9 +50,11 @@ class TestClaudeAgentSDKAdapter:
             tool_input={},
             tool_use_id="tu-1",
         )
-        assert result["hookSpecificOutput"]["permissionDecision"] == "block"
-        assert result["hookSpecificOutput"]["permissionDecisionReason"] == "denied"
-        assert result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        emitted = result["hookSpecificOutput"]
+        assert emitted["permissionDecision"] in CLAUDE_PRE_TOOL_USE_DECISIONS
+        assert emitted["permissionDecision"] == "deny"
+        assert emitted["permissionDecisionReason"] == "blocked"
+        assert emitted["hookEventName"] == "PreToolUse"
 
     async def test_pending_state_management(self):
         guard = make_guard()
@@ -99,7 +104,7 @@ class TestClaudeAgentSDKAdapter:
     async def test_observe_mode_would_deny(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("would be denied")
+            return Decision.fail("would be blocked")
 
         sink = NullAuditSink()
         guard = make_guard(mode="observe", rules=[always_deny], audit_sink=sink)
@@ -194,7 +199,7 @@ class TestEdictumRun:
     async def test_run_deny_raises(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("denied by precondition")
+            return Decision.fail("blocked by precondition")
 
         guard = make_guard(rules=[always_deny])
 
@@ -205,12 +210,12 @@ class TestEdictumRun:
 
         with pytest.raises(EdictumDenied) as exc_info:
             await guard.run("TestTool", {}, my_tool)
-        assert exc_info.value.reason == "denied by precondition"
+        assert exc_info.value.reason == "blocked by precondition"
 
     async def test_run_deny_emits_audit_no_execute(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("denied")
+            return Decision.fail("blocked")
 
         sink = NullAuditSink()
         guard = make_guard(rules=[always_deny], audit_sink=sink)
@@ -224,7 +229,7 @@ class TestEdictumRun:
             await guard.run("TestTool", {}, my_tool)
         actions = [e.action for e in sink.events]
         assert AuditAction.CALL_DENIED in actions
-        # Denied means no execution audit
+        # Blocked means no execution audit
         assert AuditAction.CALL_EXECUTED not in actions
         assert AuditAction.CALL_ALLOWED not in actions
 

--- a/tests/test_adapter_parity.py
+++ b/tests/test_adapter_parity.py
@@ -79,10 +79,10 @@ def _adapter_configs():
     from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
     def _crewai_deny(r):
-        return isinstance(r, str) and "DENIED" in r
+        return isinstance(r, str) and r.startswith("DENIED:")
 
     def _adk_deny(r):
-        return isinstance(r, dict) and "DENIED" in str(r.get("error", ""))
+        return isinstance(r, dict) and str(r.get("error", "")).startswith("DENIED:")
 
     return [
         ("CrewAI", CrewAIAdapter, _crewai_pre, _crewai_post, lambda r: r is None, _crewai_deny),
@@ -155,7 +155,7 @@ class TestParityObserve:
         guard = _make_guard(rules=[block_all], mode="observe")
         adapter = cls(guard)
         result = await pre_fn(adapter)
-        assert allow_check(result), f"{name} denied in observe mode (should allow)"
+        assert allow_check(result), f"{name} blocked in observe mode (should allow)"
 
 
 # Callback parity: CrewAI and OpenAI accept on_postcondition_warn in constructor.
@@ -352,22 +352,22 @@ class TestParitySuccessCheck:
 # --- Mutable principal helpers ---
 
 
-def _is_denied(result) -> bool:
-    """Adapter-agnostic check for a denial result."""
+def _is_blocked(result) -> bool:
+    """Adapter-agnostic check for a blocked result."""
     if result is None:
         return False
     if isinstance(result, str):
-        return "DENIED" in result
+        return result.startswith("DENIED:")
     if isinstance(result, dict):
-        # ADK adapter returns {"error": "DENIED: ..."}
-        if "DENIED" in str(result.get("error", "")):
+        # ADK adapter returns an error prefixed with the legacy block marker.
+        if str(result.get("error", "")).startswith("DENIED:"):
             return True
         # Claude SDK format
         hook = result.get("hookSpecificOutput", {})
-        return hook.get("permissionDecision") == "block"
+        return hook.get("permissionDecision") == "deny"
     # LangChain ToolMessage
     content = getattr(result, "content", "")
-    return "DENIED" in content
+    return content.startswith("DENIED:")
 
 
 # Second-call pre helpers with fresh call IDs
@@ -446,16 +446,16 @@ class TestParitySetPrincipal:
         guard = _make_guard(rules=[require_admin])
         adapter = cls(guard, principal=Principal(role="viewer"))
 
-        # First call: viewer -> denied
+        # First call: viewer -> blocked
         result1 = await pre_fn(adapter)
-        assert _is_denied(result1), f"{name} did not block viewer principal"
+        assert _is_blocked(result1), f"{name} did not block viewer principal"
 
         # Mutate principal
         adapter.set_principal(Principal(role="admin"))
 
         # Second call: admin -> allowed
         result2 = await pre_fn_2(adapter)
-        assert not _is_denied(result2), f"{name} denied after set_principal(admin)"
+        assert not _is_blocked(result2), f"{name} blocked after set_principal(admin)"
 
 
 class TestParityPrincipalResolver:
@@ -476,7 +476,7 @@ class TestParityPrincipalResolver:
         adapter = cls(guard, principal_resolver=resolver)
 
         result = await pre_fn(adapter)
-        assert not _is_denied(result), f"{name} denied when resolver returns admin"
+        assert not _is_blocked(result), f"{name} blocked when resolver returns admin"
 
     @pytest.mark.parametrize("name,cls,pre_fn", ALL_CONFIGS, ids=ALL_ADAPTER_IDS)
     async def test_resolver_overrides_static_principal(self, name, cls, pre_fn):
@@ -494,4 +494,4 @@ class TestParityPrincipalResolver:
         adapter = cls(guard, principal=Principal(role="viewer"), principal_resolver=resolver)
 
         result = await pre_fn(adapter)
-        assert not _is_denied(result), f"{name} denied when resolver returns admin (should override static viewer)"
+        assert not _is_blocked(result), f"{name} blocked when resolver returns admin (should override static viewer)"

--- a/tests/test_behavior/test_mutable_principal_behavior.py
+++ b/tests/test_behavior/test_mutable_principal_behavior.py
@@ -54,35 +54,35 @@ def _make_adapter(*, principal=None, principal_resolver=None):
     )
 
 
-def _is_denied(result: dict) -> bool:
+def _is_blocked(result: dict) -> bool:
     hook = result.get("hookSpecificOutput", {})
-    return hook.get("permissionDecision") == "block"
+    return hook.get("permissionDecision") == "deny"
 
 
 class TestSetPrincipalChangesEnforcement:
     """set_principal() must change enforcement for subsequent calls."""
 
     async def test_set_principal_changes_enforcement(self):
-        """Viewer is denied, then set_principal(admin) allows the next call."""
+        """Viewer is blocked, then set_principal(admin) allows the next call."""
         adapter = _make_adapter(principal=Principal(role="viewer"))
 
-        # Viewer -> denied
+        # Viewer -> blocked
         result = await adapter._pre_tool_use("TestTool", {}, "tc-1")
-        assert _is_denied(result), "Viewer should be denied"
+        assert _is_blocked(result), "Viewer should be blocked"
 
         # Switch to admin
         adapter.set_principal(Principal(role="admin"))
 
         # Admin -> allowed
         result = await adapter._pre_tool_use("TestTool", {}, "tc-2")
-        assert not _is_denied(result), "Admin should be allowed after set_principal"
+        assert not _is_blocked(result), "Admin should be allowed after set_principal"
 
 
 class TestPrincipalResolverOverridesStatic:
     """principal_resolver takes precedence over the static principal."""
 
     async def test_principal_resolver_overrides_static(self):
-        """Static principal is viewer (denied), but resolver returns admin (allowed)."""
+        """Static principal is viewer (blocked), but resolver returns admin (allowed)."""
 
         def resolver(tool_name, tool_input):
             return Principal(role="admin")
@@ -93,7 +93,7 @@ class TestPrincipalResolverOverridesStatic:
         )
 
         result = await adapter._pre_tool_use("TestTool", {}, "tc-1")
-        assert not _is_denied(result), "Resolver returning admin should override static viewer principal"
+        assert not _is_blocked(result), "Resolver returning admin should override static viewer principal"
 
 
 class TestPrincipalResolverReceivesToolContext:
@@ -140,14 +140,14 @@ class TestEdictumSetPrincipal:
     """Edictum.run() must use the updated principal after set_principal()."""
 
     async def test_edictum_set_principal(self):
-        """run() denies viewer, then allows admin after set_principal."""
+        """run() blocks viewer, then allows admin after set_principal."""
         guard = _make_guard()
         guard._principal = Principal(role="viewer")
 
         async def noop(**kwargs):
             return "ok"
 
-        # Viewer -> denied
+        # Viewer -> blocked
         with pytest.raises(EdictumDenied):
             await guard.run("TestTool", {}, noop)
 


### PR DESCRIPTION
## Summary

- emit the Claude Agent SDK's accepted `deny` value for blocked tool calls
- add payload-level accepted-set coverage and prove it fails under the old value
- update the manual-loop example and the 0.19.0 security disclosure

## Blast radius

The documented `ClaudeSDKClient` bridge returned the adapter payload unchanged. The invalid `block` value therefore reached the CLI, which rejected it and ran the tool. The separate manual-loop example interpreted the adapter response itself and was not affected.

Rule blocks, workflow blocks, and final approval failures all use the same emitter. Approval failures are final decisions after Edictum's approval flow, not requests for the SDK to prompt again.

## Verification

- live `claude-agent-sdk==0.2.135`: real adapter payload emitted `deny`; tool result was blocked; sentinel absent
- mutation proof: restoring only `block` fails the accepted-set regression test
- `uv run pytest tests/ -q`: 2346 passed, 3 skipped, 20 xfailed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_docs_sync.py -v`
- `uv run pytest tests/test_adapter_parity.py -v`
- fresh wheel inspected: no `edictum/gate`, no gate extra, no console entry point, packaged adapter emits `deny`
