### PR TITLE
fix(guard): validate mode at construction

### DIFF
--- a/src/edictum/_guard.py
+++ b/src/edictum/_guard.py
@@ -32,6 +32,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_VALID_MODES = frozenset({"enforce", "observe"})
+
+
+def _validate_mode(mode: str) -> None:
+    """Reject unknown mode strings.
+
+    Enforcement paths branch on exact mode equality (e.g. ``mode == "enforce"``),
+    so an unrecognized value (a typo like ``"Enforce"``) must never reach them:
+    it would silently skip the deny raise while auditing ``call_denied``.
+    """
+    from edictum._exceptions import EdictumConfigError
+
+    if mode not in _VALID_MODES:
+        raise EdictumConfigError(f"Invalid mode: {mode!r}. Must be 'enforce' or 'observe'.")
+
 
 @dataclass(frozen=True)
 class _CompiledState:
@@ -85,6 +100,7 @@ class Edictum:
         workflow_runtime: WorkflowRuntime | None = None,
     ):
         self.environment = environment
+        _validate_mode(mode)
         self.mode = mode
         self.backend = backend or MemoryBackend()
         self.redaction = redaction or RedactionPolicy()

--- a/tests/test_behavior/test_mode_validation_behavior.py
+++ b/tests/test_behavior/test_mode_validation_behavior.py
@@ -1,0 +1,53 @@
+"""Behavior tests for guard mode validation.
+
+Proves that an unrecognized mode string is rejected at construction instead of
+reaching enforcement paths that branch on exact mode equality (where it would
+silently skip the deny raise while auditing call_denied).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum, EdictumConfigError
+
+_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: mode-validation
+defaults:
+  mode: enforce
+rules:
+  - id: block-rm
+    type: pre
+    tool: Bash
+    when:
+      args.command: {contains: rm}
+    then:
+      action: block
+      message: no rm
+"""
+
+
+class TestModeValidation:
+    def test_valid_modes_accepted(self):
+        assert Edictum(mode="enforce").mode == "enforce"
+        assert Edictum(mode="observe").mode == "observe"
+
+    @pytest.mark.parametrize("bad", ["Enforce", "enforcing", "enforce ", "production", "", "OFF"])
+    def test_invalid_modes_rejected_at_construction(self, bad):
+        with pytest.raises(EdictumConfigError, match="Invalid mode"):
+            Edictum(mode=bad)
+
+    @pytest.mark.parametrize("bad", ["Enforce", "enforcing", "production"])
+    def test_invalid_modes_rejected_via_from_yaml_string(self, bad):
+        with pytest.raises(EdictumConfigError, match="Invalid mode"):
+            Edictum.from_yaml_string(_RULES, mode=bad)
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_typo_cannot_fail_open(self):
+        """A mode typo must fail at boot, not execute blocked calls."""
+        with pytest.raises(EdictumConfigError):
+            Edictum.from_yaml_string(_RULES, mode="Enforce")


### PR DESCRIPTION
## What

Unrecognized `mode` strings are now rejected with `EdictumConfigError` in `Edictum.__init__` (covers every factory — all construct through it).

## Why

Enforcement branches on exact mode equality. A typo like `mode="Enforce"` or `"enforcing"` made `Edictum.run()` fall through to **execute** every blocked call while the audit trail recorded `call_denied` + `call_executed` for the same call — a silent fail-open with a corrupted audit trail. Found by adversarial security assessment (Phase 2 PoC: mode-typo matrix, 4/4 unexpected values fail open).

Adapters branch the safe direction (`mode == "observe"` → convert block to allow), so only the `run()` entry point was exposed — but the guard is the single place to close it.

## Verification

- New behavior tests: `tests/test_behavior/test_mode_validation_behavior.py` (11 cases, incl. `@pytest.mark.security` fail-open guard)
- Regression check: tests fail (10/11) with the validation line removed
- Full suite: 2357 passed, ruff clean

## Scenarios

- Operator passes `mode="production"` (environment-style naming) → boot fails loudly instead of running unguarded with deny-shaped audit events.