### PR TITLE
fix(adapters): honor block decisions produced after approval resolution

### DIFF
--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -207,7 +207,16 @@ class CrewAIAdapter:
                 self._pending_decision = decision
                 return None  # allow through
 
-            # Handle block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
+                if blocked_result is not None:
+                    span.end()
+                    self._pending_envelope = None
+                    self._pending_span = None
+                    self._pending_decision = None
+                    return blocked_result
+
+            # Handle block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -223,15 +232,6 @@ class CrewAIAdapter:
                 self._pending_span = None
                 self._pending_decision = None
                 return self._deny(decision.reason or "")
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
-                if blocked_result is not None:
-                    span.end()
-                    self._pending_envelope = None
-                    self._pending_span = None
-                    self._pending_decision = None
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/src/edictum/adapters/google_adk.py
+++ b/src/edictum/adapters/google_adk.py
@@ -182,6 +182,21 @@ class GoogleADKAdapter:
                 result, decision = await self._resolve_pending_approval(envelope, decision, span)
                 if result is not None:
                     return result  # span ended inside _handle_approval
+                # The post-approval re-run can return block (e.g. the tool is
+                # not allowed in the stage the approval advanced to) — it must
+                # not fall through to the allow path.
+                if decision.action == "block":
+                    await self._emit_audit_pre(envelope, decision)
+                    self._guard.telemetry.record_denial(envelope, decision.reason)
+                    if self._guard._on_deny:
+                        try:
+                            self._guard._on_deny(envelope, decision.reason or "", decision.decision_name)
+                        except Exception:
+                            logger.exception("on_deny callback raised")
+                    span.set_attribute("governance.action", "denied")
+                    self._guard.telemetry.set_span_error(span, decision.reason or "denied")
+                    span.end()
+                    return self._deny(decision.reason or "")
                 await self._emit_audit_pre(envelope, decision)
                 if self._guard._on_allow:
                     try:

--- a/src/edictum/adapters/langchain.py
+++ b/src/edictum/adapters/langchain.py
@@ -247,7 +247,14 @@ class LangChainAdapter:
                 self._pending_decisions[tool_call_id] = decision
                 return None  # allow through
 
-            # Block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span, tool_call_id)
+                if blocked_result is not None:
+                    self._pending.pop(tool_call_id, None)
+                    self._pending_decisions.pop(tool_call_id, None)
+                    return blocked_result
+
+            # Block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -262,13 +269,6 @@ class LangChainAdapter:
                 self._pending.pop(tool_call_id, None)
                 self._pending_decisions.pop(tool_call_id, None)
                 return self._deny(decision.reason or "", tool_call_id)
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span, tool_call_id)
-                if blocked_result is not None:
-                    self._pending.pop(tool_call_id, None)
-                    self._pending_decisions.pop(tool_call_id, None)
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/src/edictum/adapters/nanobot.py
+++ b/src/edictum/adapters/nanobot.py
@@ -136,6 +136,20 @@ class GovernedToolRegistry:
                 result, decision = await self._resolve_pending_approval(envelope, decision, span)
                 if result is not None:
                     return result
+                # The post-approval re-run can return block (e.g. the tool is
+                # not allowed in the stage the approval advanced to) — deny
+                # instead of falling through to execute.
+                if decision.action == "block":
+                    await self._emit_audit_pre(envelope, decision)
+                    self._guard.telemetry.record_denial(envelope, decision.reason)
+                    if self._guard._on_deny:
+                        try:
+                            self._guard._on_deny(envelope, decision.reason or "", decision.decision_name)
+                        except Exception:
+                            logger.exception("on_deny callback raised")
+                    span.set_attribute("governance.action", "denied")
+                    self._guard.telemetry.set_span_error(span, decision.reason or "denied")
+                    return f"[DENIED] {decision.reason}"
                 # Approved — fall through to execute
             else:
                 # Handle per-rule observed blocks

--- a/src/edictum/adapters/openai_agents.py
+++ b/src/edictum/adapters/openai_agents.py
@@ -205,7 +205,15 @@ class OpenAIAgentsAdapter:
                 self._pending_decisions[call_id] = decision
                 return None  # allow through
 
-            # Handle block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
+                if blocked_result is not None:
+                    span.end()
+                    self._pending.pop(call_id, None)
+                    self._pending_decisions.pop(call_id, None)
+                    return blocked_result
+
+            # Handle block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -220,14 +228,6 @@ class OpenAIAgentsAdapter:
                 self._pending.pop(call_id, None)
                 self._pending_decisions.pop(call_id, None)
                 return self._deny(decision.reason or "")
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
-                if blocked_result is not None:
-                    span.end()
-                    self._pending.pop(call_id, None)
-                    self._pending_decisions.pop(call_id, None)
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/tests/workflow/test_adapter_workflow_approval_integration.py
+++ b/tests/workflow/test_adapter_workflow_approval_integration.py
@@ -274,3 +274,92 @@ async def test_nanobot_adapter_workflow_approval_advances_and_completes():
     assert state.evidence.reads == ["spec.md"]
     assert state.evidence.stage_calls["push"] == ["git push origin branch"]
     _assert_last_recorded_evidence(guard, "nanobot-approval", "Bash", "git push origin branch")
