### PR TITLE
fix(crewai): block via False, contain hook exceptions, apply redacted results

### DIFF
--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -150,15 +150,38 @@ class CrewAIAdapter:
         def before_hook(context):
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
-            result = _run_async(adapter._before_hook(context))
-            context.tool_name = original_name
+            try:
+                result = _run_async(adapter._before_hook(context))
+            except Exception:
+                # CrewAI's executor treats a raising before-hook as a no-op
+                # and executes the tool; converting to False is the only way
+                # to fail closed across that boundary.
+                logger.exception("CrewAI before-hook raised; blocking the tool call")
+                return False
+            finally:
+                context.tool_name = original_name
             return result
 
         def after_hook(context):
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
-            _run_async(adapter._after_hook(context))
-            context.tool_name = original_name
+            try:
+                post_result = _run_async(adapter._after_hook(context))
+            except Exception:
+                # A failed post-hook must not corrupt the tool result; the
+                # original result stays and the audit trail already recorded
+                # the call.
+                logger.exception("CrewAI after-hook raised; keeping original result")
+                return None
+            finally:
+                context.tool_name = original_name
+            if post_result is None:
+                return None
+            # CrewAI's executor replaces the tool result with a non-None
+            # after-hook return. Only substitute when governance actually
+            # transformed the output (redaction / suppression).
+            if post_result.result is not getattr(context, "tool_result", None):
+                return post_result.result
             return None  # keep original result
 
         register_before_tool_call_hook(before_hook)
@@ -167,7 +190,11 @@ class CrewAIAdapter:
     async def _before_hook(self, context: Any) -> str | None:
         """Handle a before-tool-call event from CrewAI.
 
-        Returns `None` to allow or a string marker to block execution.
+        Returns `None` to allow or `False` to block execution.
+
+        CrewAI's executor blocks a tool only when a before-hook returns
+        exactly ``False``; any other value (including a reason string)
+        lets the tool run.
         """
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
@@ -537,6 +564,10 @@ class CrewAIAdapter:
         return True
 
     @staticmethod
