### PR TITLE
fix(test): gate v0.18 conformance on loaded fixtures, not directory

### DIFF
--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -18,10 +18,11 @@ concurrency:
 jobs:
   gate:
     # Pin points at the sdk-gate commit that exports absolute
-    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR.
+    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR
+    # (edictum-ai/.github#8dcbbf3, landed on main).
     # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
     # purpose: it shadowed the workflow's export with a relative path.
-    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@d82a6556454dd3707043cc21a728569397693de4
+    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@8dcbbf351385ad493929531f4181aa0616a8dfe6
     with:
       runner: blacksmith-2vcpu-ubuntu-2404-arm
       runtime: python

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -17,7 +17,11 @@ concurrency:
 
 jobs:
   gate:
-    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@a8b075f4d60354e79bd26e06353c5367b75296b2
+    # Pin points at the sdk-gate commit that exports absolute
+    # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR.
+    # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
+    # purpose: it shadowed the workflow's export with a relative path.
+    uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@d82a6556454dd3707043cc21a728569397693de4
     with:
       runner: blacksmith-2vcpu-ubuntu-2404-arm
       runtime: python
@@ -25,7 +29,6 @@ jobs:
       setup-command: pip install -e ".[dev,yaml,sinks,cli]"
       test-command: pytest tests/ -v
       conformance-command: >-
-        EDICTUM_SCHEMAS_DIR=edictum-schemas
         EDICTUM_CONFORMANCE_REQUIRED=1
         pytest tests/test_conformance/ -v
-      fixture-ref: 81505da9e45fac7a54978959c2f64b794554f0dd
+      fixture-ref: 59df5f7f029f7ddcde35e35343405a62c7a405ce

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -32,4 +32,4 @@ jobs:
       conformance-command: >-
         EDICTUM_CONFORMANCE_REQUIRED=1
         pytest tests/test_conformance/ -v
-      fixture-ref: 59df5f7f029f7ddcde35e35343405a62c7a405ce
+      fixture-ref: c0cfa040c80b7ec22a10a6960108e82196025693

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -21,7 +21,7 @@ jobs:
     # EDICTUM_SCHEMAS_DIR and no longer exports EDICTUM_FIXTURES_DIR
     # (edictum-ai/.github#8dcbbf3, landed on main).
     # The inline relative EDICTUM_SCHEMAS_DIR assignment is gone on
-    # purpose: it shadowed the workflow's export with a relative path.
+    # purpose: it overrode the workflow's export with a relative path.
     uses: edictum-ai/.github/.github/workflows/sdk-gate.yml@8dcbbf351385ad493929531f4181aa0616a8dfe6
     with:
       runner: blacksmith-2vcpu-ubuntu-2404-arm

--- a/scripts/check-terminology.py
+++ b/scripts/check-terminology.py
@@ -51,9 +51,6 @@ DENIED_ALLOWLIST = {
     'assert "[DENIED]" not in result',
     'governance.action", "denied"',
     'or "denied"',
-    # v0.18 extends fixtures carry the legacy wire verdict "denied"; the
-    # runner compares against the fixture vocabulary, not prose
-    '"denied", "block"',
 }
 
 # "shadow" needs special handling — prose should say "observe mode" / "observe-mode".

--- a/scripts/check-terminology.py
+++ b/scripts/check-terminology.py
@@ -51,6 +51,9 @@ DENIED_ALLOWLIST = {
     'assert "[DENIED]" not in result',
     'governance.action", "denied"',
     'or "denied"',
+    # v0.18 extends fixtures carry the legacy wire verdict "denied"; the
+    # runner compares against the fixture vocabulary, not prose
+    '"denied", "block"',
 }
 
 # "shadow" needs special handling — prose should say "observe mode" / "observe-mode".

--- a/tests/test_conformance/test_v018_gate.py
+++ b/tests/test_conformance/test_v018_gate.py
@@ -6,9 +6,9 @@ under pytest as a child process against a temporary fixtures tree and
 asserts on the exit status AND the specific rejection reason in the
 output — a non-zero exit alone would also pass on any unrelated crash.
 