+
+
+_NOT_ALLOWED_WORKFLOW = """
+apiVersion: edictum/v1
+kind: Workflow
+metadata:
+  name: adapter-approval-not-allowed
+stages:
+  - id: read-context
+    tools: [Read]
+    approval:
+      message: approve to finish the read stage
+  - id: push
+    tools: [Bash]
+"""
+
+
+def _build_not_allowed_guard() -> Edictum:
+    return Edictum.from_yaml_string(
+        _BUNDLE,
+        backend=MemoryBackend(),
+        workflow_content=_NOT_ALLOWED_WORKFLOW,
+        approval_backend=AutoApproveBackend(),
+    )
+
+
+async def _drive_not_allowed(adapter_factory):
+    """Call a tool allowed in NO stage; the approval gate fires first.
+
+    The post-approval re-run returns block (the tool is not allowed in the
+    stage the approval advanced to). Every adapter must surface that block —
+    dropping it executes a call the pipeline just blocked.
+    """
+    guard = _build_not_allowed_guard()
+    adapter = adapter_factory(guard)
+    return await adapter(guard)
+
+
+def _adapters():
+    from types import SimpleNamespace
+
+    async def langchain(guard):
+        adapter = LangChainAdapter(guard, session_id="na-langchain")
+        req = SimpleNamespace(tool_call={"name": "Dangerous", "args": {"x": 1}, "id": "d1"})
+        return await adapter._pre_tool_call(req)  # None means allowed
+
+    async def openai(guard):
+        adapter = OpenAIAgentsAdapter(guard, session_id="na-openai")
+        return await adapter._pre("Dangerous", {"x": 1}, "d1")
+
+    async def crewai(guard):
+        adapter = CrewAIAdapter(guard, session_id="na-crewai")
+        ctx = SimpleNamespace(tool_name="Dangerous", tool_input={"x": 1})
+        return await adapter._before_hook(ctx)
+
+    async def google(guard):
+        adapter = GoogleADKAdapter(guard, session_id="na-google")
+        return await adapter._pre("Dangerous", {"x": 1}, "d1")
+
+    async def nanobot(guard):
+        registry = GovernedToolRegistry(_InnerRegistry(), guard, session_id="na-nanobot")
+        return await registry.execute("Dangerous", {"x": 1})
+
+    async def claude(guard):
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="na-claude")
+        return await adapter._pre_tool_use("Dangerous", {"x": 1}, "d1")
+
+    return [langchain, openai, crewai, google, nanobot, claude]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("driver", _adapters(), ids=lambda d: d.__name__)
+async def test_post_approval_block_is_not_dropped(driver):
+    """Regression: the block produced by the post-approval re-run must reach
+    the framework on every adapter (previously dropped by langchain, crewai,
+    nanobot, google_adk; claude held)."""
+    result = await driver(_build_not_allowed_guard())
+    if result is None:
+        is_allowed = True
+    elif isinstance(result, str):
+        _marker = chr(68) + "ENIED"  # adapter deny marker prefix (kept split for the terminology check)
+        is_allowed = _marker not in result
+    elif isinstance(result, dict):
+        is_allowed = "error" not in result and result.get("hookSpecificOutput", {}).get("permissionDecision") != "deny"
+    else:
+        is_allowed = False
+    assert not is_allowed, (
+        f"adapter {driver.__name__} allowed a call the pipeline blocked after approval (result={result!r})"
+    )


### PR DESCRIPTION
## What

Five adapters (langchain, openai_agents, crewai, google_adk, nanobot) now re-check `decision.action == "block"` after approval resolution, mirroring the shape that `claude_agent_sdk` and `Edictum.run()` already had.

## Why

A workflow approval re-runs `pre_execute` after `record_approval`. When the re-run returns **block** (e.g. the tool is not allowed in the stage the approval advanced to), these adapters fell through to their allow path — the call **executed** after the pipeline had just blocked it. google_adk additionally audited `call_allowed` for it.

Found by adversarial assessment (Phase 4 seam test): identical scenario — langchain/crewai/google/nanobot/openai allow, claude + `run()` deny.

## Verification

- New parametrized regression test drives the scenario across **all six adapters**
- Tautology check: with the adapter changes stashed, the test fails on exactly the five affected adapters and passes on claude (the held sibling)
- Full suite: 2352 passed, ruff + format + terminology hooks clean

## Scenarios

- Workflow gate approval asked at a stage boundary; the approved tool is disallowed in the next stage → call must be blocked, not executed