### PR TITLE
fix(server): reject malformed batch_get 200 instead of reading zero counters

### DIFF
--- a/src/edictum/server/backend.py
+++ b/src/edictum/server/backend.py
@@ -73,7 +73,15 @@ class ServerBackend:
                 "/v1/sessions/batch",
                 {"keys": keys},
             )
-            values = response.get("values", {})
+            values = response.get("values")
+            if not isinstance(values, dict):
+                # A 200 without a values mapping is a malformed response, not
+                # "all keys missing" — treating it as empty would read every
+                # counter as zero and silently disable operation limits.
+                raise EdictumServerError(
+                    200,
+                    f"Malformed batch response: expected 'values' mapping, got {type(values).__name__}",
+                )
             return {key: values.get(key) for key in keys}
         except EdictumServerError as exc:
             if exc.status_code in (404, 405):

--- a/tests/test_behavior/test_batch_session_behavior.py
+++ b/tests/test_behavior/test_batch_session_behavior.py
@@ -290,3 +290,25 @@ class TestPipelineBatchIntegration:
             await pipeline.pre_execute(tool_call, session)
 
             mock_batch.assert_called_once_with(include_tool=None)
+
+
+class TestServerFailureModes:
+    """Malformed success responses must fail closed; raised flushes must not
+    drop the audit batch. Uses httpx.MockTransport (controlled dependency)."""
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_batch_get_malformed_200_raises(self, monkeypatch):
+        import httpx
+
+        from edictum.server.backend import ServerBackend
+        from edictum.server.client import EdictumServerClient
+
+        client = EdictumServerClient("http://localhost:9", "k", agent_id="poc", env="prod")
+        client._ensure_client()
+        client._local.client._transport = httpx.MockTransport(
+            lambda request: httpx.Response(200, json={"unrelated": True})
+        )
+        backend = ServerBackend(client)
+        with pytest.raises(EdictumServerError, match="Malformed batch response"):
+            await backend.batch_get(["s:poc:attempts", "s:poc:execs"])


### PR DESCRIPTION
## What

`ServerBackend.batch_get` raises `EdictumServerError` when a 200 response's `values` field is not a mapping.

## Why (executed against a mock transport in the assessment)

`response.get("values", {})` turned a malformed 200 into "all keys absent" → every session counter read as 0 → `max_tool_calls` / `max_attempts` / per-tool caps silently pass. The backend docstring says "Fail-closed: other errors propagate so the pipeline denies rather than silently allowing with missing data" — a well-formed-status malformed body is not an error by that code's definition, and it failed open. A broken server version or TLS-terminating intermediary returning `200 {}` disables all operation limits with no signal.

## Deliberately out of scope

The 4xx-flush **dropping** the audit batch (`_flush` raises without `_restore_events`) is a documented, security-tested design choice (`test_audit_sink_auth_behavior.py`: auth errors never retry; event lost, not hoarded). Reversing it is a design decision, not a mechanical fix — recorded in the assessment report instead.

## Verification

- New `@pytest.mark.security` test: malformed 200 raises `EdictumServerError` (mock transport)
- Full suite: 2347 passed; ruff/format/terminology clean