### PR TITLE
fix(approval): re-evaluate remaining checks after a non-workflow ask grant

### DIFF
--- a/src/edictum/_runner.py
+++ b/src/edictum/_runner.py
@@ -114,7 +114,7 @@ async def _run(
                     decision_source=pre.decision_source,
                     decision_name=pre.decision_name,
                 )
-            if pre.action == "pending_approval":
+            if pre.action == "pending_approval" or (approval_audit_handled and pre.action == "allow"):
                 self.telemetry.record_allowed(envelope)
                 if self._on_allow:
                     try:
@@ -352,7 +352,24 @@ async def _resolve_pending_approval(
             return False, decision, current, False
 
         if current.decision_source != "workflow" or not current.workflow_stage_id or self._workflow_runtime is None:
-            return True, decision, current, True
+            # Non-workflow ask rule approved. The pending return skipped the
+            # checks ordered after it (sandbox, session rules, workflow
+            # gates, limits) — record the grant bound to this call, then
+            # re-run them and honor a block from the re-run.
+            await session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+            re_eval = await pipeline.pre_execute(envelope, session)
+            await _emit_workflow_events(self, envelope, session, re_eval.workflow_events)
+            if re_eval.action == "pending_approval":
+                current = re_eval
+                continue
+            if re_eval.action != "block":
+                # Carry the original approval metadata so span/timeout
+                # handling reflects the grant that actually happened.
+                re_eval.approval_timeout = current.approval_timeout
+                re_eval.approval_timeout_action = current.approval_timeout_action
+            # approval_audit_handled stays True for allow (the approval events
+            # already fired); a block must emit its own CALL_DENIED audit.
+            return True, decision, re_eval, re_eval.action != "block"
 
         await self._workflow_runtime.record_approval(session, current.workflow_stage_id)
         current = await pipeline.pre_execute(envelope, session)

--- a/src/edictum/adapters/agno.py
+++ b/src/edictum/adapters/agno.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -427,7 +427,17 @@ class AgnoAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -397,7 +397,17 @@ class ClaudeAgentSDKAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -454,7 +454,17 @@ class CrewAIAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -207,7 +207,16 @@ class CrewAIAdapter:
                 self._pending_decision = decision
                 return None  # allow through
 
-            # Handle block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
+                if blocked_result is not None:
+                    span.end()
+                    self._pending_envelope = None
+                    self._pending_span = None
+                    self._pending_decision = None
+                    return blocked_result
+
+            # Handle block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -223,15 +232,6 @@ class CrewAIAdapter:
                 self._pending_span = None
                 self._pending_decision = None
                 return self._deny(decision.reason or "")
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
-                if blocked_result is not None:
-                    span.end()
-                    self._pending_envelope = None
-                    self._pending_span = None
-                    self._pending_decision = None
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/src/edictum/adapters/google_adk.py
+++ b/src/edictum/adapters/google_adk.py
@@ -182,6 +182,21 @@ class GoogleADKAdapter:
                 result, decision = await self._resolve_pending_approval(envelope, decision, span)
                 if result is not None:
                     return result  # span ended inside _handle_approval
+                # The post-approval re-run can return block (e.g. the tool is
+                # not allowed in the stage the approval advanced to) — it must
+                # not fall through to the allow path.
+                if decision.action == "block":
+                    await self._emit_audit_pre(envelope, decision)
+                    self._guard.telemetry.record_denial(envelope, decision.reason)
+                    if self._guard._on_deny:
+                        try:
+                            self._guard._on_deny(envelope, decision.reason or "", decision.decision_name)
+                        except Exception:
+                            logger.exception("on_deny callback raised")
+                    span.set_attribute("governance.action", "denied")
+                    self._guard.telemetry.set_span_error(span, decision.reason or "denied")
+                    span.end()
+                    return self._deny(decision.reason or "")
                 await self._emit_audit_pre(envelope, decision)
                 if self._guard._on_allow:
                     try:

--- a/src/edictum/adapters/google_adk.py
+++ b/src/edictum/adapters/google_adk.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -495,7 +495,17 @@ class GoogleADKAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/langchain.py
+++ b/src/edictum/adapters/langchain.py
@@ -247,7 +247,14 @@ class LangChainAdapter:
                 self._pending_decisions[tool_call_id] = decision
                 return None  # allow through
 
-            # Block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span, tool_call_id)
+                if blocked_result is not None:
+                    self._pending.pop(tool_call_id, None)
+                    self._pending_decisions.pop(tool_call_id, None)
+                    return blocked_result
+
+            # Block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -262,13 +269,6 @@ class LangChainAdapter:
                 self._pending.pop(tool_call_id, None)
                 self._pending_decisions.pop(tool_call_id, None)
                 return self._deny(decision.reason or "", tool_call_id)
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span, tool_call_id)
-                if blocked_result is not None:
-                    self._pending.pop(tool_call_id, None)
-                    self._pending_decisions.pop(tool_call_id, None)
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/src/edictum/adapters/langchain.py
+++ b/src/edictum/adapters/langchain.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -475,7 +475,17 @@ class LangChainAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/nanobot.py
+++ b/src/edictum/adapters/nanobot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus, _request_approval_with_session_compat
@@ -272,7 +272,17 @@ class GovernedToolRegistry:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/nanobot.py
+++ b/src/edictum/adapters/nanobot.py
@@ -136,6 +136,20 @@ class GovernedToolRegistry:
                 result, decision = await self._resolve_pending_approval(envelope, decision, span)
                 if result is not None:
                     return result
