### PR TITLE
fix(redaction): redact tool args sent to approval backends; match camelCase sensitive keys

### DIFF
--- a/src/edictum/_runner.py
+++ b/src/edictum/_runner.py
@@ -325,7 +325,7 @@ async def _resolve_pending_approval(
         approval_request = await _request_approval_with_session_compat(
             self._approval_backend,
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self.redaction.redact_args(envelope.args),
             message=current.approval_message or current.reason or "",
             timeout=current.approval_timeout,
             timeout_action=current.approval_timeout_action,

--- a/src/edictum/adapters/agno.py
+++ b/src/edictum/adapters/agno.py
@@ -453,7 +453,7 @@ class AgnoAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -422,7 +422,7 @@ class ClaudeAgentSDKAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -479,7 +479,7 @@ class CrewAIAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/google_adk.py
+++ b/src/edictum/adapters/google_adk.py
@@ -509,7 +509,7 @@ class GoogleADKAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/langchain.py
+++ b/src/edictum/adapters/langchain.py
@@ -507,7 +507,7 @@ class LangChainAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/nanobot.py
+++ b/src/edictum/adapters/nanobot.py
@@ -285,7 +285,7 @@ class GovernedToolRegistry:
         approval_request = await _request_approval_with_session_compat(
             self._guard._approval_backend,
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/openai_agents.py
+++ b/src/edictum/adapters/openai_agents.py
@@ -477,7 +477,7 @@ class OpenAIAgentsAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/adapters/semantic_kernel.py
+++ b/src/edictum/adapters/semantic_kernel.py
@@ -429,7 +429,7 @@ class SemanticKernelAdapter:
         principal_dict = asdict(envelope.principal) if envelope.principal else None
         approval_request = await self._guard._approval_backend.request_approval(
             tool_name=envelope.tool_name,
-            tool_args=envelope.args,
+            tool_args=self._guard.redaction.redact_args(envelope.args),
             message=decision.approval_message or decision.reason or "",
             timeout=decision.approval_timeout,
             timeout_action=decision.approval_timeout_action,

--- a/src/edictum/audit.py
+++ b/src/edictum/audit.py
@@ -218,15 +218,15 @@ class RedactionPolicy:
     )
 
     def _is_sensitive_key(self, key: str) -> bool:
-        k = key.lower()
-        # Normalize hyphens to underscores so both "api-key" and "api_key"
-        # match consistently across sensitive keys, safe keys, and word parts.
-        normalized = k.replace("-", "_")
+        # Normalize hyphens AND camelCase to underscores so "api-key",
+        # "api_key" and "apiKey" match consistently across sensitive keys,
+        # safe keys, and word parts (clientSecret -> client_secret).
+        normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).lower().replace("-", "_")
         if normalized in self._keys:
             return True
         if normalized in self._safe_compound_keys:
             return False
-        parts = re.split(r"[_\-]", k)
+        parts = re.split(r"[_\-]", normalized)
         return any(p in self._SENSITIVE_PARTS for p in parts)
 
     def _looks_like_secret(self, value: str) -> bool:

--- a/tests/test_behavior/test_approval_redaction_behavior.py
+++ b/tests/test_behavior/test_approval_redaction_behavior.py
@@ -43,3 +43,61 @@ class TestLocalApprovalRedaction:
         assert "hunter2" not in captured.out
         assert "[REDACTED]" in captured.out
         assert "localhost" in captured.out
+
+
+class TestApprovalRequestRedaction:
+    """Approval requests must receive the same redaction as audit events.
+
+    ServerApprovalBackend posts tool_args to /v1/approvals, which fans out to
+    Slack/Telegram/Discord — raw credentials must not reach human channels or
+    third-party chat logs.
+    """
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_runner_redacts_args_before_approval_request(self):
+        from edictum import Edictum
+
+        rules = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: approval-redaction
+defaults:
+  mode: enforce
+rules:
+  - id: ask-deploy
+    type: pre
+    tool: deploy
+    when:
+      tool.name: {equals: deploy}
+    then:
+      action: ask
+      message: deploy?
+"""
+        captured = {}
+
+        class Capture(LocalApprovalBackend):
+            async def request_approval(self, tool_name, tool_args, message, **kw):
+                captured["args"] = dict(tool_args)
+                return await super().request_approval(tool_name, tool_args, message, **kw)
+
+        guard = Edictum.from_yaml_string(rules, approval_backend=Capture())
+        try:
+            await guard.run("deploy", {"api_key": "sk-live-xyz123", "note": "x"}, lambda **kw: "ok")
+        except Exception:
+            pass
+        assert captured["args"].get("api_key") == "[REDACTED]"
+
+    @pytest.mark.security
+    def test_camel_case_sensitive_keys_are_redacted(self):
+        from edictum.audit import RedactionPolicy
+
+        policy = RedactionPolicy()
+        redacted = policy.redact_args(
+            {"clientSecret": "hunter2", "accessToken": "tok", "sessionKey": "k", "maxTokens": 100}
+        )
+        assert redacted["clientSecret"] == "[REDACTED]"
+        assert redacted["accessToken"] == "[REDACTED]"
+        assert redacted["sessionKey"] == "[REDACTED]"
+        assert redacted["maxTokens"] == 100  # safe compound key survives


### PR DESCRIPTION
## What

1. All nine approval-request call sites (runner + 8 adapters) now pass `redact_args(envelope.args)` — the same redaction every audit event for the same call already applies.
2. `_is_sensitive_key` normalizes camelCase before matching (`clientSecret` → `client_secret`), with the split at lowercase→uppercase boundaries only so `PASSWORD` still reduces correctly.

## Why (executed PoC)

A capture backend received `{'api_key': 'sk-live-…', 'clientSecret': 'hunter2-blue', …}` verbatim while the audit event for the same call recorded `api_key: [REDACTED]`. In production, `ServerApprovalBackend` posts these to `/v1/approvals` which fans out to Telegram/Slack/Discord — live credentials in third-party chat logs. The same output showed the camelCase gap: `clientSecret` unredacted in audit too.

LocalApprovalBackend already redacted at its display layer (`test_approval_redaction_behavior.py`, `@pytest.mark.security`) — the other nine sites just never mirrored it.

## Verification

- 4 tests in the redaction behavior file (3 `@pytest.mark.security`): runner redacts before request; camelCase redacted; `maxTokens` safe-compound survives; existing PASSWORD case still green
- Full suite: 2348 passed; ruff/format/terminology clean