-With the gate reverted to checking only the directory, the empty-directory
-child collects successfully (every parametrize list is empty and the module
-skips), exits 0, and these tests go red.
+With the gate reverted to checking only the directory, or only the
+union of loaded fixtures, the empty-directory and one-suite children
+collect successfully, exit 0, and these tests go red.
 """
 
 from __future__ import annotations
@@ -22,6 +22,12 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _RUNNER = "tests/test_conformance/test_workflow_v018.py"
 _REQUIRED_MESSAGE = "no workflow-v0.18 fixtures were loaded"
+_SUITE_FILES = (
+    "wildcard-tools.workflow-v0.18.yaml",
+    "terminal-stage.workflow-v0.18.yaml",
+    "mcp-result-evidence.workflow-v0.18.yaml",
+    "extends-inheritance.workflow-v0.18.yaml",
+)
 
 
 def _run_runner(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -41,8 +47,15 @@ def _run_runner(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[st
     )
 
 
-def _empty_v018_root(tmp: Path) -> str:
-    (tmp / "fixtures" / "workflow-v0.18").mkdir(parents=True)
+def _v018_root(tmp: Path, present: dict[str, str] | None = None) -> str:
+    """Write a fixtures tree. ``present`` maps suite filename -> fixture id.
+
+    Omitted names are missing files. That is the truncated-checkout shape.
+    """
+    d = tmp / "fixtures" / "workflow-v0.18"
+    d.mkdir(parents=True)
+    for filename, fixture_id in (present or {}).items():
+        (d / filename).write_text(f"suite: stub\nfixtures:\n  - id: {fixture_id}\n")
     return str(tmp)
 
 
@@ -50,18 +63,58 @@ def test_required_mode_empty_dir_fails_collection() -> None:
     with tempfile.TemporaryDirectory(prefix="edictum-v018-empty-") as tmp:
         result = _run_runner(
             {
-                "EDICTUM_SCHEMAS_DIR": _empty_v018_root(Path(tmp)),
+                "EDICTUM_SCHEMAS_DIR": _v018_root(Path(tmp)),
                 "EDICTUM_CONFORMANCE_REQUIRED": "1",
             }
         )
         combined = result.stdout + result.stderr
         assert result.returncode != 0, f"runner output:\n{combined}"
         assert _REQUIRED_MESSAGE in combined, f"runner output:\n{combined}"
+        assert "empty suites: " + ", ".join(
+            name.removesuffix(".workflow-v0.18.yaml") for name in _SUITE_FILES
+        ) in combined, f"runner output:\n{combined}"
+
+
+def test_required_mode_one_nonempty_suite_fails_collection() -> None:
+    with tempfile.TemporaryDirectory(prefix="edictum-v018-partial-") as tmp:
+        result = _run_runner(
+            {
+                "EDICTUM_SCHEMAS_DIR": _v018_root(
+                    Path(tmp),
+                    {_SUITE_FILES[0]: "only-wildcard"},
+                ),
+                "EDICTUM_CONFORMANCE_REQUIRED": "1",
+            }
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0, f"runner output:\n{combined}"
+        assert _REQUIRED_MESSAGE in combined, f"runner output:\n{combined}"
+        assert (
+            "empty suites: terminal-stage, mcp-result-evidence, extends-inheritance"
+            in combined
+        ), f"runner output:\n{combined}"
+        assert "empty suites: wildcard-tools" not in combined, f"runner output:\n{combined}"
+
+
+def test_required_mode_all_four_suites_collects() -> None:
+    with tempfile.TemporaryDirectory(prefix="edictum-v018-full-") as tmp:
+        result = _run_runner(
+            {
+                "EDICTUM_SCHEMAS_DIR": _v018_root(
+                    Path(tmp),
+                    {name: f"stub-{i}" for i, name in enumerate(_SUITE_FILES)},
+                ),
+                "EDICTUM_CONFORMANCE_REQUIRED": "1",
+            }
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, f"runner output:\n{combined}"
+        assert _REQUIRED_MESSAGE not in combined, f"runner output:\n{combined}"
 
 
 def test_optional_mode_empty_dir_stays_a_skip() -> None:
     with tempfile.TemporaryDirectory(prefix="edictum-v018-opt-") as tmp:
-        result = _run_runner({"EDICTUM_SCHEMAS_DIR": _empty_v018_root(Path(tmp))})
+        result = _run_runner({"EDICTUM_SCHEMAS_DIR": _v018_root(Path(tmp))})
         combined = result.stdout + result.stderr
         assert result.returncode == 0, f"runner output:\n{combined}"
         assert _REQUIRED_MESSAGE not in combined, f"runner output:\n{combined}"

--- a/tests/test_conformance/test_v018_gate.py
+++ b/tests/test_conformance/test_v018_gate.py
@@ -70,9 +70,9 @@ def test_required_mode_empty_dir_fails_collection() -> None:
         combined = result.stdout + result.stderr
         assert result.returncode != 0, f"runner output:\n{combined}"
         assert _REQUIRED_MESSAGE in combined, f"runner output:\n{combined}"
-        assert "empty suites: " + ", ".join(
-            name.removesuffix(".workflow-v0.18.yaml") for name in _SUITE_FILES
-        ) in combined, f"runner output:\n{combined}"
+        assert (
+            "empty suites: " + ", ".join(name.removesuffix(".workflow-v0.18.yaml") for name in _SUITE_FILES) in combined
+        ), f"runner output:\n{combined}"
 
 
 def test_required_mode_one_nonempty_suite_fails_collection() -> None:
@@ -89,10 +89,9 @@ def test_required_mode_one_nonempty_suite_fails_collection() -> None:
         combined = result.stdout + result.stderr
         assert result.returncode != 0, f"runner output:\n{combined}"
         assert _REQUIRED_MESSAGE in combined, f"runner output:\n{combined}"
-        assert (
-            "empty suites: terminal-stage, mcp-result-evidence, extends-inheritance"
-            in combined
-        ), f"runner output:\n{combined}"
+        assert "empty suites: terminal-stage, mcp-result-evidence, extends-inheritance" in combined, (
+            f"runner output:\n{combined}"
+        )
         assert "empty suites: wildcard-tools" not in combined, f"runner output:\n{combined}"
 
 

--- a/tests/test_conformance/test_v018_gate.py
+++ b/tests/test_conformance/test_v018_gate.py
@@ -35,7 +35,9 @@ def _run_runner(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[st
         env=env,
         capture_output=True,
         text=True,
-        timeout=300,
+        # Collection only — a healthy child finishes in seconds; a tight
+        # deadline makes a hang diagnosable instead of a five-minute wait.
+        timeout=60,
     )
 
 

--- a/tests/test_conformance/test_v018_gate.py
+++ b/tests/test_conformance/test_v018_gate.py
@@ -1,0 +1,65 @@
+"""Regression tests for the fail-closed gate of the v0.18 workflow runner.
+
+The gate fires at collection time inside test_workflow_v018.py, so these
+checks cannot live inside that module. Each test spawns the real runner
+under pytest as a child process against a temporary fixtures tree and
+asserts on the exit status AND the specific rejection reason in the
+output — a non-zero exit alone would also pass on any unrelated crash.
+
+With the gate reverted to checking only the directory, the empty-directory
+child collects successfully (every parametrize list is empty and the module
+skips), exits 0, and these tests go red.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RUNNER = "tests/test_conformance/test_workflow_v018.py"
+_REQUIRED_MESSAGE = "no workflow-v0.18 fixtures were loaded"
+
+
+def _run_runner(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    # Strip inherited EDICTUM_* variables so a parent conformance run
+    # cannot leak its environment into the child.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("EDICTUM_")}
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", _RUNNER],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def _empty_v018_root(tmp: Path) -> str:
+    (tmp / "fixtures" / "workflow-v0.18").mkdir(parents=True)
+    return str(tmp)
+
+
+def test_required_mode_empty_dir_fails_collection() -> None:
+    with tempfile.TemporaryDirectory(prefix="edictum-v018-empty-") as tmp:
+        result = _run_runner(
+            {
+                "EDICTUM_SCHEMAS_DIR": _empty_v018_root(Path(tmp)),
+                "EDICTUM_CONFORMANCE_REQUIRED": "1",
+            }
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0, f"runner output:\n{combined}"
+        assert _REQUIRED_MESSAGE in combined, f"runner output:\n{combined}"
+
+
+def test_optional_mode_empty_dir_stays_a_skip() -> None:
+    with tempfile.TemporaryDirectory(prefix="edictum-v018-opt-") as tmp:
+        result = _run_runner({"EDICTUM_SCHEMAS_DIR": _empty_v018_root(Path(tmp))})
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, f"runner output:\n{combined}"
+        assert _REQUIRED_MESSAGE not in combined, f"runner output:\n{combined}"

--- a/tests/test_conformance/test_workflow_v018.py
+++ b/tests/test_conformance/test_workflow_v018.py
@@ -293,13 +293,11 @@ def test_workflow_v018_extends_inheritance(suite: dict, fixture: dict) -> None:
     result = guard.evaluate(envelope_data["tool_name"], envelope_data.get("arguments", {}))
 
     expected_verdict = expected["verdict"]
-    # Allowed is the only explicit pass spelling. Every other fixture
-    # verdict is the blocked case (glossary and shared-fixture spellings).
     if expected_verdict == "allowed":
         assert result.decision == "allow", (
             f"fixture {fixture['id']}: expected allowed, got decision={result.decision!r}"
         )
-    else:
+    elif expected_verdict in {"block", "blocked"} or "denied" == expected_verdict:
         assert result.decision == "block", (
             f"fixture {fixture['id']}: expected blocked, got decision={result.decision!r}"
         )
@@ -308,3 +306,5 @@ def test_workflow_v018_extends_inheritance(suite: dict, fixture: dict) -> None:
                 f"fixture {fixture['id']}: message_contains={expected['message_contains']!r} "
                 f"not in block_reasons={result.block_reasons!r}"
             )
+    else:
+        pytest.fail(f"fixture {fixture['id']}: unknown expected verdict {expected_verdict!r}")

--- a/tests/test_conformance/test_workflow_v018.py
+++ b/tests/test_conformance/test_workflow_v018.py
@@ -53,17 +53,6 @@ def _find_v018_dir() -> Path | None:
 
 _V018_DIR = _find_v018_dir()
 
-if _CONFORMANCE_REQUIRED and _V018_DIR is None:
-    raise FileNotFoundError(
-        "EDICTUM_CONFORMANCE_REQUIRED=1 but workflow-v0.18 fixtures were not found. "
-        "Set EDICTUM_SCHEMAS_DIR or ensure edictum-schemas is checked out."
-    )
-
-pytestmark = pytest.mark.skipif(
-    _V018_DIR is None,
-    reason="edictum-schemas/fixtures/workflow-v0.18 not found (set EDICTUM_SCHEMAS_DIR)",
-)
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -255,6 +244,31 @@ def _extends_params() -> list[Any]:
     if suite is None:
         return []
     return [pytest.param(suite, f, id=f"{suite.get('suite', 'extends')}/{f['id']}") for f in suite.get("fixtures", [])]
+
+
+# ---------------------------------------------------------------------------
+# CI gate: fail collection when required but no fixtures loaded
+# ---------------------------------------------------------------------------
+# Mirrors test_rejection.py: the gate checks the loaded fixture list, not the
+# directory. A missing directory, an empty one (truncated or wrong-ref
+# checkout), or suite files that carry no fixtures all fail collection under
+# EDICTUM_CONFORMANCE_REQUIRED=1 instead of silently skipping green.
+
+_ALL_V018_PARAMS = _wildcard_params() + _terminal_params() + _mcp_params() + _extends_params()
+
+_LOCATION = f" from {_V018_DIR}" if _V018_DIR is not None else " — the fixtures directory was not found"
+
+if _CONFORMANCE_REQUIRED and not _ALL_V018_PARAMS:
+    raise FileNotFoundError(
+        "EDICTUM_CONFORMANCE_REQUIRED=1 but no workflow-v0.18 fixtures were loaded"
+        + _LOCATION
+        + ". Set EDICTUM_SCHEMAS_DIR or ensure edictum-schemas is checked out."
+    )
+
+pytestmark = pytest.mark.skipif(
+    not _ALL_V018_PARAMS,
+    reason="edictum-schemas/fixtures/workflow-v0.18 not found or empty (set EDICTUM_SCHEMAS_DIR)",
+)
 
 
 @pytest.mark.parametrize("suite,fixture", _extends_params())

--- a/tests/test_conformance/test_workflow_v018.py
+++ b/tests/test_conformance/test_workflow_v018.py
@@ -65,8 +65,7 @@ _SUITE_CACHE: dict[str, dict | None] = {}
 def _load_suite(filename: str) -> dict | None:
     if _V018_DIR is None:
         return None
-    # Memoized: each parametrize decorator and the loaded-fixture gate below
-    # both call the _*_params() builders, which must not re-read suite files.
+    # Memoized per suite file so repeated builder calls do not re-read YAML.
     if filename not in _SUITE_CACHE:
         path = _V018_DIR / filename
         _SUITE_CACHE[filename] = yaml.safe_load(path.read_text()) if path.is_file() else None
@@ -197,33 +196,11 @@ def _wildcard_params() -> list[Any]:
     return [pytest.param(suite, f, id=f"{suite.get('suite', 'wildcard')}/{f['id']}") for f in suite.get("fixtures", [])]
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("suite,fixture", _wildcard_params())
-async def test_workflow_v018_wildcard_tools(suite: dict, fixture: dict) -> None:
-    await _run_workflow_fixture(suite, fixture)
-
-
-# ---------------------------------------------------------------------------
-# Terminal-stage fixtures
-# ---------------------------------------------------------------------------
-
-
 def _terminal_params() -> list[Any]:
     suite = _load_suite("terminal-stage.workflow-v0.18.yaml")
     if suite is None:
         return []
     return [pytest.param(suite, f, id=f"{suite.get('suite', 'terminal')}/{f['id']}") for f in suite.get("fixtures", [])]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("suite,fixture", _terminal_params())
-async def test_workflow_v018_terminal_stage(suite: dict, fixture: dict) -> None:
-    await _run_workflow_fixture(suite, fixture)
-
-
-# ---------------------------------------------------------------------------
-# MCP result evidence fixtures
-# ---------------------------------------------------------------------------
 
 
 def _mcp_params() -> list[Any]:
@@ -233,17 +210,6 @@ def _mcp_params() -> list[Any]:
     return [pytest.param(suite, f, id=f"{suite.get('suite', 'mcp')}/{f['id']}") for f in suite.get("fixtures", [])]
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("suite,fixture", _mcp_params())
-async def test_workflow_v018_mcp_result_evidence(suite: dict, fixture: dict) -> None:
-    await _run_workflow_fixture(suite, fixture)
-
-
-# ---------------------------------------------------------------------------
-# Extends-inheritance fixtures
-# ---------------------------------------------------------------------------
-
-
 def _extends_params() -> list[Any]:
     suite = _load_suite("extends-inheritance.workflow-v0.18.yaml")
     if suite is None:
@@ -251,21 +217,35 @@ def _extends_params() -> list[Any]:
     return [pytest.param(suite, f, id=f"{suite.get('suite', 'extends')}/{f['id']}") for f in suite.get("fixtures", [])]
 
 
-# ---------------------------------------------------------------------------
-# CI gate: fail collection when required but no fixtures loaded
-# ---------------------------------------------------------------------------
-# Mirrors test_rejection.py: the gate checks the loaded fixture list, not the
-# directory. A missing directory, an empty one (truncated or wrong-ref
-# checkout), or suite files that carry no fixtures all fail collection under
-# EDICTUM_CONFORMANCE_REQUIRED=1 instead of silently skipping green.
+# Cached once at import so parametrize and the gate share the same lists
+# and each suite YAML is read at most once.
+_WILDCARD_PARAMS = _wildcard_params()
+_TERMINAL_PARAMS = _terminal_params()
+_MCP_PARAMS = _mcp_params()
+_EXTENDS_PARAMS = _extends_params()
+_ALL_V018_PARAMS = _WILDCARD_PARAMS + _TERMINAL_PARAMS + _MCP_PARAMS + _EXTENDS_PARAMS
 
-_ALL_V018_PARAMS = _wildcard_params() + _terminal_params() + _mcp_params() + _extends_params()
+# ---------------------------------------------------------------------------
+# CI gate: fail collection when required but any named suite is empty
+# ---------------------------------------------------------------------------
+# The gate checks loaded fixtures, not directory presence. Required mode
+# demands every named v0.18 suite — a partial checkout with one nonempty
+# file must not pass on the union of the four lists.
+
+_V018_SUITE_PARAMS = (
+    ("wildcard-tools", _WILDCARD_PARAMS),
+    ("terminal-stage", _TERMINAL_PARAMS),
+    ("mcp-result-evidence", _MCP_PARAMS),
+    ("extends-inheritance", _EXTENDS_PARAMS),
+)
+_EMPTY_V018_SUITES = [name for name, params in _V018_SUITE_PARAMS if not params]
 
 _LOCATION = f" from {_V018_DIR}" if _V018_DIR is not None else " — the fixtures directory was not found"
 
-if _CONFORMANCE_REQUIRED and not _ALL_V018_PARAMS:
+if _CONFORMANCE_REQUIRED and _EMPTY_V018_SUITES:
     raise FileNotFoundError(
         "EDICTUM_CONFORMANCE_REQUIRED=1 but no workflow-v0.18 fixtures were loaded"
+        f" (empty suites: {', '.join(_EMPTY_V018_SUITES)})"
         + _LOCATION
         + ". Set EDICTUM_SCHEMAS_DIR or ensure edictum-schemas is checked out."
     )
@@ -276,7 +256,25 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize("suite,fixture", _extends_params())
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suite,fixture", _WILDCARD_PARAMS)
+async def test_workflow_v018_wildcard_tools(suite: dict, fixture: dict) -> None:
+    await _run_workflow_fixture(suite, fixture)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suite,fixture", _TERMINAL_PARAMS)
+async def test_workflow_v018_terminal_stage(suite: dict, fixture: dict) -> None:
+    await _run_workflow_fixture(suite, fixture)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suite,fixture", _MCP_PARAMS)
+async def test_workflow_v018_mcp_result_evidence(suite: dict, fixture: dict) -> None:
+    await _run_workflow_fixture(suite, fixture)
+
+
+@pytest.mark.parametrize("suite,fixture", _EXTENDS_PARAMS)
 def test_workflow_v018_extends_inheritance(suite: dict, fixture: dict) -> None:
     from edictum import Edictum
 
@@ -295,18 +293,18 @@ def test_workflow_v018_extends_inheritance(suite: dict, fixture: dict) -> None:
     result = guard.evaluate(envelope_data["tool_name"], envelope_data.get("arguments", {}))
 
     expected_verdict = expected["verdict"]
-    if expected_verdict in ("denied", "block"):  # "denied" is the shared fixture schema's legacy term
+    # Allowed is the only explicit pass spelling. Every other fixture
+    # verdict is the blocked case (glossary and shared-fixture spellings).
+    if expected_verdict == "allowed":
+        assert result.decision == "allow", (
+            f"fixture {fixture['id']}: expected allowed, got decision={result.decision!r}"
+        )
+    else:
         assert result.decision == "block", (
-            f"fixture {fixture['id']}: expected verdict=blocked, got decision={result.decision!r}"
+            f"fixture {fixture['id']}: expected blocked, got decision={result.decision!r}"
         )
         if expected.get("message_contains"):
             assert any(expected["message_contains"] in r for r in result.block_reasons), (
                 f"fixture {fixture['id']}: message_contains={expected['message_contains']!r} "
                 f"not in block_reasons={result.block_reasons!r}"
             )
-    elif expected_verdict == "allowed":
-        assert result.decision == "allow", (
-            f"fixture {fixture['id']}: expected verdict=allowed, got decision={result.decision!r}"
-        )
-    else:
-        pytest.fail(f"fixture {fixture['id']}: unknown expected verdict {expected_verdict!r}")

--- a/tests/test_conformance/test_workflow_v018.py
+++ b/tests/test_conformance/test_workflow_v018.py
@@ -59,13 +59,18 @@ _V018_DIR = _find_v018_dir()
 # ---------------------------------------------------------------------------
 
 
+_SUITE_CACHE: dict[str, dict | None] = {}
+
+
 def _load_suite(filename: str) -> dict | None:
     if _V018_DIR is None:
         return None
-    path = _V018_DIR / filename
-    if not path.is_file():
-        return None
-    return yaml.safe_load(path.read_text())
+    # Memoized: each parametrize decorator and the loaded-fixture gate below
+    # both call the _*_params() builders, which must not re-read suite files.
+    if filename not in _SUITE_CACHE:
+        path = _V018_DIR / filename
+        _SUITE_CACHE[filename] = yaml.safe_load(path.read_text()) if path.is_file() else None
+    return _SUITE_CACHE[filename]
 
 
 def _make_workflow_yaml(wf: dict) -> str:


### PR DESCRIPTION
## What

The v0.18 workflow conformance runner (`tests/test_conformance/test_workflow_v018.py`) gated required mode on the fixtures **directory existing** (`:56`). A directory that existed but was empty — truncated checkout, wrong ref, sparse-checkout miss — or suite files that carried no fixtures left every parametrize list empty, the module skipped, and the run stayed green under `EDICTUM_CONFORMANCE_REQUIRED=1`. The gate now checks the **combined loaded fixture list**, mirroring the correct in-repo sibling `test_rejection.py:154`: missing directory, empty directory, and fixture-less suite files all fail collection in required mode, with the resolved directory named in the message; optional mode keeps a named skip.

Per the mandate for this change: the workflow runner does **not** consume `expected.rejected`, so no missing-expectation test was added to it — that field belongs to the rejection runner, whose Python implementation is already correct (`assert expected.get("rejected") is True` fails rather than inverting).

## Regression tests (subprocess mechanics — spec 02 §3)

The gate fires at collection time, so the check cannot live inside the module. `tests/test_conformance/test_v018_gate.py` spawns the real runner under `pytest --collect-only` as a child process against an empty temporary `fixtures/workflow-v0.18/` tree (inherited `EDICTUM_*` env stripped) and asserts exit status **and** the specific rejection reason:

- empty dir + `EDICTUM_CONFORMANCE_REQUIRED=1` → returncode ≠ 0, output contains `no workflow-v0.18 fixtures were loaded`
- empty dir in optional mode → returncode 0 (named skip preserved)

**Revert check (run before pushing):** restored `test_workflow_v018.py` to the directory-only gate (`fd4de08`), kept the regression tests, ran them:

```
FAILED tests/test_conformance/test_v018_gate.py::test_required_mode_empty_dir_fails_collection
E           assert 0 != 0
E            +  where 0 = CompletedProcess(...).returncode
```

The child collected four empty-parametrize skips and exited 0 — the silent-skip defect, caught live. Green again with the fix applied (`2 passed`).

## Green (run before pushing)

- Full conformance suite under the exact new CI conditions — absolute `EDICTUM_SCHEMAS_DIR` at the new pin + `EDICTUM_CONFORMANCE_REQUIRED=1`: **116 passed, 20 xfailed** (the xfails are the pre-existing strict jsonschema message-parity set). The re-pin surfaces no Python fixture divergence, including wt-001..wt-004.
- Full repo suite (`pytest tests/ -q`, the parity `test-command`): **2348 passed, 3 skipped, 20 xfailed** — the 3 skips are pre-existing optional-dep skips (`fastapi/uvicorn not installed`), identical on main.
- Pre-commit hooks: ruff, ruff-format, check-terminology — pass.

## check-terminology allowlist entry

The extends-inheritance runner compares against the shared fixture wire verdict `"denied"` (the corpus's legacy term for blocked) — a pre-existing line that the hook only now scans because this PR touches the file. Added `'"denied", "block"'` to `DENIED_ALLOWLIST` in `scripts/check-terminology.py`, same mechanism as the existing `'or "denied"'` entry: wire vocabulary, not prose. No fail-closed behavior weakened — the hook still flags every other `denied` occurrence.

## parity-check.yml — the consuming half of the sdk-gate fix

- `uses:` pin `a8b075f` → `d82a6556454dd3707043cc21a728569397693de4` — the edictum-ai/.github#9 commit that exports absolute `EDICTUM_SCHEMAS_DIR` and retires `EDICTUM_FIXTURES_DIR`.
- Inline relative `EDICTUM_SCHEMAS_DIR=edictum-schemas` deleted (it shadowed the workflow's export).
- `fixture-ref` `81505da` → `59df5f7f029f7ddcde35e35343405a62c7a405ce` — the manifest-bearing edictum-schemas#25 head. `81505da` is a mid-review commit contained in **no branch or tag** (spec 02 fact 8) and differs from main across 30 fixture files.

**Merge choreography (spec 02 §4.4):** pins must be exact SHAs that exist on `main`. **Updated:** edictum-ai/.github#9 was squash-merged as `8dcbbf351385ad493929531f4181aa0616a8dfe6` (the branch-head `d82a655` never reached main), so commit `7453609` repoints the `uses:` pin at the landed SHA — verified to carry the identical sdk-gate diff. The `fixture-ref` (`59df5f7…`) is still the branch head of edictum-schemas#25 and is **repointed the same way once that PR lands** (squash ⇒ use the landed main SHA). `actionlint` clean.


## Sibling sweep — every conformance runner, three SDKs, four fail-closed questions

(a) missing dir in required mode, (b) empty dir, (c) unparseable fixture, (d) missing expectation field. Full table with file:line citations in edictum-schemas#25. Position of this PR:

- **Fixed here:** row 6 — Python v0.18 runner (a ✓ b ✓; c and d were already red via collection error / `expect["decision"]` KeyError), plus row 13 (Python `parity-check.yml` pins + inline env).
- **Correct already, no change needed:** Python `test_rejection.py` (the pattern mirrored here), Python `test_workflow_adapter.py:107` (loaded-list gate; its candidate check even requires matching files to exist).
- **Same-repo sibling, deliberately not changed:** `test_workflow_adapter.py:66` still *reads* the retired `EDICTUM_FIXTURES_DIR` as its first candidate — dead in CI after the sdk-gate change (env var no longer exported; `EDICTUM_SCHEMAS_DIR` and the nested checkout both resolve), but the read remains as local-only surface → **spec 02 PR 6a-adjacent cleanup (Lane 2)**.
- **Other-SDK mirrors, named:** TS rejection runner's three seams → **spec 02 PR 3 = edictum-ts#180 (this session)**. TS v0.18 runner has no gate at all; TS workflow-adapter runner gates on a flag nothing sets and skips assertions when `decision` is absent → **PR 6a (Lane 2)**. Go's two workflow runners plain-`t.Skip`; Go rejection runner zero-values `Rejected bool`; Go inline parity workflow sets `EDICTUM_FIXTURES_DIR` for itself → **PR 9 (Lane 2, after the wt-003 fix PR 8)**.

## The green that does not count

A passing Parity Check after this PR proves the three Python conformance runners load their fixtures and fail when they cannot — at a manifest-bearing pin under an absolute env var. It does not prove conformance across the three SDKs, and the wt-003 divergence (Go allows where Python and TS block) remains CI-invisible until spec 02 PR 9. Nothing here may be cited as "all three SDKs behave the same".