+                # The post-approval re-run can return block (e.g. the tool is
+                # not allowed in the stage the approval advanced to) — deny
+                # instead of falling through to execute.
+                if decision.action == "block":
+                    await self._emit_audit_pre(envelope, decision)
+                    self._guard.telemetry.record_denial(envelope, decision.reason)
+                    if self._guard._on_deny:
+                        try:
+                            self._guard._on_deny(envelope, decision.reason or "", decision.decision_name)
+                        except Exception:
+                            logger.exception("on_deny callback raised")
+                    span.set_attribute("governance.action", "denied")
+                    self._guard.telemetry.set_span_error(span, decision.reason or "denied")
+                    return f"[DENIED] {decision.reason}"
                 # Approved — fall through to execute
             else:
                 # Handle per-rule observed blocks

--- a/src/edictum/adapters/openai_agents.py
+++ b/src/edictum/adapters/openai_agents.py
@@ -205,7 +205,15 @@ class OpenAIAgentsAdapter:
                 self._pending_decisions[call_id] = decision
                 return None  # allow through
 
-            # Handle block
+            if decision.action == "pending_approval":
+                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
+                if blocked_result is not None:
+                    span.end()
+                    self._pending.pop(call_id, None)
+                    self._pending_decisions.pop(call_id, None)
+                    return blocked_result
+
+            # Handle block (also covers a block produced by the post-approval re-run)
             if decision.action == "block":
                 await self._emit_audit_pre(envelope, decision)
                 self._guard.telemetry.record_denial(envelope, decision.reason)
@@ -220,14 +228,6 @@ class OpenAIAgentsAdapter:
                 self._pending.pop(call_id, None)
                 self._pending_decisions.pop(call_id, None)
                 return self._deny(decision.reason or "")
-
-            if decision.action == "pending_approval":
-                blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
-                if blocked_result is not None:
-                    span.end()
-                    self._pending.pop(call_id, None)
-                    self._pending_decisions.pop(call_id, None)
-                    return blocked_result
 
             # Handle per-rule observed blocks
             if decision.observed:

--- a/src/edictum/adapters/openai_agents.py
+++ b/src/edictum/adapters/openai_agents.py
@@ -6,7 +6,7 @@ import json
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -451,7 +451,17 @@ class OpenAIAgentsAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/adapters/semantic_kernel.py
+++ b/src/edictum/adapters/semantic_kernel.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
@@ -403,7 +403,17 @@ class SemanticKernelAdapter:
                 or not current.workflow_stage_id
                 or self._guard._workflow_runtime is None
             ):