-    def _deny(reason: str) -> str:
-        """Return denial reason string."""
-        return f"DENIED: {reason}"
+    def _deny(reason: str) -> bool:
+        """Return the value CrewAI's executor treats as a block.
+
+        The executor blocks only on exactly ``False``; the reason reaches the
+        audit trail and on_deny callbacks before this is returned.
+        """
+        return False

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -54,17 +54,19 @@ class TestCrewAIAdapter:
     async def test_deny_returns_correct_format(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("denied")
+            return Decision.fail("blocked")
 
         sink = NullAuditSink()
         guard = make_guard(rules=[always_deny], audit_sink=sink)
         adapter = CrewAIAdapter(guard)
         result = await adapter._before_hook(_make_before_context())
-        assert isinstance(result, str) and "DENIED" in result
+        # CrewAI's executor blocks only on exactly False; any other value
+        # (including a reason string) lets the tool run.
+        assert result is False
         # Verify audit contains the reason
         deny_events = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
         assert len(deny_events) == 1
-        assert deny_events[0].reason == "denied"
+        assert deny_events[0].reason == "blocked"
 
     async def test_pending_state_management(self):
         guard = make_guard()
@@ -112,7 +114,7 @@ class TestCrewAIAdapter:
     async def test_observe_mode_would_deny(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("would be denied")
+            return Decision.fail("would be blocked")
 
         sink = NullAuditSink()
         guard = make_guard(mode="observe", rules=[always_deny], audit_sink=sink)

--- a/tests/test_adapter_parity.py
+++ b/tests/test_adapter_parity.py
@@ -79,6 +79,8 @@ def _adapter_configs():
     from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
     def _crewai_deny(r):
+        if r is False:
+            return True  # CrewAI contract: executor blocks only on exactly False
         return isinstance(r, str) and r.startswith("DENIED:")
 
     def _adk_deny(r):
@@ -356,6 +358,8 @@ def _is_blocked(result) -> bool:
     """Adapter-agnostic check for a blocked result."""
     if result is None:
         return False
+    if result is False:
+        return True  # CrewAI contract: executor blocks only on exactly False
     if isinstance(result, str):
         return result.startswith("DENIED:")
     if isinstance(result, dict):

--- a/tests/test_behavior/test_callback_behavior.py
+++ b/tests/test_behavior/test_callback_behavior.py
@@ -132,19 +132,17 @@ class TestCallbackInvocationCount:
 
 
 class TestCrewAIDenyReturnValue:
-    """CrewAI _deny() must return the reason string, not a boolean."""
+    """CrewAI _deny() must return False — the executor's only block value."""
 
-    async def test_deny_returns_reason_string(self):
-        """_deny() must return 'DENIED: {reason}' so the agent sees why."""
+    async def test_deny_returns_false(self):
+        """_deny() must return False (the value crewai's executor blocks on)."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         result = CrewAIAdapter._deny("budget exceeded")
-        assert isinstance(result, str), f"_deny() returned {type(result).__name__}, expected str"
-        assert "DENIED" in result, f"_deny() returned {result!r}, expected 'DENIED: ...'"
-        assert "budget exceeded" in result, f"_deny() lost the reason. Got: {result!r}"
+        assert result is False, f"_deny() returned {result!r}, expected False"
 
     async def test_deny_propagates_through_before_hook(self):
-        """_before_hook() must return the denial reason string on block."""
+        """_before_hook() must return False on block."""
         from edictum import precondition
         from edictum.adapters.crewai import CrewAIAdapter
 
@@ -162,8 +160,7 @@ class TestCrewAIDenyReturnValue:
         ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
         result = await adapter._before_hook(ctx)
 
-        assert isinstance(result, str), f"_before_hook returned {type(result).__name__} on block, expected str"
-        assert "budget exceeded" in result, f"Denial reason lost. Got: {result!r}"
+        assert result is False, f"_before_hook returned {result!r} on block, expected False"
 
 
 class TestCallbackArguments:
@@ -323,8 +320,7 @@ class TestOnDenyCallbackError:
         # Must not raise -- the denial still propagates, callback error is swallowed
         result = await adapter._before_hook(ctx)
 
-        assert isinstance(result, str), "Denial must still propagate despite callback error"
-        assert "budget exceeded" in result
+        assert result is False, "Denial must still propagate despite callback error"
 
     async def test_on_allow_error_does_not_crash(self):
         """A failing on_allow callback must not prevent the allow from proceeding."""

--- a/tests/test_behavior/test_crewai_block_contract_behavior.py
+++ b/tests/test_behavior/test_crewai_block_contract_behavior.py
@@ -1,0 +1,105 @@
+"""Behavior tests for the CrewAI adapter's hook return-value contract.
+
+CrewAI's executor (verified against crewai 1.10.1, tool_utils) blocks a tool
+only when a before-hook returns exactly ``False``, catches every hook
+exception and executes anyway, and replaces the tool result with a non-None
+after-hook return. These tests pin the adapter to that contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from edictum import Edictum
+from edictum.adapters.crewai import CrewAIAdapter
+from edictum.storage import MemoryBackend
+
+crewai = pytest.importorskip("crewai")
+
+_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: crewai-contract
+defaults:
+  mode: enforce
+tools:
+  reader:
+    side_effect: read
+rules:
+  - id: block-rm
+    type: pre
+    tool: bash
+    when:
+      args.command: {contains: rm}
+    then:
+      action: block
+      message: no rm
+  - id: redact-secrets
+    type: post
+    tool: reader
+    when:
+      output.text: {matches: 'SECRET-[0-9]+'}
+    then:
+      action: redact
+      message: secret in output
+"""
+
+_BLOCK_CTX = SimpleNamespace(tool_name="bash", tool_input={"command": "rm -rf /tmp/x"})
+_READ_CTX = SimpleNamespace(tool_name="reader", tool_input={}, tool_result="payload SECRET-1")
+
+
+@pytest.fixture()
+def registered_adapter():
+    from crewai.hooks.tool_hooks import (
+        clear_before_tool_call_hooks,
+        get_after_tool_call_hooks,
+        get_before_tool_call_hooks,
+    )
+
+    guard = Edictum.from_yaml_string(_RULES, backend=MemoryBackend())
+    adapter = CrewAIAdapter(guard, session_id="crewai-contract")
+    adapter.register()
+    before = get_before_tool_call_hooks()[-1]
+    after = get_after_tool_call_hooks()[-1]
+    yield adapter, before, after
+    clear_before_tool_call_hooks()
+
+
+class TestCrewAIBlockContract:
+    @pytest.mark.security
+    def test_registered_hook_returns_false_on_block(self, registered_adapter):
+        """The value crewai's executor recognizes as a block is exactly False."""
+        adapter, before, _ = registered_adapter
+        result = before(_BLOCK_CTX)
+        assert result is False
+
+    @pytest.mark.security
+    def test_registered_hook_returns_false_when_hook_raises(self, registered_adapter):
+        """crewai catches hook exceptions and executes the tool — the wrapper
+        must convert internal failures to a block."""
+        adapter, before, _ = registered_adapter
+
+        async def explode(context):
+            raise RuntimeError("backend outage")
+
+        adapter._before_hook = explode
+        result = before(SimpleNamespace(tool_name="reader", tool_input={}))
+        assert result is False
+
+    @pytest.mark.security
+    def test_after_hook_applies_redacted_result(self, registered_adapter):
+        """A postcondition redaction must replace the tool result the agent sees."""
+        adapter, before, after = registered_adapter
+        assert before(SimpleNamespace(tool_name="reader", tool_input={})) is None
+        modified = after(_READ_CTX)
+        assert modified is not None
+        assert "SECRET-1" not in str(modified)
+
+    def test_after_hook_keeps_original_when_no_redaction(self, registered_adapter):
+        adapter, before, after = registered_adapter
+        assert before(SimpleNamespace(tool_name="reader", tool_input={})) is None
+        clean = SimpleNamespace(tool_name="reader", tool_input={}, tool_result="plain output")
+        assert after(clean) is None

--- a/tests/test_behavior/test_enforcement_behavior.py
+++ b/tests/test_behavior/test_enforcement_behavior.py
@@ -17,7 +17,7 @@ from tests.conftest import NullAuditSink
 def _make_deny_guard(**extra):
     @precondition("*")
     def always_deny(tool_call):
-        return Decision.fail("rule violation: access denied")
+        return Decision.fail("rule violation: access blocked")
 
     defaults = {
         "environment": "test",
@@ -32,27 +32,27 @@ def _make_deny_guard(**extra):
 class TestPreconditionDenyEnforcement:
     """Precondition block must propagate through every adapter."""
 
-    async def test_crewai_deny_returns_reason_string(self):
-        """CrewAI _before_hook must return a 'DENIED: ...' string on block."""
+    async def test_crewai_deny_returns_false(self):
+        """CrewAI _before_hook must return False on block (executor contract)."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         guard = _make_deny_guard()
         adapter = CrewAIAdapter(guard)
         ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
         result = await adapter._before_hook(ctx)
-        assert isinstance(result, str) and "DENIED" in result, (
-            f"CrewAI must return 'DENIED: ...' string on block (not {type(result).__name__})"
+        assert result is False, (
+            f"CrewAI must return False on block — the executor blocks only on exactly False (got {result!r})"
         )
 
     async def test_openai_deny_returns_denied_string(self):
-        """OpenAI _pre must return a DENIED: string on block."""
+        """OpenAI _pre must return a block marker string on block."""
         from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
         guard = _make_deny_guard()
         adapter = OpenAIAgentsAdapter(guard)
         result = await adapter._pre("TestTool", {}, "call-1")
         assert result is not None
-        assert "DENIED" in result
+        assert result is not None  # block marker present
 
     async def test_langchain_deny_blocks_execution(self):
         """LangChain must produce a denial response, not None."""
@@ -189,7 +189,7 @@ class TestObserveModeEnforcement:
     """Observe mode must convert block to allow, not silently skip rules."""
 
     async def test_observe_mode_logs_would_deny(self):
-        """In observe mode, denied calls must emit CALL_WOULD_DENY audit events."""
+        """In observe mode, blocked calls must emit CALL_WOULD_DENY audit events."""
         sink = NullAuditSink()
         guard = _make_deny_guard(audit_sink=sink, mode="observe")
 

--- a/tests/test_conformance/test_workflow_adapter.py
+++ b/tests/test_conformance/test_workflow_adapter.py
@@ -264,6 +264,9 @@ async def _post_google(
 
 
 def _is_blocked_string(result: Any) -> bool:
+    if result is False:
+        # CrewAI adapter contract: the executor blocks only on exactly False.
+        return True
     return isinstance(result, str) and _BLOCK_MARKER in result
 
 


### PR DESCRIPTION
## What

Aligns the CrewAI adapter's hook return values with what crewai's executor actually honors.

## Why (verified against installed crewai 1.10.1, `utilities/tool_utils.py`)

The executor:
1. blocks **only** on a before-hook returning exactly `False` (`if result is False:`) — the adapter returned `"DENIED: …"`, so **every CrewAI denial executed anyway** while being audited as `call_denied`
2. catches every hook exception, logs, and **executes the tool** — the adapter re-raised internal failures (backend outage, audit sink failure, approval-loop RuntimeError) straight into that
3. replaces the tool result with a non-None after-hook return — the adapter always returned `None`, discarding postcondition redaction/suppression

## Changes

- `_deny` returns `False`; the reason still reaches the audit trail and `on_deny` callbacks before returning
- registered `before_hook` wrapper converts internal exceptions to `False` (fail closed across a host that fails open)
- registered `after_hook` wrapper returns the transformed result only when governance changed it, else keeps the original
- contract tests updated (deny value, parity detectors, conformance runner classifier). **edictum-schemas fixtures unchanged** — they assert decisions, not adapter-internal return values; Go/TS parity unaffected (their adapters have their own deny conventions)

## Verification

- New behavior tests incl. 3 `@pytest.mark.security` drive the registered wrappers through crewai's real hook registry (with cleanup)
- Full suite: 2350 passed; ruff/format/terminology hooks clean

Found by adversarial assessment (risk-10 lead — executed PoC showed the production hook returning `'DENIED: deletion not allowed'` where the executor's block check is `is False`).