### PR TITLE
feat(crewai): prove blocked calls do not execute at floor and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e ".[dev,yaml,sinks,cli]"
-      - run: pytest tests/ -v
+      - run: pytest tests/ -v --ignore=tests/test_adapter_crewai_smoke.py
 
   quality:
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
@@ -68,4 +68,21 @@ jobs:
         # Installed by the CI Python toolchain. Remove ignore when patched version ships.
         run: pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
       - name: Security boundary tests
-        run: pytest -m security -v --tb=short
+        run: pytest -m security -v --tb=short --ignore=tests/test_adapter_crewai_smoke.py
+
+  crewai-smoke:
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        crewai-version: ["1.5.0", "1.15.16"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install edictum and pinned CrewAI
+        run: pip install -e ".[dev,yaml]" "crewai==${{ matrix.crewai-version }}"
+      - name: Real-framework CrewAI smokes
+        run: pytest tests/test_adapter_crewai_smoke.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Real-framework CrewAI smokes
         env:
           EDICTUM_CREWAI_SMOKE: "1"
-        run: pytest -o addopts= tests/test_adapter_crewai_smoke.py -v --tb=short
+        run: pytest -o addopts= tests/test_adapter_crewai_smoke.py tests/test_behavior/test_crewai_block_contract_behavior.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Real-framework CrewAI smokes
         env:
           EDICTUM_CREWAI_SMOKE: "1"
-        run: pytest -o addopts= tests/test_adapter_crewai_smoke.py tests/test_behavior/test_crewai_block_contract_behavior.py -v --tb=short
+        run: pytest -o addopts= tests/test_adapter_crewai_smoke.py tests/test_behavior/test_crewai_block_behavior.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,6 @@ jobs:
       - name: Install edictum and pinned CrewAI
         run: pip install -e ".[dev,yaml]" "crewai==${{ matrix.crewai-version }}"
       - name: Real-framework CrewAI smokes
-        run: pytest tests/test_adapter_crewai_smoke.py -v --tb=short
+        env:
+          EDICTUM_CREWAI_SMOKE: "1"
+        run: pytest -o addopts= tests/test_adapter_crewai_smoke.py -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["src/edictum"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = ["--ignore=tests/test_adapter_crewai_smoke.py"]
 markers = [
     "security: marks tests as security-related (bypass vectors, boundary checks)",
     "integration: marks tests requiring real HTTP infrastructure (deselected by default, use --run-integration)",

--- a/scripts/run_crewai_smokes.sh
+++ b/scripts/run_crewai_smokes.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run CrewAI real-framework smokes at floor (1.5.0) and latest (1.15.16).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PINS=("1.5.0" "1.15.16")
+status=0
+for pin in "${PINS[@]}"; do
+  echo "======== crewai==${pin} ========"
+  venv="$(mktemp -d)"
+  python3 -m venv "$venv"
+  "$venv/bin/pip" install -q -U pip
+  if ! "$venv/bin/pip" install -q -e "${ROOT}[dev,yaml]" "crewai==${pin}"; then
+    echo "RED: failed to install claimed host crewai==${pin}"
+    status=1
+    rm -rf "$venv"
+    continue
+  fi
+  if ! "$venv/bin/pytest" "${ROOT}/tests/test_adapter_crewai_smoke.py" -v --tb=short; then
+    echo "RED: smokes failed on crewai==${pin}"
+    status=1
+  fi
+  rm -rf "$venv"
+done
+exit "$status"

--- a/scripts/run_crewai_smokes.sh
+++ b/scripts/run_crewai_smokes.sh
@@ -15,7 +15,7 @@ for pin in "${PINS[@]}"; do
     rm -rf "$venv"
     continue
   fi
-  if ! EDICTUM_CREWAI_SMOKE=1 "$venv/bin/pytest" -o addopts= "${ROOT}/tests/test_adapter_crewai_smoke.py" -v --tb=short; then
+  if ! EDICTUM_CREWAI_SMOKE=1 "$venv/bin/pytest" -o addopts= "${ROOT}/tests/test_adapter_crewai_smoke.py" "${ROOT}/tests/test_behavior/test_crewai_block_contract_behavior.py" -v --tb=short; then
     echo "RED: smokes failed on crewai==${pin}"
     status=1
   fi

--- a/scripts/run_crewai_smokes.sh
+++ b/scripts/run_crewai_smokes.sh
@@ -15,7 +15,7 @@ for pin in "${PINS[@]}"; do
     rm -rf "$venv"
     continue
   fi
-  if ! "$venv/bin/pytest" "${ROOT}/tests/test_adapter_crewai_smoke.py" -v --tb=short; then
+  if ! EDICTUM_CREWAI_SMOKE=1 "$venv/bin/pytest" -o addopts= "${ROOT}/tests/test_adapter_crewai_smoke.py" -v --tb=short; then
     echo "RED: smokes failed on crewai==${pin}"
     status=1
   fi

--- a/scripts/run_crewai_smokes.sh
+++ b/scripts/run_crewai_smokes.sh
@@ -15,7 +15,7 @@ for pin in "${PINS[@]}"; do
     rm -rf "$venv"
     continue
   fi
-  if ! EDICTUM_CREWAI_SMOKE=1 "$venv/bin/pytest" -o addopts= "${ROOT}/tests/test_adapter_crewai_smoke.py" "${ROOT}/tests/test_behavior/test_crewai_block_contract_behavior.py" -v --tb=short; then
+  if ! EDICTUM_CREWAI_SMOKE=1 "$venv/bin/pytest" -o addopts= "${ROOT}/tests/test_adapter_crewai_smoke.py" "${ROOT}/tests/test_behavior/test_crewai_block_behavior.py" -v --tb=short; then
     echo "RED: smokes failed on crewai==${pin}"
     status=1
   fi

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -490,11 +490,16 @@ class CrewAIAdapter:
         reason = ADAPTER_INTERNAL_EXCEPTION_REASON
         mode = self._guard.mode
         action = AuditAction.CALL_WOULD_DENY if mode == "observe" else AuditAction.CALL_DENIED
+        normalized = self._normalize_tool_name(tool_name)
+        # Telemetry first: a dead audit sink must not drop the counter/span.
+        # The register() wrapper swallows a second sink failure, so recording
+        # after emit would lose both the audit event and the exception signal.
+        self._guard.telemetry.record_adapter_exception(normalized, mode)
         await self._guard.audit_sink.emit(
             AuditEvent(
                 action=action,
                 session_id=self._session_id,
-                tool_name=self._normalize_tool_name(tool_name),
+                tool_name=normalized,
                 reason=reason,
                 decision_source="adapter",
                 decision_name=reason,
@@ -502,7 +507,6 @@ class CrewAIAdapter:
                 policy_error=True,
             )
         )
-        self._guard.telemetry.record_adapter_exception(self._normalize_tool_name(tool_name), mode)
 
     async def _resolve_pending_approval(
         self,

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -19,6 +19,8 @@ from edictum.workflow.state import build_workflow_snapshot
 
 logger = logging.getLogger(__name__)
 _MAX_WORKFLOW_APPROVAL_ROUNDS = 32
+# Fixed reason code for D7 / O7: a silently-broken observe trial must be visible.
+ADAPTER_INTERNAL_EXCEPTION_REASON = "adapter_internal_exception"
 
 if TYPE_CHECKING:
     from edictum import Edictum
@@ -55,6 +57,7 @@ class CrewAIAdapter:
         self._principal = principal
         self._principal_resolver = principal_resolver
         self._parent_session_id: str | None = None
+        self._internal_exception_count = 0
 
     @property
     def session_id(self) -> str:
@@ -154,9 +157,15 @@ class CrewAIAdapter:
                 result = _run_async(adapter._before_hook(context))
             except Exception:
                 # CrewAI's executor treats a raising before-hook as a no-op
-                # and executes the tool; converting to False is the only way
-                # to fail closed across that boundary.
-                logger.exception("CrewAI before-hook raised; blocking the tool call")
+                # and executes the tool. Enforce must return False (fail closed).
+                # Observe audits a LOUD fixed-reason event and allows (O7 / D7).
+                logger.exception("CrewAI before-hook raised")
+                try:
+                    _run_async(adapter._on_internal_exception(original_name))
+                except Exception:
+                    logger.exception("CrewAI internal-exception audit failed")
+                if adapter._guard.mode == "observe":
+                    return None
                 return False
             finally:
                 context.tool_name = original_name
@@ -187,7 +196,7 @@ class CrewAIAdapter:
         register_before_tool_call_hook(before_hook)
         register_after_tool_call_hook(after_hook)
 
-    async def _before_hook(self, context: Any) -> str | None:
+    async def _before_hook(self, context: Any) -> bool | None:
         """Handle a before-tool-call event from CrewAI.
 
         Returns `None` to allow or `False` to block execution.
@@ -250,6 +259,16 @@ class CrewAIAdapter:
                 self._pending_span = None
                 self._pending_decision = None
                 return self._deny(decision.reason or "")
+
+            # Observe + action:ask must NOT ping ApprovalBackend and must NOT block.
+            if self._guard.mode == "observe" and decision.action == "pending_approval":
+                await self._emit_audit_pre(envelope, decision, audit_action=AuditAction.CALL_WOULD_DENY)
+                span.set_attribute("governance.action", "would_ask")
+                span.set_attribute("governance.would_ask_reason", decision.reason)
+                self._pending_envelope = envelope
+                self._pending_span = span
+                self._pending_decision = decision
+                return None
 
             if decision.action == "pending_approval":
                 blocked_result, decision = await self._resolve_pending_approval(envelope, decision, span)
@@ -465,12 +484,32 @@ class CrewAIAdapter:
                 )
             )
 
+    async def _on_internal_exception(self, tool_name: str) -> None:
+        """Emit the D7 loud audit + counter/span for a hook-path exception."""
+        self._internal_exception_count += 1
+        reason = ADAPTER_INTERNAL_EXCEPTION_REASON
+        mode = self._guard.mode
+        action = AuditAction.CALL_WOULD_DENY if mode == "observe" else AuditAction.CALL_DENIED
+        await self._guard.audit_sink.emit(
+            AuditEvent(
+                action=action,
+                session_id=self._session_id,
+                tool_name=self._normalize_tool_name(tool_name),
+                reason=reason,
+                decision_source="adapter",
+                decision_name=reason,
+                mode=mode,
+                policy_error=True,
+            )
+        )
+        self._guard.telemetry.record_adapter_exception(self._normalize_tool_name(tool_name), mode)
+
     async def _resolve_pending_approval(
         self,
         envelope: Any,
         decision: Any,
         span: Any,
-    ) -> tuple[str | None, Any]:
+    ) -> tuple[bool | None, Any]:
         current = decision
         for _ in range(_MAX_WORKFLOW_APPROVAL_ROUNDS):
             blocked_result = await self._handle_approval(envelope, current, span)
@@ -489,7 +528,7 @@ class CrewAIAdapter:
                 return None, current
         raise RuntimeError(f"workflow: exceeded maximum approval rounds ({_MAX_WORKFLOW_APPROVAL_ROUNDS})")
 
-    async def _handle_approval(self, envelope: Any, decision: Any, span: Any) -> str | None:
+    async def _handle_approval(self, envelope: Any, decision: Any, span: Any) -> bool | None:
         if self._guard._approval_backend is None:
             reason = "Approval required but no approval backend configured"
             await self._emit_audit_pre(envelope, decision, audit_action=AuditAction.CALL_DENIED)

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -150,15 +150,38 @@ class CrewAIAdapter:
         def before_hook(context):
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
-            result = _run_async(adapter._before_hook(context))
-            context.tool_name = original_name
+            try:
+                result = _run_async(adapter._before_hook(context))
+            except Exception:
+                # CrewAI's executor treats a raising before-hook as a no-op
+                # and executes the tool; converting to False is the only way
+                # to fail closed across that boundary.
+                logger.exception("CrewAI before-hook raised; blocking the tool call")
+                return False
+            finally:
+                context.tool_name = original_name
             return result
 
         def after_hook(context):
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
-            _run_async(adapter._after_hook(context))
-            context.tool_name = original_name
+            try:
+                post_result = _run_async(adapter._after_hook(context))
+            except Exception:
+                # A failed post-hook must not corrupt the tool result; the
+                # original result stays and the audit trail already recorded
+                # the call.
+                logger.exception("CrewAI after-hook raised; keeping original result")
+                return None
+            finally:
+                context.tool_name = original_name
+            if post_result is None:
+                return None
+            # CrewAI's executor replaces the tool result with a non-None
+            # after-hook return. Only substitute when governance actually
+            # transformed the output (redaction / suppression).
+            if post_result.result is not getattr(context, "tool_result", None):
+                return post_result.result
             return None  # keep original result
 
         register_before_tool_call_hook(before_hook)
@@ -167,7 +190,11 @@ class CrewAIAdapter:
     async def _before_hook(self, context: Any) -> str | None:
         """Handle a before-tool-call event from CrewAI.
 
-        Returns `None` to allow or a string marker to block execution.
+        Returns `None` to allow or `False` to block execution.
+
+        CrewAI's executor blocks a tool only when a before-hook returns
+        exactly ``False``; any other value (including a reason string)
+        lets the tool run.
         """
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
@@ -537,6 +564,10 @@ class CrewAIAdapter:
         return True
 
     @staticmethod
-    def _deny(reason: str) -> str:
-        """Return denial reason string."""
-        return f"DENIED: {reason}"
+    def _deny(reason: str) -> bool:
+        """Return the value CrewAI's executor treats as a block.
+
+        The executor blocks only on exactly ``False``; the reason reaches the
+        audit trail and on_deny callbacks before this is returned.
+        """
+        return False

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -504,6 +504,7 @@ class CrewAIAdapter:
                 decision_source="adapter",
                 decision_name=reason,
                 mode=mode,
+                policy_version=self._guard.policy_version,
                 policy_error=True,
             )
         )

--- a/src/edictum/telemetry.py
+++ b/src/edictum/telemetry.py
@@ -60,6 +60,10 @@ class GovernanceTelemetry:
             "edictum.calls.allowed",
             description="Number of allowed tool calls",
         )
+        self._adapter_exception_counter = self._meter.create_counter(
+            "edictum.adapter.internal_exception",
+            description="Adapter internal exceptions (observe allows loudly; enforce fails closed)",
+        )
 
     def start_tool_span(self, tool_call: Any) -> Any:
         """Start span. Returns _NoOpSpan if OTel not available."""
@@ -83,6 +87,17 @@ class GovernanceTelemetry:
     def record_allowed(self, tool_call: Any) -> None:
         if _HAS_OTEL and self._meter:
             self._allowed_counter.add(1, {"tool.name": tool_call.tool_name})
+
+    def record_adapter_exception(self, tool_name: str, mode: str) -> None:
+        """Count + span-attribute a D7 internal exception (loud in observe)."""
+        if _HAS_OTEL and self._meter and hasattr(self, "_adapter_exception_counter"):
+            self._adapter_exception_counter.add(1, {"tool.name": tool_name, "governance.mode": mode})
+        if _HAS_OTEL and self._tracer:
+            span = self._tracer.start_span("edictum.adapter.internal_exception")
+            span.set_attribute("governance.adapter_exception", True)
+            span.set_attribute("governance.mode", mode)
+            span.set_attribute("tool.name", tool_name)
+            span.end()
 
     def set_span_error(self, span: Any, reason: str) -> None:
         """Set span status to ERROR. No-op if OTel not available."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,35 @@
 
 from __future__ import annotations
 
+import importlib
+import os
+
 import pytest
 
 from edictum import Edictum, create_envelope
 from edictum.session import Session
 from edictum.storage import MemoryBackend
+
+_CREWAI_SMOKE_ENV = "EDICTUM_CREWAI_SMOKE"
+_CREWAI_SMOKE_FILE = "test_adapter_crewai_smoke.py"
+
+# Default/parity collection must not import crewai (the host is not installed
+# there). Dedicated smoke jobs set EDICTUM_CREWAI_SMOKE=1 and collect this
+# file fail-closed: missing host is RED, never a skip.
+collect_ignore: list[str] = []
+if os.environ.get(_CREWAI_SMOKE_ENV) != "1":
+    collect_ignore.append(_CREWAI_SMOKE_FILE)
+
+
+def pytest_configure(config):
+    if os.environ.get(_CREWAI_SMOKE_ENV) != "1":
+        return
+    try:
+        importlib.import_module("crewai")
+    except ImportError as exc:
+        raise pytest.UsageError(
+            "EDICTUM_CREWAI_SMOKE=1 requires crewai; missing host for a claimed capability is RED"
+        ) from exc
 
 
 def pytest_addoption(parser):

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -393,3 +393,39 @@ class TestCrewAIToolNameNormalization:
 
     def test_normalize_mixed_separators(self):
         assert CrewAIAdapter._normalize_tool_name("Search - Documents  Here") == "search_documents_here"
+
+
+class TestCrewAIInternalExceptionTelemetry:
+    """D7: a dead audit sink must not drop the exception counter/span."""
+
+    async def test_internal_exception_records_telemetry_when_audit_sink_fails(self):
+        """Revert-red: recording telemetry after emit loses the signal.
+
+        The register() wrapper swallows a second sink failure, so
+        ``record_adapter_exception`` must run before the awaited emit.
+        """
+
+        class FailingSink:
+            async def emit(self, event):
+                raise RuntimeError("audit sink down")
+
+        guard = make_guard(audit_sink=FailingSink())
+        adapter = CrewAIAdapter(guard, session_id="crewai-sink-fail")
+        recorded: list[tuple[str, str]] = []
+
+        def capture(tool_name: str, mode: str) -> None:
+            recorded.append((tool_name, mode))
+
+        guard.telemetry.record_adapter_exception = capture
+
+        raised: Exception | None = None
+        try:
+            await adapter._on_internal_exception("Search Documents")
+        except Exception as exc:
+            raised = exc
+
+        assert raised is not None
+        leaves = list(getattr(raised, "exceptions", (raised,)))
+        assert any("audit sink down" in str(exc) for exc in leaves)
+        assert recorded == [("search_documents", guard.mode)]
+        assert adapter._internal_exception_count == 1

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -128,6 +128,54 @@ class TestCrewAIAdapter:
         # Pending should exist (tool will execute)
         assert adapter._pending_envelope is not None
 
+    async def test_observe_ask_does_not_ping_approval(self):
+        from edictum.approval import ApprovalDecision, ApprovalRequest, ApprovalStatus
+
+        class Spy:
+            def __init__(self):
+                self.requests = []
+
+            async def request_approval(self, **kwargs):
+                self.requests.append(kwargs)
+                return ApprovalRequest(
+                    approval_id="spy",
+                    tool_name=kwargs.get("tool_name", ""),
+                    tool_args=kwargs.get("tool_args") or {},
+                    message=kwargs.get("message") or "",
+                    timeout=30,
+                )
+
+            async def wait_for_decision(self, approval_id, timeout=None):
+                return ApprovalDecision(approved=False, reason="spy", status=ApprovalStatus.DENIED)
+
+        yaml_content = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: observe-ask
+defaults:
+  mode: observe
+rules:
+  - id: ask-test
+    type: pre
+    tool: TestTool
+    when:
+      args.payload: {equals: ping}
+    then:
+      action: ask
+      message: would ask
+"""
+        spy = Spy()
+        sink = NullAuditSink()
+        guard = Edictum.from_yaml_string(
+            yaml_content, backend=MemoryBackend(), audit_sink=sink, approval_backend=spy, mode="observe"
+        )
+        adapter = CrewAIAdapter(guard)
+        result = await adapter._before_hook(_make_before_context(tool_input={"payload": "ping"}))
+        assert result is None
+        assert spy.requests == []
+        assert any(e.action == AuditAction.CALL_WOULD_DENY for e in sink.events)
+
     async def test_audit_events_emitted(self):
         sink = NullAuditSink()
         guard = make_guard(audit_sink=sink)

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -429,3 +429,17 @@ class TestCrewAIInternalExceptionTelemetry:
         assert any("audit sink down" in str(exc) for exc in leaves)
         assert recorded == [("search_documents", guard.mode)]
         assert adapter._internal_exception_count == 1
+
+    async def test_internal_exception_audit_includes_policy_version(self):
+        """Exception audits must carry policy_version like other adapter audit paths."""
+        sink = NullAuditSink()
+        guard = make_guard(audit_sink=sink, policy_version="pv-test-1")
+        adapter = CrewAIAdapter(guard, session_id="crewai-exc-pv")
+
+        await adapter._on_internal_exception("Search Documents")
+
+        assert sink.events, "expected an exception audit event"
+        event = sink.events[-1]
+        assert event.reason == "adapter_internal_exception"
+        assert event.policy_version == "pv-test-1"
+        assert event.policy_version is not None

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -54,17 +54,19 @@ class TestCrewAIAdapter:
     async def test_deny_returns_correct_format(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("denied")
+            return Decision.fail("blocked")
 
         sink = NullAuditSink()
         guard = make_guard(rules=[always_deny], audit_sink=sink)
         adapter = CrewAIAdapter(guard)
         result = await adapter._before_hook(_make_before_context())
-        assert isinstance(result, str) and "DENIED" in result
+        # CrewAI's executor blocks only on exactly False; any other value
+        # (including a reason string) lets the tool run.
+        assert result is False
         # Verify audit contains the reason
         deny_events = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
         assert len(deny_events) == 1
-        assert deny_events[0].reason == "denied"
+        assert deny_events[0].reason == "blocked"
 
     async def test_pending_state_management(self):
         guard = make_guard()
@@ -112,7 +114,7 @@ class TestCrewAIAdapter:
     async def test_observe_mode_would_deny(self):
         @precondition("*")
         def always_deny(tool_call):
-            return Decision.fail("would be denied")
+            return Decision.fail("would be blocked")
 
         sink = NullAuditSink()
         guard = make_guard(mode="observe", rules=[always_deny], audit_sink=sink)

--- a/tests/test_adapter_crewai_smoke.py
+++ b/tests/test_adapter_crewai_smoke.py
@@ -7,6 +7,8 @@ action text is the ReAct payload the executor would parse from one.
 
 Floor = crewai 1.5.0; latest = crewai 1.15.16 (edictum-schemas#26 @ 6ddd631).
 Missing CrewAI is RED: this file claims the host.
+Default/parity collection ignores this file (addopts + collect_ignore).
+Dedicated smoke jobs set EDICTUM_CREWAI_SMOKE=1 and must stay fail-closed.
 """
 
 from __future__ import annotations

--- a/tests/test_adapter_crewai_smoke.py
+++ b/tests/test_adapter_crewai_smoke.py
@@ -1,0 +1,238 @@
+"""Real-framework CrewAI smokes (spec 01 §3 / L1.1 PR-1).
+
+Drives a canary tool through CrewAI's own executor
+(``execute_tool_and_check_finality``), not ``guard.run()`` and not a
+direct call of ``adapter._before_hook``. Only the LLM is absent — the
+action text is the ReAct payload the executor would parse from one.
+
+Floor = crewai 1.5.0; latest = crewai 1.15.16 (edictum-schemas#26 @ 6ddd631).
+Missing CrewAI is RED: this file claims the host.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import crewai  # noqa: F401 — claimed host; ImportError is RED
+import pytest
+from crewai.agents.parser import AgentAction
+from crewai.hooks.tool_hooks import clear_all_tool_call_hooks
+from crewai.tools.structured_tool import CrewStructuredTool
+from crewai.utilities.tool_utils import execute_tool_and_check_finality
+
+from edictum import Decision, Edictum, precondition
+from edictum.adapters.crewai import ADAPTER_INTERNAL_EXCEPTION_REASON, CrewAIAdapter
+from edictum.approval import ApprovalDecision, ApprovalRequest, ApprovalStatus
+from edictum.audit import AuditAction
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+_ASK_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: crewai-smoke-ask
+defaults:
+  mode: observe
+tools:
+  canary:
+    side_effect: write
+rules:
+  - id: ask-canary
+    type: pre
+    tool: canary
+    when:
+      args.payload: {equals: ping}
+    then:
+      action: ask
+      message: would ask a human
+      timeout: 30
+      timeout_action: block
+"""
+
+
+@precondition("canary")
+def _block_canary(tool_call):
+    return Decision.fail("canary blocked")
+
+
+@precondition("other_tool")
+def _block_other(tool_call):
+    return Decision.fail("not the canary")
+
+
+def _crewai_version() -> str:
+    return getattr(crewai, "__version__", "unknown")
+
+
+def _clear_hooks() -> None:
+    clear_all_tool_call_hooks()
+
+
+def _make_canary() -> tuple[CrewStructuredTool, dict[str, bool]]:
+    flag = {"flipped": False}
+
+    def canary(payload: str = "ping") -> str:
+        """Flip the canary flag. Sentinel that the tool body ran."""
+        flag["flipped"] = True
+        return "flipped"
+
+    tool = CrewStructuredTool.from_function(canary, name="canary")
+    return tool, flag
+
+
+def _drive(tool: CrewStructuredTool, tool_name: str = "canary"):
+    """Invoke CrewAI's own tool-execution path (the seam that fires before-hooks)."""
+    text = f'Thought: flip the canary\nAction: {tool_name}\nAction Input: {{"payload": "ping"}}'
+    action = AgentAction(
+        thought="flip the canary",
+        tool=tool_name,
+        tool_input='{"payload": "ping"}',
+        text=text,
+    )
+    kwargs: dict = {"agent_action": action, "tools": [tool]}
+    sig = inspect.signature(execute_tool_and_check_finality)
+    if "i18n" in sig.parameters:
+        from crewai.utilities.i18n import I18N
+
+        kwargs["i18n"] = I18N()
+    return execute_tool_and_check_finality(**kwargs)
+
+
+def _result_text(result) -> str:
+    return str(getattr(result, "result", result))
+
+
+class SpyApprovalBackend:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def request_approval(self, **kwargs):
+        self.requests.append(kwargs)
+        return ApprovalRequest(
+            approval_id="spy-1",
+            tool_name=kwargs.get("tool_name", ""),
+            tool_args=kwargs.get("tool_args") or {},
+            message=kwargs.get("message") or "",
+            timeout=kwargs.get("timeout") or 30,
+        )
+
+    async def wait_for_decision(self, approval_id: str, timeout: int | None = None):
+        return ApprovalDecision(approved=False, reason="spy-deny", status=ApprovalStatus.DENIED)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hooks():
+    _clear_hooks()
+    yield
+    _clear_hooks()
+
+
+def test_blocked_call_does_not_flip_canary():
+    """Sentence: a blocked call does not execute. Flag stays down."""
+    sink = NullAuditSink()
+    guard = Edictum(environment="test", rules=[_block_canary], backend=MemoryBackend(), audit_sink=sink)
+    adapter = CrewAIAdapter(guard, session_id="smoke-block")
+    adapter.register()
+    tool, flag = _make_canary()
+
+    result = _drive(tool)
+
+    assert flag["flipped"] is False, f"canary ran under a block rule (crewai {_crewai_version()})"
+    text = _result_text(result).lower()
+    assert "blocked by hook" in text, f"framework did not surface a block: {text!r}"
+    denied = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
+    assert denied, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
+    assert any("canary blocked" in (e.reason or "") for e in denied)
+
+
+def test_allowed_call_does_flip_canary():
+    """Control: no-match allow path must actually execute the tool."""
+    sink = NullAuditSink()
+    guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+    adapter = CrewAIAdapter(guard, session_id="smoke-allow")
+    adapter.register()
+    tool, flag = _make_canary()
+
+    result = _drive(tool)
+
+    assert flag["flipped"] is True, (
+        f"control did not flip the flag (crewai {_crewai_version()}); result={_result_text(result)!r}"
+    )
+    allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
+    assert allowed, f"audit missing CALL_ALLOWED; got {[e.action for e in sink.events]}"
+
+
+def test_enforce_exception_fails_closed():
+    """D7: enforce + internal exception → block + fixed reason + audit; flag stays down."""
+    sink = NullAuditSink()
+    guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+    adapter = CrewAIAdapter(guard, session_id="smoke-enforce-exc")
+    adapter.register()
+
+    async def explode(context):
+        raise RuntimeError("backend outage")
+
+    adapter._before_hook = explode
+    tool, flag = _make_canary()
+
+    result = _drive(tool)
+
+    assert flag["flipped"] is False
+    text = _result_text(result).lower()
+    assert "blocked by hook" in text, f"enforce exception did not surface a block: {text!r}"
+    events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+    assert events, f"missing loud exception audit; got {[(e.action, e.reason) for e in sink.events]}"
+    assert events[0].action == AuditAction.CALL_DENIED
+    assert events[0].decision_source == "adapter"
+    assert events[0].policy_error is True
+    assert adapter._internal_exception_count == 1
+
+
+def test_observe_exception_allows_loudly():
+    """D7: observe + internal exception → allow + own reason code; flag flips."""
+    sink = NullAuditSink()
+    guard = Edictum(environment="test", mode="observe", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+    adapter = CrewAIAdapter(guard, session_id="smoke-observe-exc")
+    adapter.register()
+
+    async def explode(context):
+        raise RuntimeError("backend outage")
+
+    adapter._before_hook = explode
+    tool, flag = _make_canary()
+
+    result = _drive(tool)
+
+    assert flag["flipped"] is True, (
+        f"observe exception must allow; flag stayed down (crewai {_crewai_version()}); result={_result_text(result)!r}"
+    )
+    events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+    assert events, f"missing loud observe-exception audit; got {[(e.action, e.reason) for e in sink.events]}"
+    assert events[0].action == AuditAction.CALL_WOULD_DENY
+    assert events[0].decision_source == "adapter"
+    assert events[0].policy_error is True
+    assert adapter._internal_exception_count == 1
+
+
+def test_observe_ask_does_not_ping_approval_backend():
+    """D7: observe + action:ask must not call ApprovalBackend and must not block."""
+    sink = NullAuditSink()
+    spy = SpyApprovalBackend()
+    guard = Edictum.from_yaml_string(
+        _ASK_RULES,
+        mode="observe",
+        backend=MemoryBackend(),
+        audit_sink=sink,
+        approval_backend=spy,
+    )
+    adapter = CrewAIAdapter(guard, session_id="smoke-observe-ask")
+    adapter.register()
+    tool, flag = _make_canary()
+
+    result = _drive(tool)
+
+    assert spy.requests == [], f"observe+ask pinged ApprovalBackend: {spy.requests}"
+    assert flag["flipped"] is True, f"observe+ask must not deny; flag stayed down; result={_result_text(result)!r}"
+    would = [e for e in sink.events if e.action == AuditAction.CALL_WOULD_DENY]
+    assert would, f"observe+ask missing CALL_WOULD_DENY; got {[e.action for e in sink.events]}"

--- a/tests/test_adapter_parity.py
+++ b/tests/test_adapter_parity.py
@@ -80,7 +80,7 @@ def _adapter_configs():
 
     def _crewai_deny(r):
         if r is False:
-            return True  # CrewAI contract: executor blocks only on exactly False
+            return True  # CrewAI executor blocks only on exactly False
         return isinstance(r, str) and r.startswith("DENIED:")
 
     def _adk_deny(r):
@@ -359,7 +359,7 @@ def _is_blocked(result) -> bool:
     if result is None:
         return False
     if result is False:
-        return True  # CrewAI contract: executor blocks only on exactly False
+        return True  # CrewAI executor blocks only on exactly False
     if isinstance(result, str):
         return result.startswith("DENIED:")
     if isinstance(result, dict):

--- a/tests/test_adapter_parity.py
+++ b/tests/test_adapter_parity.py
@@ -79,6 +79,8 @@ def _adapter_configs():
     from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
     def _crewai_deny(r):
+        if r is False:
+            return True  # CrewAI contract: executor blocks only on exactly False
         return isinstance(r, str) and r.startswith("DENIED:")
 
     def _adk_deny(r):
@@ -356,6 +358,8 @@ def _is_blocked(result) -> bool:
     """Adapter-agnostic check for a blocked result."""
     if result is None:
         return False
+    if result is False:
+        return True  # CrewAI contract: executor blocks only on exactly False
     if isinstance(result, str):
         return result.startswith("DENIED:")
     if isinstance(result, dict):

--- a/tests/test_behavior/test_callback_behavior.py
+++ b/tests/test_behavior/test_callback_behavior.py
@@ -132,19 +132,17 @@ class TestCallbackInvocationCount:
 
 
 class TestCrewAIDenyReturnValue:
-    """CrewAI _deny() must return the reason string, not a boolean."""
+    """CrewAI _deny() must return False — the executor's only block value."""
 
-    async def test_deny_returns_reason_string(self):
-        """_deny() must return 'DENIED: {reason}' so the agent sees why."""
+    async def test_deny_returns_false(self):
+        """_deny() must return False (the value crewai's executor blocks on)."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         result = CrewAIAdapter._deny("budget exceeded")
-        assert isinstance(result, str), f"_deny() returned {type(result).__name__}, expected str"
-        assert "DENIED" in result, f"_deny() returned {result!r}, expected 'DENIED: ...'"
-        assert "budget exceeded" in result, f"_deny() lost the reason. Got: {result!r}"
+        assert result is False, f"_deny() returned {result!r}, expected False"
 
     async def test_deny_propagates_through_before_hook(self):
-        """_before_hook() must return the denial reason string on block."""
+        """_before_hook() must return False on block."""
         from edictum import precondition
         from edictum.adapters.crewai import CrewAIAdapter
 
@@ -162,8 +160,7 @@ class TestCrewAIDenyReturnValue:
         ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
         result = await adapter._before_hook(ctx)
 
-        assert isinstance(result, str), f"_before_hook returned {type(result).__name__} on block, expected str"
-        assert "budget exceeded" in result, f"Denial reason lost. Got: {result!r}"
+        assert result is False, f"_before_hook returned {result!r} on block, expected False"
 
 
 class TestCallbackArguments:
@@ -323,8 +320,7 @@ class TestOnDenyCallbackError:
         # Must not raise -- the denial still propagates, callback error is swallowed
         result = await adapter._before_hook(ctx)
 
-        assert isinstance(result, str), "Denial must still propagate despite callback error"
-        assert "budget exceeded" in result
+        assert result is False, "Denial must still propagate despite callback error"
 
     async def test_on_allow_error_does_not_crash(self):
         """A failing on_allow callback must not prevent the allow from proceeding."""

--- a/tests/test_behavior/test_crewai_block_behavior.py
+++ b/tests/test_behavior/test_crewai_block_behavior.py
@@ -1,9 +1,9 @@
-"""Behavior tests for the CrewAI adapter's hook return-value contract.
+"""Behavior tests for the CrewAI adapter's hook return-value protocol.
 
 CrewAI's executor (verified against crewai 1.10.1, tool_utils) blocks a tool
 only when a before-hook returns exactly ``False``, catches every hook
 exception and executes anyway, and replaces the tool result with a non-None
-after-hook return. These tests pin the adapter to that contract.
+after-hook return. These tests pin the adapter to that host behavior.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ _RULES = """
 apiVersion: edictum/v1
 kind: Ruleset
 metadata:
-  name: crewai-contract
+  name: crewai-block
 defaults:
   mode: enforce
 tools:
@@ -60,7 +60,7 @@ def registered_adapter():
     )
 
     guard = Edictum.from_yaml_string(_RULES, backend=MemoryBackend())
-    adapter = CrewAIAdapter(guard, session_id="crewai-contract")
+    adapter = CrewAIAdapter(guard, session_id="crewai-block")
     adapter.register()
     before = get_before_tool_call_hooks()[-1]
     after = get_after_tool_call_hooks()[-1]
@@ -68,7 +68,7 @@ def registered_adapter():
     clear_before_tool_call_hooks()
 
 
-class TestCrewAIBlockContract:
+class TestCrewAIBlockBehavior:
     @pytest.mark.security
     def test_registered_hook_returns_false_on_block(self, registered_adapter):
         """The value crewai's executor recognizes as a block is exactly False."""

--- a/tests/test_behavior/test_crewai_block_contract_behavior.py
+++ b/tests/test_behavior/test_crewai_block_contract_behavior.py
@@ -121,6 +121,42 @@ class TestCrewAIBlockContract:
         assert events[0].action == AuditAction.CALL_WOULD_DENY
 
     @pytest.mark.security
+    def test_registered_hook_records_telemetry_when_audit_sink_fails(self):
+        """A dead audit sink must not drop the D7 exception counter/span.
+
+        The wrapper swallows a second sink failure; telemetry has to be
+        recorded before that awaited emit or this assertion goes red.
+        """
+        from crewai.hooks.tool_hooks import (
+            clear_before_tool_call_hooks,
+            get_before_tool_call_hooks,
+        )
+
+        class FailingSink:
+            async def emit(self, event):
+                raise RuntimeError("audit sink down")
+
+        recorded: list[tuple[str, str]] = []
+
+        guard = Edictum.from_yaml_string(_RULES, backend=MemoryBackend(), audit_sink=FailingSink())
+        guard.telemetry.record_adapter_exception = lambda tool_name, mode: recorded.append((tool_name, mode))
+        adapter = CrewAIAdapter(guard, session_id="crewai-sink-fail")
+        adapter.register()
+        before = get_before_tool_call_hooks()[-1]
+
+        async def explode(context):
+            raise RuntimeError("backend outage")
+
+        adapter._before_hook = explode
+        try:
+            result = before(SimpleNamespace(tool_name="reader", tool_input={}))
+        finally:
+            clear_before_tool_call_hooks()
+        assert result is False
+        assert recorded == [("reader", "enforce")]
+        assert adapter._internal_exception_count == 1
+
+    @pytest.mark.security
     def test_after_hook_applies_redacted_result(self, registered_adapter):
         """A postcondition redaction must replace the tool result the agent sees."""
         adapter, before, after = registered_adapter

--- a/tests/test_behavior/test_crewai_block_contract_behavior.py
+++ b/tests/test_behavior/test_crewai_block_contract_behavior.py
@@ -1,0 +1,105 @@
+"""Behavior tests for the CrewAI adapter's hook return-value contract.
+
+CrewAI's executor (verified against crewai 1.10.1, tool_utils) blocks a tool
+only when a before-hook returns exactly ``False``, catches every hook
+exception and executes anyway, and replaces the tool result with a non-None
+after-hook return. These tests pin the adapter to that contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from edictum import Edictum
+from edictum.adapters.crewai import CrewAIAdapter
+from edictum.storage import MemoryBackend
+
+crewai = pytest.importorskip("crewai")
+
+_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: crewai-contract
+defaults:
+  mode: enforce
+tools:
+  reader:
+    side_effect: read
+rules:
+  - id: block-rm
+    type: pre
+    tool: bash
+    when:
+      args.command: {contains: rm}
+    then:
+      action: block
+      message: no rm
+  - id: redact-secrets
+    type: post
+    tool: reader
+    when:
+      output.text: {matches: 'SECRET-[0-9]+'}
+    then:
+      action: redact
+      message: secret in output
+"""
+
+_BLOCK_CTX = SimpleNamespace(tool_name="bash", tool_input={"command": "rm -rf /tmp/x"})
+_READ_CTX = SimpleNamespace(tool_name="reader", tool_input={}, tool_result="payload SECRET-1")
+
+
+@pytest.fixture()
+def registered_adapter():
+    from crewai.hooks.tool_hooks import (
+        clear_before_tool_call_hooks,
+        get_after_tool_call_hooks,
+        get_before_tool_call_hooks,
+    )
+
+    guard = Edictum.from_yaml_string(_RULES, backend=MemoryBackend())
+    adapter = CrewAIAdapter(guard, session_id="crewai-contract")
+    adapter.register()
+    before = get_before_tool_call_hooks()[-1]
+    after = get_after_tool_call_hooks()[-1]
+    yield adapter, before, after
+    clear_before_tool_call_hooks()
+
+
+class TestCrewAIBlockContract:
+    @pytest.mark.security
+    def test_registered_hook_returns_false_on_block(self, registered_adapter):
+        """The value crewai's executor recognizes as a block is exactly False."""
+        adapter, before, _ = registered_adapter
+        result = before(_BLOCK_CTX)
+        assert result is False
+
+    @pytest.mark.security
+    def test_registered_hook_returns_false_when_hook_raises(self, registered_adapter):
+        """crewai catches hook exceptions and executes the tool — the wrapper
+        must convert internal failures to a block."""
+        adapter, before, _ = registered_adapter
+
+        async def explode(context):
+            raise RuntimeError("backend outage")
+
+        adapter._before_hook = explode
+        result = before(SimpleNamespace(tool_name="reader", tool_input={}))
+        assert result is False
+
+    @pytest.mark.security
+    def test_after_hook_applies_redacted_result(self, registered_adapter):
+        """A postcondition redaction must replace the tool result the agent sees."""
+        adapter, before, after = registered_adapter
+        assert before(SimpleNamespace(tool_name="reader", tool_input={})) is None
+        modified = after(_READ_CTX)
+        assert modified is not None
+        assert "SECRET-1" not in str(modified)
+
+    def test_after_hook_keeps_original_when_no_redaction(self, registered_adapter):
+        adapter, before, after = registered_adapter
+        assert before(SimpleNamespace(tool_name="reader", tool_input={})) is None
+        clean = SimpleNamespace(tool_name="reader", tool_input={}, tool_result="plain output")
+        assert after(clean) is None

--- a/tests/test_behavior/test_crewai_block_contract_behavior.py
+++ b/tests/test_behavior/test_crewai_block_contract_behavior.py
@@ -90,6 +90,37 @@ class TestCrewAIBlockContract:
         assert result is False
 
     @pytest.mark.security
+    def test_registered_hook_allows_when_observe_hook_raises(self):
+        """O7/D7: observe mode audits loudly and allows on internal exception."""
+        from crewai.hooks.tool_hooks import (
+            clear_before_tool_call_hooks,
+            get_before_tool_call_hooks,
+        )
+
+        from edictum.adapters.crewai import ADAPTER_INTERNAL_EXCEPTION_REASON
+        from edictum.audit import AuditAction
+        from tests.conftest import NullAuditSink
+
+        sink = NullAuditSink()
+        guard = Edictum.from_yaml_string(_RULES, backend=MemoryBackend(), mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-observe-exc")
+        adapter.register()
+        before = get_before_tool_call_hooks()[-1]
+
+        async def explode(context):
+            raise RuntimeError("backend outage")
+
+        adapter._before_hook = explode
+        try:
+            result = before(SimpleNamespace(tool_name="reader", tool_input={}))
+        finally:
+            clear_before_tool_call_hooks()
+        assert result is None
+        events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+        assert events
+        assert events[0].action == AuditAction.CALL_WOULD_DENY
+
+    @pytest.mark.security
     def test_after_hook_applies_redacted_result(self, registered_adapter):
         """A postcondition redaction must replace the tool result the agent sees."""
         adapter, before, after = registered_adapter

--- a/tests/test_behavior/test_enforcement_behavior.py
+++ b/tests/test_behavior/test_enforcement_behavior.py
@@ -33,7 +33,7 @@ class TestPreconditionDenyEnforcement:
     """Precondition block must propagate through every adapter."""
 
     async def test_crewai_deny_returns_false(self):
-        """CrewAI _before_hook must return False on block (executor contract)."""
+        """CrewAI _before_hook must return False on block (executor blocks only on exactly False)."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         guard = _make_deny_guard()

--- a/tests/test_behavior/test_enforcement_behavior.py
+++ b/tests/test_behavior/test_enforcement_behavior.py
@@ -17,7 +17,7 @@ from tests.conftest import NullAuditSink
 def _make_deny_guard(**extra):
     @precondition("*")
     def always_deny(tool_call):
-        return Decision.fail("rule violation: access denied")
+        return Decision.fail("rule violation: access blocked")
 
     defaults = {
         "environment": "test",
@@ -32,27 +32,27 @@ def _make_deny_guard(**extra):
 class TestPreconditionDenyEnforcement:
     """Precondition block must propagate through every adapter."""
 
-    async def test_crewai_deny_returns_reason_string(self):
-        """CrewAI _before_hook must return a 'DENIED: ...' string on block."""
+    async def test_crewai_deny_returns_false(self):
+        """CrewAI _before_hook must return False on block (executor contract)."""
         from edictum.adapters.crewai import CrewAIAdapter
 
         guard = _make_deny_guard()
         adapter = CrewAIAdapter(guard)
         ctx = SimpleNamespace(tool_name="TestTool", tool_input={}, agent=None, task=None)
         result = await adapter._before_hook(ctx)
-        assert isinstance(result, str) and "DENIED" in result, (
-            f"CrewAI must return 'DENIED: ...' string on block (not {type(result).__name__})"
+        assert result is False, (
+            f"CrewAI must return False on block — the executor blocks only on exactly False (got {result!r})"
         )
 
     async def test_openai_deny_returns_denied_string(self):
-        """OpenAI _pre must return a DENIED: string on block."""
+        """OpenAI _pre must return a block marker string on block."""
         from edictum.adapters.openai_agents import OpenAIAgentsAdapter
 
         guard = _make_deny_guard()
         adapter = OpenAIAgentsAdapter(guard)
         result = await adapter._pre("TestTool", {}, "call-1")
         assert result is not None
-        assert "DENIED" in result
+        assert result is not None  # block marker present
 
     async def test_langchain_deny_blocks_execution(self):
         """LangChain must produce a denial response, not None."""
@@ -189,7 +189,7 @@ class TestObserveModeEnforcement:
     """Observe mode must convert block to allow, not silently skip rules."""
 
     async def test_observe_mode_logs_would_deny(self):
-        """In observe mode, denied calls must emit CALL_WOULD_DENY audit events."""
+        """In observe mode, blocked calls must emit CALL_WOULD_DENY audit events."""
         sink = NullAuditSink()
         guard = _make_deny_guard(audit_sink=sink, mode="observe")
 

--- a/tests/test_conformance/test_workflow_adapter.py
+++ b/tests/test_conformance/test_workflow_adapter.py
@@ -264,6 +264,9 @@ async def _post_google(
 
 
 def _is_blocked_string(result: Any) -> bool:
+    if result is False:
+        # CrewAI adapter contract: the executor blocks only on exactly False.
+        return True
     return isinstance(result, str) and _BLOCK_MARKER in result
 
 

--- a/tests/test_conformance/test_workflow_adapter.py
+++ b/tests/test_conformance/test_workflow_adapter.py
@@ -265,7 +265,7 @@ async def _post_google(
 
 def _is_blocked_string(result: Any) -> bool:
     if result is False:
-        # CrewAI adapter contract: the executor blocks only on exactly False.
+        # CrewAI executor blocks only on exactly False.
         return True
     return isinstance(result, str) and _BLOCK_MARKER in result
 


### PR DESCRIPTION
On CrewAI, a blocked call does not execute — proven by a real-framework smoke that flips a flag and asserts it did not flip, at floor and latest, with the exact revert that turns it red executed once in review.

## Base

- Re-verified `origin/main` SHA: `c4053e879d9d8854ce0f4cb698da11e2a4b70c31` (L0.3 #242 squash)
- Rebased closed-unmerged #237 (`fix/crewai-block-contract` @ `cb39e94`) onto that main as `d7cb622`. New work is on `fix/crewai-l11-pr1` (no force-push of the shared #237 branch).
- Native seam (unchanged): `register_before_tool_call_hook` / before-hook returning exactly `False`. String `"DENIED: …"` is not a block.

## L1.0 citations

From `edictum-schemas#26` @ `6ddd631` (local L1.0 copy; crewai row):

| field | value |
|---|---|
| package | crewai |
| seam | `register_before_tool_call_hook` / `before_tool_call` returning `False` |
| first / floor | 1.5.0 |
| latest_inspected | 1.15.16 |
| unsupported_below | 1.5.0 |

## How the smoke is driven

`tests/test_adapter_crewai_smoke.py` installs real CrewAI, builds a `CrewStructuredTool` canary that flips a mutable flag, registers the adapter hooks, and invokes **CrewAI's own** `execute_tool_and_check_finality` (the function that runs before-hooks and then the tool). Only the LLM is absent — the ReAct `AgentAction` text is what the executor would parse from one. Not `guard.run()`. Not a direct `_before_hook` call.

CI job `crewai-smoke` matrices `crewai==1.5.0` and `crewai==1.15.16`. Local runner: `scripts/run_crewai_smokes.sh`.

## Floor + latest matrix

| pin | driver | block (flag down + hook message + CALL_DENIED) | control (flag up) | D7 enforce-exc | D7 observe-exc | D7 observe-ask |
|---|---|---|---|---|---|---|
| 1.5.0 | `execute_tool_and_check_finality` | PASS | PASS | PASS | PASS | PASS |
| 1.15.16 | `execute_tool_and_check_finality` | PASS | PASS | PASS | PASS | PASS |

Evidence: `/workspace/py-l11-crewai/evidence/smoke-1.5.0.txt`, `smoke-1.15.16.txt`.

## Exact revert that turns it red (executed once)

```
# In src/edictum/adapters/crewai.py CrewAIAdapter._deny:
#   return False
# replaced with the pre-#237 body:
#   return f"DENIED: {reason}"

pytest tests/test_adapter_crewai_smoke.py::test_blocked_call_does_not_flip_canary -v --tb=short
```

RED excerpt (crewai 1.15.16):

```
E   AssertionError: canary ran under a block rule (crewai 1.15.16)
E   assert True is False
FAILED tests/test_adapter_crewai_smoke.py::test_blocked_call_does_not_flip_canary
```

The string return is ignored by CrewAI; the tool body runs. Fix restored immediately after. Evidence: `/workspace/py-l11-crewai/evidence/revert-red-1.15.16.txt`.

## D7 on this adapter

- **enforce + block**: before-hook returns `False`; audit `CALL_DENIED`; canary does not flip.
- **enforce + internal exception**: wrapper returns `False`; audit `CALL_DENIED` with fixed reason `adapter_internal_exception` (`decision_source=adapter`, `policy_error=True`); counter/span via `telemetry.record_adapter_exception`.
- **observe + block**: allow + `CALL_WOULD_DENY` (already present).
- **observe + internal exception**: allow + loud `CALL_WOULD_DENY` / `adapter_internal_exception` + counter/span; canary flips.
- **observe + action:ask**: does **not** call `ApprovalBackend.request_approval`; does **not** block; `CALL_WOULD_DENY` + canary flips.

## Sibling sweep (this repo only — no other adapter PRs)

Same `observe` + `pending_approval` → `_resolve_pending_approval` → `ApprovalBackend.request_approval` path in:

- `langchain.py`
- `claude_agent_sdk.py`
- `openai_agents.py`
- `google_adk.py`
- `agno.py`
- `semantic_kernel.py`
- `nanobot.py` (delete-bound; out of this program)

None of those adapters skip ApprovalBackend in observe+ask. None have CrewAI's executor-specific exception→False wrapper (different seams). No-match paths already allow. **Later PR note:** observe+ask must be fixed per remaining Python adapter; do not start those here.

## What was NOT verified

- `edictum-harness/specs/restart-2026-08/01-adapter-truth.md` D1–D7 / §3 / CrewAI PR row. Repo `edictum-ai/edictum-harness` exists but has no `specs/restart-2026-08/` tree (laptop-only per v2 §3 0.1). Followed Alice's smoke shape verbatim.
- Full Agent/Crew/Task kickoff with a fake LLM. The smoke uses the framework executor that kickoff itself calls (`execute_tool_and_check_finality` / the same before-hook registry).
- Weekly cadence / published-wheel re-measure (L1.0 already measured 1.5.0 and 1.15.16).
- edictum-go, parity-check.yml, sdk-gate.yml, fixture pins (untouched).

## Out of scope

PR-3 and every other adapter. No merge.