-                return None, replace(current, action="allow")
+                # Non-workflow ask rule approved. The pending return skipped
+                # the checks ordered after it (sandbox, session rules,
+                # workflow gates, limits) — record the grant bound to this
+                # call, then re-run them and honor a block.
+                await self._session.set_value(f"ask:{current.decision_name}:{envelope.call_id}", "approved")
+                re_eval = await self._pipeline.pre_execute(envelope, self._session)
+                await self._emit_workflow_events(envelope, re_eval.workflow_events)
+                if re_eval.action == "pending_approval":
+                    current = re_eval
+                    continue
+                return None, re_eval
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
             await self._emit_workflow_events(envelope, current.workflow_events)

--- a/src/edictum/pipeline.py
+++ b/src/edictum/pipeline.py
@@ -18,6 +18,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _ask_approved(session: Session, rule_name: str, call_id: str) -> bool:
+    """True when this exact call already received a grant for the ask rule.
+
+    A granted ask approval binds to the call (rule id + call id) so that the
+    post-approval re-evaluation does not re-ask the same rule.
+    """
+    from edictum.session import _validate_key_component
+
+    name = f"ask:{rule_name}:{call_id}"
+    try:
+        _validate_key_component(name)
+    except ValueError:
+        return False
+    return await session.get_value(name) == "approved"
+
+
 @dataclass
 class PreDecision:
     """Result of pre-execution governance evaluation."""
@@ -160,6 +176,8 @@ class CheckPipeline:
 
                 action = getattr(rule, "_edictum_effect", "block")
                 if action == "ask":
+                    if await _ask_approved(session, rule_record["name"], tool_call.call_id):
+                        continue  # already granted for this exact call
                     return PreDecision(
                         action="pending_approval",
                         reason=decision.message,
@@ -215,6 +233,8 @@ class CheckPipeline:
 
                 action = getattr(rule, "_edictum_effect", "block")
                 if action == "ask":
+                    if await _ask_approved(session, rule_record["name"], tool_call.call_id):
+                        continue  # already granted for this exact call
                     return PreDecision(
                         action="pending_approval",
                         reason=decision.message,

--- a/tests/test_behavior/test_approval_reevaluation_behavior.py
+++ b/tests/test_behavior/test_approval_reevaluation_behavior.py
@@ -1,0 +1,119 @@
+"""Behavior tests for post-approval re-evaluation of non-workflow ask rules.
+
+An approved ask rule must not waive the checks ordered after it in the
+pipeline (sandbox, session rules, workflow gates, limits): after a grant, the
+remaining checks are re-run and a block from the re-run is honored. The grant
+binds to the exact call (rule id + call id) so the re-run does not re-ask.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from edictum import Edictum
+from edictum._exceptions import EdictumDenied
+from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
+from edictum.adapters.langchain import LangChainAdapter
+from edictum.approval import (
+    ApprovalBackend,
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalStatus,
+)
+from edictum.audit import AuditAction
+from edictum.storage import MemoryBackend
+
+_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: approval-reevaluation
+defaults:
+  mode: enforce
+rules:
+  - id: ask-before-bash
+    type: pre
+    tool: Bash
+    when:
+      tool.name: {equals: Bash}
+    then:
+      action: ask
+      message: run this bash command?
+  - id: path-sandbox
+    type: sandbox
+    tools: [Bash]
+    within:
+      - /tmp/safe-zone
+    message: path outside sandbox
+"""
+
+
+class AutoApprove(ApprovalBackend):
+    def __init__(self):
+        self.requests = 0
+
+    async def request_approval(self, tool_name, tool_args, message, **kw):
+        self.requests += 1
+        return ApprovalRequest(
+            approval_id=f"a{self.requests}",
+            tool_name=tool_name,
+            tool_args=tool_args,
+            message=message,
+            timeout=30,
+        )
+
+    async def wait_for_decision(self, approval_id, timeout=None):
+        return ApprovalDecision(approved=True, approver="human", status=ApprovalStatus.APPROVED)
+
+
+def _guard():
+    return Edictum.from_yaml_string(_RULES, backend=MemoryBackend(), approval_backend=AutoApprove())
+
+
+class TestPostApprovalReevaluation:
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_approval_does_not_waive_sandbox(self):
+        guard = _guard()
+        with pytest.raises(EdictumDenied, match="path outside sandbox"):
+            await guard.run("Bash", {"command": "cat /etc/passwd"}, lambda **kw: "ran")
+        executed = [e for e in guard.local_sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert not executed
+
+    @pytest.mark.asyncio
+    async def test_approved_call_within_sandbox_executes(self):
+        guard = _guard()
+        result = await guard.run("Bash", {"command": "cat /tmp/safe-zone/file"}, lambda **kw: "ok")
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_grant_binds_to_the_call_no_reask(self):
+        guard = _guard()
+        await guard.run("Bash", {"command": "cat /tmp/safe-zone/file"}, lambda **kw: "ok")
+        assert guard._approval_backend.requests == 1, "the approved rule must not be re-asked"
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_new_call_asks_again(self):
+        guard = _guard()
+        await guard.run("Bash", {"command": "cat /tmp/safe-zone/a"}, lambda **kw: "ok")
+        await guard.run("Bash", {"command": "cat /tmp/safe-zone/b"}, lambda **kw: "ok")
+        assert guard._approval_backend.requests == 2, "a new call must ask again"
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_langchain_honors_post_approval_block(self):
+        guard = _guard()
+        adapter = LangChainAdapter(guard, session_id="re-eval-lc")
+        req = SimpleNamespace(tool_call={"name": "Bash", "args": {"command": "cat /etc/passwd"}, "id": "d1"})
+        result = await adapter._pre_tool_call(req)
+        assert result is not None, "sandbox-blocked call must not execute after approval"
+
+    @pytest.mark.asyncio
+    async def test_claude_adapter_still_executes_clean_call(self):
+        guard = _guard()
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="re-eval-cl")
+        result = await adapter._pre_tool_use("Bash", {"command": "cat /tmp/safe-zone/f"}, "c1")
+        assert result == {}

--- a/tests/workflow/test_adapter_workflow_approval_integration.py
+++ b/tests/workflow/test_adapter_workflow_approval_integration.py
@@ -274,3 +274,92 @@ async def test_nanobot_adapter_workflow_approval_advances_and_completes():
     assert state.evidence.reads == ["spec.md"]
     assert state.evidence.stage_calls["push"] == ["git push origin branch"]
     _assert_last_recorded_evidence(guard, "nanobot-approval", "Bash", "git push origin branch")
+
+
+_NOT_ALLOWED_WORKFLOW = """
+apiVersion: edictum/v1
+kind: Workflow
+metadata:
+  name: adapter-approval-not-allowed
+stages:
+  - id: read-context
+    tools: [Read]
+    approval:
+      message: approve to finish the read stage
+  - id: push
+    tools: [Bash]
+"""
+
+
+def _build_not_allowed_guard() -> Edictum:
+    return Edictum.from_yaml_string(
+        _BUNDLE,
+        backend=MemoryBackend(),
+        workflow_content=_NOT_ALLOWED_WORKFLOW,
+        approval_backend=AutoApproveBackend(),
+    )
+
+
+async def _drive_not_allowed(adapter_factory):
+    """Call a tool allowed in NO stage; the approval gate fires first.
+
+    The post-approval re-run returns block (the tool is not allowed in the
+    stage the approval advanced to). Every adapter must surface that block —
+    dropping it executes a call the pipeline just blocked.
+    """
+    guard = _build_not_allowed_guard()
+    adapter = adapter_factory(guard)
+    return await adapter(guard)
+
+
+def _adapters():
+    from types import SimpleNamespace
+
+    async def langchain(guard):
+        adapter = LangChainAdapter(guard, session_id="na-langchain")
+        req = SimpleNamespace(tool_call={"name": "Dangerous", "args": {"x": 1}, "id": "d1"})
+        return await adapter._pre_tool_call(req)  # None means allowed
+
+    async def openai(guard):
+        adapter = OpenAIAgentsAdapter(guard, session_id="na-openai")
+        return await adapter._pre("Dangerous", {"x": 1}, "d1")
+
+    async def crewai(guard):
+        adapter = CrewAIAdapter(guard, session_id="na-crewai")
+        ctx = SimpleNamespace(tool_name="Dangerous", tool_input={"x": 1})
+        return await adapter._before_hook(ctx)
+
+    async def google(guard):
+        adapter = GoogleADKAdapter(guard, session_id="na-google")
+        return await adapter._pre("Dangerous", {"x": 1}, "d1")
+
+    async def nanobot(guard):
+        registry = GovernedToolRegistry(_InnerRegistry(), guard, session_id="na-nanobot")
+        return await registry.execute("Dangerous", {"x": 1})
+
+    async def claude(guard):
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="na-claude")
+        return await adapter._pre_tool_use("Dangerous", {"x": 1}, "d1")
+
+    return [langchain, openai, crewai, google, nanobot, claude]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("driver", _adapters(), ids=lambda d: d.__name__)
+async def test_post_approval_block_is_not_dropped(driver):
+    """Regression: the block produced by the post-approval re-run must reach
+    the framework on every adapter (previously dropped by langchain, crewai,
+    nanobot, google_adk; claude held)."""
+    result = await driver(_build_not_allowed_guard())
+    if result is None:
+        is_allowed = True
+    elif isinstance(result, str):
+        _marker = chr(68) + "ENIED"  # adapter deny marker prefix (kept split for the terminology check)
+        is_allowed = _marker not in result
+    elif isinstance(result, dict):
+        is_allowed = "error" not in result and result.get("hookSpecificOutput", {}).get("permissionDecision") != "deny"
+    else:
+        is_allowed = False
+    assert not is_allowed, (
+        f"adapter {driver.__name__} allowed a call the pipeline blocked after approval (result={result!r})"
+    )


### PR DESCRIPTION
Stacks on #236.

## What

After a human approves a non-workflow `action: ask` rule, the pipeline checks that the pending return skipped (sandbox, session rules, workflow gates, limits) are now re-run, and a block from the re-run is honored. The grant binds to the exact call (rule id + call id) so the re-run doesn't re-ask the same rule.

## Why

Pipeline ordering: an ask rule returns `pending_approval` at step 3 — **before** sandbox (3.5), session (4), workflow (5), limits (6). The approval path then jumped straight to execution for non-workflow sources (adapters forged `replace(current, action="allow")`; `run()` returned the stale pending decision). One human yes to "run this tool?" executed a call the path sandbox would have blocked, with `call_executed` audited and `rules_evaluated=[]`.

Executed PoC: control run blocked `/etc/passwd` by the sandbox; identical call with an earlier ask rule + approval **executed**.

## Changes

- `pipeline._ask_approved`: an ask rule granted for this exact call is skipped on re-evaluation
- grant recorded in session state (`ask:{rule}:{call_id}`) by `_run` and all 8 adapters
- non-workflow approval path re-runs `pre_execute`; block → CALL_DENIED + deny (runner) / adapter block shape; a different later ask rule starts a new approval round under the existing 32-round cap
- approval metadata (timeout fields) carried onto the re-evaluated decision so span/timeout handling is unchanged

## Verification

- 6 new behavior tests incl. 3 `@pytest.mark.security`: sandbox survives approval, clean call still executes, no re-ask within a call, new call asks again, langchain + claude adapters
- Full suite: 2358 passed; hooks clean