### PR TITLE
fix(crewai): record observe-exception executions and sanitize names

### DIFF
--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -11,9 +11,9 @@ from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
 from edictum.audit import AuditAction, AuditEvent
-from edictum.envelope import Principal, create_envelope
+from edictum.envelope import Principal, _validate_tool_name, create_envelope
 from edictum.findings import Finding, PostCallResult, build_findings
-from edictum.pipeline import CheckPipeline
+from edictum.pipeline import CheckPipeline, PreDecision
 from edictum.session import Session, validate_session_id
 from edictum.workflow.state import build_workflow_snapshot
 
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 _MAX_WORKFLOW_APPROVAL_ROUNDS = 32
 # Fixed reason code for D7 / O7: a silently-broken observe trial must be visible.
 ADAPTER_INTERNAL_EXCEPTION_REASON = "adapter_internal_exception"
+# Fail-closed stand-in when a tool name is still invalid after normalize.
+ADAPTER_UNKNOWN_TOOL_NAME = "unknown_tool"
 
 if TYPE_CHECKING:
     from edictum import Edictum
@@ -99,6 +101,18 @@ class CrewAIAdapter:
 
         return re.sub(r"_+", "_", re.sub(r"[\s\-]+", "_", name.lower())).strip("_")
 
+    @staticmethod
+    def _safe_tool_name(name: str) -> str:
+        """Normalize then validate; replace still-invalid names before emit."""
+        if not isinstance(name, str):
+            return ADAPTER_UNKNOWN_TOOL_NAME
+        normalized = CrewAIAdapter._normalize_tool_name(name)
+        try:
+            _validate_tool_name(normalized)
+        except ValueError:
+            return ADAPTER_UNKNOWN_TOOL_NAME
+        return normalized
+
     def register(
         self,
         on_postcondition_warn: Callable[[Any, list[Finding]], Any] | None = None,
@@ -165,6 +179,10 @@ class CrewAIAdapter:
                 except Exception:
                     logger.exception("CrewAI internal-exception audit failed")
                 if adapter._guard.mode == "observe":
+                    try:
+                        _run_async(adapter._ensure_observe_exception_pending(context))
+                    except Exception:
+                        logger.exception("CrewAI observe-exception pending seed failed")
                     return None
                 return False
             finally:
@@ -490,16 +508,16 @@ class CrewAIAdapter:
         reason = ADAPTER_INTERNAL_EXCEPTION_REASON
         mode = self._guard.mode
         action = AuditAction.CALL_WOULD_DENY if mode == "observe" else AuditAction.CALL_DENIED
-        normalized = self._normalize_tool_name(tool_name)
+        safe_name = self._safe_tool_name(tool_name)
         # Telemetry first: a dead audit sink must not drop the counter/span.
         # The register() wrapper swallows a second sink failure, so recording
         # after emit would lose both the audit event and the exception signal.
-        self._guard.telemetry.record_adapter_exception(normalized, mode)
+        self._guard.telemetry.record_adapter_exception(safe_name, mode)
         await self._guard.audit_sink.emit(
             AuditEvent(
                 action=action,
                 session_id=self._session_id,
-                tool_name=normalized,
+                tool_name=safe_name,
                 reason=reason,
                 decision_source="adapter",
                 decision_name=reason,
@@ -508,6 +526,40 @@ class CrewAIAdapter:
                 policy_error=True,
             )
         )
+
+    async def _ensure_observe_exception_pending(self, context: Any) -> None:
+        """Keep enough pending state so after-hook can record the allowed execution."""
+        if (
+            self._pending_envelope is not None
+            and self._pending_span is not None
+            and self._pending_decision is not None
+        ):
+            return
+        tool_name = self._safe_tool_name(getattr(context, "tool_name", "") or "")
+        raw_input = getattr(context, "tool_input", None)
+        tool_input = raw_input if isinstance(raw_input, dict) else {}
+        envelope = create_envelope(
+            tool_name=tool_name,
+            tool_input=tool_input,
+            run_id=self._session_id,
+            call_index=self._call_index,
+            tool_use_id=str(uuid.uuid4()),
+            environment=self._guard.environment,
+            registry=self._guard.tool_registry,
+            principal=self._resolve_principal(tool_name, tool_input),
+        )
+        span = self._guard.telemetry.start_tool_span(envelope)
+        self._pending_envelope = envelope
+        self._pending_span = span
+        self._pending_decision = PreDecision(
+            action="allow",
+            reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
+            decision_source="adapter",
+            decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
+            policy_error=True,
+        )
+        self._call_index += 1
+        await self._session.increment_attempts()
 
     async def _resolve_pending_approval(
         self,

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -566,9 +566,7 @@ class CrewAIAdapter:
             raw_input = getattr(context, "tool_input", None)
             tool_input = raw_input if isinstance(raw_input, dict) else {}
             call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
-            principal = (
-                self._hook_resolved_principal if self._hook_principal_resolved else self._principal
-            )
+            principal = self._hook_resolved_principal if self._hook_principal_resolved else self._principal
             envelope = create_envelope(
                 tool_name=tool_name,
                 tool_input=tool_input,

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -62,6 +62,9 @@ class CrewAIAdapter:
         self._internal_exception_count = 0
         self._hook_call_index_advanced = False
         self._hook_attempts_advanced = False
+        self._hook_envelope: Any | None = None
+        self._hook_resolved_principal: Principal | None = None
+        self._hook_principal_resolved = False
 
     @property
     def session_id(self) -> str:
@@ -169,6 +172,9 @@ class CrewAIAdapter:
         def before_hook(context):
             adapter._hook_call_index_advanced = False
             adapter._hook_attempts_advanced = False
+            adapter._hook_envelope = None
+            adapter._hook_resolved_principal = None
+            adapter._hook_principal_resolved = False
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
             try:
@@ -229,9 +235,19 @@ class CrewAIAdapter:
         """
         self._hook_call_index_advanced = False
         self._hook_attempts_advanced = False
+        self._hook_envelope = None
+        self._hook_resolved_principal = None
+        self._hook_principal_resolved = False
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
         call_id = str(uuid.uuid4())
+
+        # Resolve and stash before later hook steps. A later raise must not
+        # drop a principal/envelope already produced, and must not retry
+        # the resolver (it may be non-idempotent or the failure itself).
+        principal = self._resolve_principal(tool_name, tool_input)
+        self._hook_resolved_principal = principal
+        self._hook_principal_resolved = True
 
         # Create envelope
         envelope = create_envelope(
@@ -242,8 +258,9 @@ class CrewAIAdapter:
             tool_use_id=call_id,
             environment=self._guard.environment,
             registry=self._guard.tool_registry,
-            principal=self._resolve_principal(tool_name, tool_input),
+            principal=principal,
         )
+        self._hook_envelope = envelope
         self._call_index += 1
         self._hook_call_index_advanced = True
 
@@ -540,31 +557,39 @@ class CrewAIAdapter:
         """Keep enough pending state so after-hook can record the allowed execution."""
         if self._pending_envelope is not None and self._pending_span is not None and self._pending_decision is not None:
             return
-        tool_name = self._safe_tool_name(getattr(context, "tool_name", "") or "")
-        raw_input = getattr(context, "tool_input", None)
-        tool_input = raw_input if isinstance(raw_input, dict) else {}
-        # Do not re-invoke principal_resolver: it may be the exception that got us here.
-        call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
-        envelope = create_envelope(
-            tool_name=tool_name,
-            tool_input=tool_input,
-            run_id=self._session_id,
-            call_index=call_index,
-            tool_use_id=str(uuid.uuid4()),
-            environment=self._guard.environment,
-            registry=self._guard.tool_registry,
-            principal=self._principal,
-        )
-        span = self._guard.telemetry.start_tool_span(envelope)
+        # Reuse values already produced in _before_hook. Never recompute the
+        # envelope or re-invoke principal_resolver: both may already have
+        # succeeded, and the resolver is not safe to retry.
+        envelope = self._hook_envelope if self._hook_envelope is not None else self._pending_envelope
+        if envelope is None:
+            tool_name = self._safe_tool_name(getattr(context, "tool_name", "") or "")
+            raw_input = getattr(context, "tool_input", None)
+            tool_input = raw_input if isinstance(raw_input, dict) else {}
+            call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
+            principal = (
+                self._hook_resolved_principal if self._hook_principal_resolved else self._principal
+            )
+            envelope = create_envelope(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                run_id=self._session_id,
+                call_index=call_index,
+                tool_use_id=str(uuid.uuid4()),
+                environment=self._guard.environment,
+                registry=self._guard.tool_registry,
+                principal=principal,
+            )
+        if self._pending_span is None:
+            self._pending_span = self._guard.telemetry.start_tool_span(envelope)
         self._pending_envelope = envelope
-        self._pending_span = span
-        self._pending_decision = PreDecision(
-            action="allow",
-            reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
-            decision_source="adapter",
-            decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
-            policy_error=True,
-        )
+        if self._pending_decision is None:
+            self._pending_decision = PreDecision(
+                action="allow",
+                reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                decision_source="adapter",
+                decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                policy_error=True,
+            )
         # Local call_index is safe to advance. Do not retry increment_attempts
         # or similar backend counter writes when the original hook already
         # attempted them: the mutation may have applied even if the response

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -60,6 +60,8 @@ class CrewAIAdapter:
         self._principal_resolver = principal_resolver
         self._parent_session_id: str | None = None
         self._internal_exception_count = 0
+        self._hook_call_index_advanced = False
+        self._hook_attempts_advanced = False
 
     @property
     def session_id(self) -> str:
@@ -165,6 +167,8 @@ class CrewAIAdapter:
             return asyncio.run(coro)
 
         def before_hook(context):
+            adapter._hook_call_index_advanced = False
+            adapter._hook_attempts_advanced = False
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
             try:
@@ -223,6 +227,8 @@ class CrewAIAdapter:
         exactly ``False``; any other value (including a reason string)
         lets the tool run.
         """
+        self._hook_call_index_advanced = False
+        self._hook_attempts_advanced = False
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
         call_id = str(uuid.uuid4())
@@ -239,9 +245,11 @@ class CrewAIAdapter:
             principal=self._resolve_principal(tool_name, tool_input),
         )
         self._call_index += 1
+        self._hook_call_index_advanced = True
 
         # Increment attempts BEFORE governance
         await self._session.increment_attempts()
+        self._hook_attempts_advanced = True
 
         # Start OTel span
         span = self._guard.telemetry.start_tool_span(envelope)
@@ -529,24 +537,22 @@ class CrewAIAdapter:
 
     async def _ensure_observe_exception_pending(self, context: Any) -> None:
         """Keep enough pending state so after-hook can record the allowed execution."""
-        if (
-            self._pending_envelope is not None
-            and self._pending_span is not None
-            and self._pending_decision is not None
-        ):
+        if self._pending_envelope is not None and self._pending_span is not None and self._pending_decision is not None:
             return
         tool_name = self._safe_tool_name(getattr(context, "tool_name", "") or "")
         raw_input = getattr(context, "tool_input", None)
         tool_input = raw_input if isinstance(raw_input, dict) else {}
+        # Do not re-invoke principal_resolver: it may be the exception that got us here.
+        call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
         envelope = create_envelope(
             tool_name=tool_name,
             tool_input=tool_input,
             run_id=self._session_id,
-            call_index=self._call_index,
+            call_index=call_index,
             tool_use_id=str(uuid.uuid4()),
             environment=self._guard.environment,
             registry=self._guard.tool_registry,
-            principal=self._resolve_principal(tool_name, tool_input),
+            principal=self._principal,
         )
         span = self._guard.telemetry.start_tool_span(envelope)
         self._pending_envelope = envelope
@@ -558,8 +564,12 @@ class CrewAIAdapter:
             decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
             policy_error=True,
         )
-        self._call_index += 1
-        await self._session.increment_attempts()
+        if not self._hook_call_index_advanced:
+            self._call_index += 1
+            self._hook_call_index_advanced = True
+        if not self._hook_attempts_advanced:
+            await self._session.increment_attempts()
+            self._hook_attempts_advanced = True
 
     async def _resolve_pending_approval(
         self,

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -11,10 +11,11 @@ from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
 from edictum.audit import AuditAction, AuditEvent
-from edictum.envelope import Principal, _validate_tool_name, create_envelope
+from edictum.envelope import Principal, ToolCall, _validate_tool_name, create_envelope
 from edictum.findings import Finding, PostCallResult, build_findings
 from edictum.pipeline import CheckPipeline, PreDecision
 from edictum.session import Session, validate_session_id
+from edictum.telemetry import _NoOpSpan
 from edictum.workflow.state import build_workflow_snapshot
 
 logger = logging.getLogger(__name__)
@@ -63,9 +64,12 @@ class CrewAIAdapter:
         self._hook_call_index_advanced = False
         self._hook_attempts_advanced = False
         self._hook_envelope: Any | None = None
+        self._hook_envelope_attempted = False
         self._hook_resolved_principal: Principal | None = None
         self._hook_principal_resolved = False
         self._hook_decision: PreDecision | None = None
+        self._hook_span: Any | None = None
+        self._hook_span_attempted = False
 
     @property
     def session_id(self) -> str:
@@ -174,9 +178,12 @@ class CrewAIAdapter:
             adapter._hook_call_index_advanced = False
             adapter._hook_attempts_advanced = False
             adapter._hook_envelope = None
+            adapter._hook_envelope_attempted = False
             adapter._hook_resolved_principal = None
             adapter._hook_principal_resolved = False
             adapter._hook_decision = None
+            adapter._hook_span = None
+            adapter._hook_span_attempted = False
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
             try:
@@ -238,9 +245,12 @@ class CrewAIAdapter:
         self._hook_call_index_advanced = False
         self._hook_attempts_advanced = False
         self._hook_envelope = None
+        self._hook_envelope_attempted = False
         self._hook_resolved_principal = None
         self._hook_principal_resolved = False
         self._hook_decision = None
+        self._hook_span = None
+        self._hook_span_attempted = False
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
         call_id = str(uuid.uuid4())
@@ -252,7 +262,9 @@ class CrewAIAdapter:
         self._hook_resolved_principal = principal
         self._hook_principal_resolved = True
 
-        # Create envelope
+        # Create envelope. Mark first: a failed deep-copy must not be retried
+        # in the observe fallback.
+        self._hook_envelope_attempted = True
         envelope = create_envelope(
             tool_name=tool_name,
             tool_input=tool_input,
@@ -272,8 +284,11 @@ class CrewAIAdapter:
         self._hook_attempts_advanced = True
         await self._session.increment_attempts()
 
-        # Start OTel span
+        # Start OTel span. Mark first: a failed start must not be retried
+        # in the observe fallback.
+        self._hook_span_attempted = True
         span = self._guard.telemetry.start_tool_span(envelope)
+        self._hook_span = span
 
         # Run pipeline
         try:
@@ -573,18 +588,37 @@ class CrewAIAdapter:
             tool_input = raw_input if isinstance(raw_input, dict) else {}
             call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
             principal = self._hook_resolved_principal if self._hook_principal_resolved else self._principal
-            envelope = create_envelope(
-                tool_name=tool_name,
-                tool_input=tool_input,
-                run_id=self._session_id,
-                call_index=call_index,
-                tool_use_id=str(uuid.uuid4()),
-                environment=self._guard.environment,
-                registry=self._guard.tool_registry,
-                principal=principal,
-            )
+            if self._hook_envelope_attempted:
+                # create_envelope already failed. Do not retry the deep-copy.
+                # Seed a minimal correlation envelope without copying inputs.
+                envelope = ToolCall(
+                    tool_name=tool_name,
+                    args=tool_input,
+                    run_id=self._session_id,
+                    call_index=call_index,
+                    tool_use_id=str(uuid.uuid4()),
+                    environment=self._guard.environment,
+                    principal=principal,
+                )
+            else:
+                envelope = create_envelope(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    run_id=self._session_id,
+                    call_index=call_index,
+                    tool_use_id=str(uuid.uuid4()),
+                    environment=self._guard.environment,
+                    registry=self._guard.tool_registry,
+                    principal=principal,
+                )
         if self._pending_span is None:
-            self._pending_span = self._guard.telemetry.start_tool_span(envelope)
+            if self._hook_span is not None:
+                self._pending_span = self._hook_span
+            elif self._hook_span_attempted:
+                # start_tool_span already failed. Do not retry the tracer.
+                self._pending_span = _NoOpSpan()
+            else:
+                self._pending_span = self._guard.telemetry.start_tool_span(envelope)
         self._pending_envelope = envelope
         if self._pending_decision is None:
             # Reuse the evaluated decision when pre_execute already succeeded.

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -65,6 +65,7 @@ class CrewAIAdapter:
         self._hook_envelope: Any | None = None
         self._hook_resolved_principal: Principal | None = None
         self._hook_principal_resolved = False
+        self._hook_decision: PreDecision | None = None
 
     @property
     def session_id(self) -> str:
@@ -175,6 +176,7 @@ class CrewAIAdapter:
             adapter._hook_envelope = None
             adapter._hook_resolved_principal = None
             adapter._hook_principal_resolved = False
+            adapter._hook_decision = None
             original_name = context.tool_name
             context.tool_name = adapter._normalize_tool_name(original_name)
             try:
@@ -238,6 +240,7 @@ class CrewAIAdapter:
         self._hook_envelope = None
         self._hook_resolved_principal = None
         self._hook_principal_resolved = False
+        self._hook_decision = None
         tool_name: str = context.tool_name
         tool_input: dict = context.tool_input
         call_id = str(uuid.uuid4())
@@ -275,6 +278,9 @@ class CrewAIAdapter:
         # Run pipeline
         try:
             decision = await self._pipeline.pre_execute(envelope, self._session)
+            # Stash immediately: a later emit/audit raise must not drop
+            # workflow_involved / stage / snapshot the pipeline already produced.
+            self._hook_decision = decision
             await self._emit_workflow_events(envelope, decision.workflow_events)
 
             # Handle observe mode: convert block to allow with warning
@@ -581,13 +587,19 @@ class CrewAIAdapter:
             self._pending_span = self._guard.telemetry.start_tool_span(envelope)
         self._pending_envelope = envelope
         if self._pending_decision is None:
-            self._pending_decision = PreDecision(
-                action="allow",
-                reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
-                decision_source="adapter",
-                decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
-                policy_error=True,
-            )
+            # Reuse the evaluated decision when pre_execute already succeeded.
+            # A blank allow would drop workflow_involved / stage / snapshot and
+            # after-hook would skip record_result for a tool that actually ran.
+            if self._hook_decision is not None:
+                self._pending_decision = self._hook_decision
+            else:
+                self._pending_decision = PreDecision(
+                    action="allow",
+                    reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                    decision_source="adapter",
+                    decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                    policy_error=True,
+                )
         # Local call_index is safe to advance. Do not retry increment_attempts
         # or similar backend counter writes when the original hook already
         # attempted them: the mutation may have applied even if the response
@@ -618,6 +630,7 @@ class CrewAIAdapter:
                 return None, replace(current, action="allow")
             await self._guard._workflow_runtime.record_approval(self._session, current.workflow_stage_id)
             current = await self._pipeline.pre_execute(envelope, self._session)
+            self._hook_decision = current
             await self._emit_workflow_events(envelope, current.workflow_events)
             if current.action != "pending_approval":
                 return None, current

--- a/src/edictum/adapters/crewai.py
+++ b/src/edictum/adapters/crewai.py
@@ -247,9 +247,10 @@ class CrewAIAdapter:
         self._call_index += 1
         self._hook_call_index_advanced = True
 
-        # Increment attempts BEFORE governance
-        await self._session.increment_attempts()
+        # Increment attempts BEFORE governance. Mark first: this write is not
+        # idempotent, so a timeout/unknown outcome must not be retried later.
         self._hook_attempts_advanced = True
+        await self._session.increment_attempts()
 
         # Start OTel span
         span = self._guard.telemetry.start_tool_span(envelope)
@@ -564,12 +565,16 @@ class CrewAIAdapter:
             decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
             policy_error=True,
         )
+        # Local call_index is safe to advance. Do not retry increment_attempts
+        # or similar backend counter writes when the original hook already
+        # attempted them: the mutation may have applied even if the response
+        # failed. Seed pending correlation without re-running those writes.
         if not self._hook_call_index_advanced:
             self._call_index += 1
             self._hook_call_index_advanced = True
         if not self._hook_attempts_advanced:
-            await self._session.increment_attempts()
             self._hook_attempts_advanced = True
+            await self._session.increment_attempts()
 
     async def _resolve_pending_approval(
         self,

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -745,3 +745,64 @@ class TestCrewAIObserveExceptionPending:
         assert record_calls == ["read-context"]
         assert executed[0].workflow == {"current_stage": "read-context", "status": "recorded"}
         assert await adapter._session.execution_count() == 1
+
+    async def test_observe_exception_does_not_retry_failed_span_start(self):
+        """Revert-red: fallback retries start_tool_span after it raised."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-span")
+        span_calls: list[int] = []
+
+        def boom_span(envelope):
+            span_calls.append(1)
+            raise RuntimeError("tracer down")
+
+        guard.telemetry.start_tool_span = boom_span
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._pending_span is not None
+            assert adapter._pending_decision is not None
+            assert span_calls == [1]
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert span_calls == [1]
+        assert await adapter._session.execution_count() == 1
+
+    async def test_observe_exception_does_not_retry_failed_envelope_create(self):
+        """Revert-red: fallback retries create_envelope after it raised."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-envelope")
+        create_calls: list[int] = []
+
+        from edictum.adapters import crewai as crewai_mod
+
+        orig_create = crewai_mod.create_envelope
+
+        def boom_create(*args, **kwargs):
+            create_calls.append(1)
+            raise RuntimeError("envelope deep-copy failed")
+
+        crewai_mod.create_envelope = boom_create
+        try:
+            with _capture_registered_hooks(adapter) as (before, after):
+                result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+                assert result is None
+                assert adapter._pending_envelope is not None
+                assert adapter._pending_span is not None
+                assert adapter._pending_decision is not None
+                assert create_calls == [1]
+                after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+        finally:
+            crewai_mod.create_envelope = orig_create
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert create_calls == [1]
+        assert executed[0].tool_name == "canary"
+        assert await adapter._session.execution_count() == 1

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -8,6 +8,7 @@ from edictum import Decision, Edictum, precondition
 from edictum.adapters.crewai import ADAPTER_UNKNOWN_TOOL_NAME, CrewAIAdapter
 from edictum.audit import AuditAction
 from edictum.envelope import Principal
+from edictum.pipeline import PreDecision
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
@@ -680,4 +681,67 @@ class TestCrewAIObserveExceptionPending:
         assert increment_calls == [1]
         assert executed[0].session_attempt_count == 1
         assert await adapter._session.attempt_count() == 1
+        assert await adapter._session.execution_count() == 1
+
+    async def test_observe_exception_preserves_evaluated_workflow_state(self):
+        """Revert-red: fallback discards workflow fields after pre_execute succeeded."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-workflow")
+        snapshot = {"name": "obs-exc", "current_stage": "read-context"}
+        evaluated = PreDecision(
+            action="allow",
+            reason="ok",
+            decision_source="workflow",
+            decision_name="read-context",
+            workflow_involved=True,
+            workflow_stage_id="read-context",
+            workflow=snapshot,
+        )
+
+        async def pre(*args, **kwargs):
+            return evaluated
+
+        async def boom_emit(*args, **kwargs):
+            raise RuntimeError("workflow event emit failed")
+
+        record_calls: list[str] = []
+
+        class _Runtime:
+            definition = object()
+
+            async def record_result(self, session, stage_id, envelope, mcp_result=None):
+                record_calls.append(stage_id)
+                return []
+
+            async def state(self, session):
+                return SimpleNamespace()
+
+        adapter._pipeline.pre_execute = pre
+        adapter._emit_workflow_events = boom_emit
+        guard._workflow_runtime = _Runtime()
+
+        from edictum.adapters import crewai as crewai_mod
+
+        orig_snapshot = crewai_mod.build_workflow_snapshot
+        crewai_mod.build_workflow_snapshot = lambda definition, state: {
+            "current_stage": "read-context",
+            "status": "recorded",
+        }
+        try:
+            with _capture_registered_hooks(adapter) as (before, after):
+                result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+                assert result is None
+                assert adapter._pending_decision is evaluated
+                assert adapter._pending_decision.workflow_involved is True
+                assert adapter._pending_decision.workflow_stage_id == "read-context"
+                assert adapter._pending_decision.workflow == snapshot
+                after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+        finally:
+            crewai_mod.build_workflow_snapshot = orig_snapshot
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert record_calls == ["read-context"]
+        assert executed[0].workflow == {"current_stage": "read-context", "status": "recorded"}
         assert await adapter._session.execution_count() == 1

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from edictum import Decision, Edictum, precondition
-from edictum.adapters.crewai import CrewAIAdapter
+from edictum.adapters.crewai import ADAPTER_UNKNOWN_TOOL_NAME, CrewAIAdapter
 from edictum.audit import AuditAction
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
@@ -42,6 +42,55 @@ def _make_after_context(
         agent=None,
         task=None,
     )
+
+
+
+def _capture_registered_hooks(adapter: CrewAIAdapter):
+    """Register adapter hooks against a mocked CrewAI hook module."""
+    import sys
+    from contextlib import contextmanager
+    from types import ModuleType
+
+    @contextmanager
+    def _ctx():
+        mock_hooks = ModuleType("crewai.hooks.tool_hooks")
+        captured: dict = {}
+
+        def capture_before(fn):
+            captured["before"] = fn
+
+        def capture_after(fn):
+            captured["after"] = fn
+
+        mock_hooks.register_before_tool_call_hook = capture_before
+        mock_hooks.register_after_tool_call_hook = capture_after
+
+        mock_crewai = sys.modules.get("crewai") or ModuleType("crewai")
+        mock_crewai_hooks = sys.modules.get("crewai.hooks") or ModuleType("crewai.hooks")
+        orig_crewai = sys.modules.get("crewai")
+        orig_hooks_parent = sys.modules.get("crewai.hooks")
+        orig_hooks = sys.modules.get("crewai.hooks.tool_hooks")
+        sys.modules["crewai"] = mock_crewai
+        sys.modules["crewai.hooks"] = mock_crewai_hooks
+        sys.modules["crewai.hooks.tool_hooks"] = mock_hooks
+        try:
+            adapter.register()
+            yield captured["before"], captured["after"]
+        finally:
+            if orig_crewai is not None:
+                sys.modules["crewai"] = orig_crewai
+            else:
+                sys.modules.pop("crewai", None)
+            if orig_hooks_parent is not None:
+                sys.modules["crewai.hooks"] = orig_hooks_parent
+            else:
+                sys.modules.pop("crewai.hooks", None)
+            if orig_hooks is not None:
+                sys.modules["crewai.hooks.tool_hooks"] = orig_hooks
+            else:
+                sys.modules.pop("crewai.hooks.tool_hooks", None)
+
+    return _ctx()
 
 
 class TestCrewAIAdapter:
@@ -443,3 +492,59 @@ class TestCrewAIInternalExceptionTelemetry:
         assert event.reason == "adapter_internal_exception"
         assert event.policy_version == "pv-test-1"
         assert event.policy_version is not None
+
+    async def test_internal_exception_replaces_invalid_tool_name(self):
+        """Revert-red: exception path must not republish control chars or path separators."""
+        sink = NullAuditSink()
+        guard = make_guard(audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-exc-name")
+        recorded: list[str] = []
+
+        def capture(tool_name: str, mode: str) -> None:
+            recorded.append(tool_name)
+
+        guard.telemetry.record_adapter_exception = capture
+
+        await adapter._on_internal_exception("foo/bar")
+        await adapter._on_internal_exception("tool\\name")
+        await adapter._on_internal_exception("bad\x00name")
+        await adapter._on_internal_exception("Search Documents")
+
+        assert recorded == [
+            ADAPTER_UNKNOWN_TOOL_NAME,
+            ADAPTER_UNKNOWN_TOOL_NAME,
+            ADAPTER_UNKNOWN_TOOL_NAME,
+            "search_documents",
+        ]
+        assert [e.tool_name for e in sink.events] == recorded
+        for name in recorded[:3]:
+            assert "/" not in name
+            assert "\\" not in name
+            assert "\x00" not in name
+
+
+class TestCrewAIObserveExceptionPending:
+    """Observe-mode hook exceptions must still record the allowed execution."""
+
+    async def test_observe_exception_records_execution_on_after_hook(self):
+        """Revert-red: missing pending after observe exception drops CALL_EXECUTED."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-exec")
+
+        async def explode(context):
+            raise RuntimeError("backend outage")
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            adapter._before_hook = explode
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._pending_span is not None
+            assert adapter._pending_decision is not None
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert await adapter._session.execution_count() == 1
+        assert executed[0].tool_name == "canary"

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -609,3 +609,35 @@ class TestCrewAIObserveExceptionPending:
         assert adapter._call_index == 1
         assert await adapter._session.attempt_count() == 1
         assert await adapter._session.execution_count() == 1
+
+    async def test_observe_exception_does_not_retry_failed_attempt_increment(self):
+        """Revert-red: fallback retries increment_attempts after it raised."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-incr")
+        increment_calls: list[int] = []
+        real_increment = adapter._session.increment_attempts
+
+        async def timeout_after_apply() -> int:
+            increment_calls.append(1)
+            await real_increment()
+            raise TimeoutError("backend increment timed out")
+
+        adapter._session.increment_attempts = timeout_after_apply
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._pending_span is not None
+            assert adapter._pending_decision is not None
+            assert increment_calls == [1]
+            assert await adapter._session.attempt_count() == 1
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert increment_calls == [1]
+        assert executed[0].session_attempt_count == 1
+        assert await adapter._session.attempt_count() == 1
+        assert await adapter._session.execution_count() == 1

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -582,6 +582,46 @@ class TestCrewAIObserveExceptionPending:
         assert await adapter._session.execution_count() == 1
         assert len(resolver_calls) == 1
 
+    async def test_observe_exception_preserves_resolved_principal(self):
+        """Revert-red: fallback rebuilds envelope with static principal."""
+        sink = NullAuditSink()
+        static = Principal(user_id="static-user")
+        resolved = Principal(user_id="resolved-user", role="admin")
+        resolver_calls: list[tuple[str, dict]] = []
+
+        def resolver(tool_name: str, tool_input: dict) -> Principal:
+            resolver_calls.append((tool_name, dict(tool_input)))
+            return resolved
+
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(
+            guard,
+            session_id="crewai-obs-exc-resolved-principal",
+            principal=static,
+            principal_resolver=resolver,
+        )
+
+        async def boom_pre(*args, **kwargs):
+            raise RuntimeError("pipeline outage")
+
+        adapter._pipeline.pre_execute = boom_pre
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._pending_envelope.principal == resolved
+            assert adapter._pending_envelope.principal != static
+            assert len(resolver_calls) == 1
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert executed[0].principal is not None
+        assert executed[0].principal["user_id"] == "resolved-user"
+        assert executed[0].principal["role"] == "admin"
+        assert len(resolver_calls) == 1
+
     async def test_observe_exception_preserves_counters_advanced_by_failed_hook(self):
         """Revert-red: fallback increments again after pre_execute already did."""
         sink = NullAuditSink()

--- a/tests/test_adapter_crewai.py
+++ b/tests/test_adapter_crewai.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from edictum import Decision, Edictum, precondition
 from edictum.adapters.crewai import ADAPTER_UNKNOWN_TOOL_NAME, CrewAIAdapter
 from edictum.audit import AuditAction
+from edictum.envelope import Principal
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
@@ -42,7 +43,6 @@ def _make_after_context(
         agent=None,
         task=None,
     )
-
 
 
 def _capture_registered_hooks(adapter: CrewAIAdapter):
@@ -548,3 +548,64 @@ class TestCrewAIObserveExceptionPending:
         assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
         assert await adapter._session.execution_count() == 1
         assert executed[0].tool_name == "canary"
+
+    async def test_observe_exception_does_not_retry_failing_principal_resolver(self):
+        """Revert-red: fallback re-invokes principal_resolver and drops pending."""
+        sink = NullAuditSink()
+        resolver_calls: list[tuple[str, dict]] = []
+        static = Principal(user_id="static-user")
+
+        def boom_resolver(tool_name: str, tool_input: dict) -> Principal:
+            resolver_calls.append((tool_name, dict(tool_input)))
+            raise RuntimeError("resolver down")
+
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(
+            guard,
+            session_id="crewai-obs-exc-resolver",
+            principal=static,
+            principal_resolver=boom_resolver,
+        )
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._pending_span is not None
+            assert adapter._pending_decision is not None
+            assert adapter._pending_envelope.principal == static
+            assert len(resolver_calls) == 1
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert await adapter._session.execution_count() == 1
+        assert len(resolver_calls) == 1
+
+    async def test_observe_exception_preserves_counters_advanced_by_failed_hook(self):
+        """Revert-red: fallback increments again after pre_execute already did."""
+        sink = NullAuditSink()
+        guard = make_guard(mode="observe", audit_sink=sink)
+        adapter = CrewAIAdapter(guard, session_id="crewai-obs-exc-counters")
+
+        async def boom_pre(*args, **kwargs):
+            raise RuntimeError("pipeline outage")
+
+        adapter._pipeline.pre_execute = boom_pre
+
+        with _capture_registered_hooks(adapter) as (before, after):
+            result = before(_make_before_context(tool_name="canary", tool_input={"payload": "ping"}))
+            assert result is None
+            assert adapter._pending_envelope is not None
+            assert adapter._call_index == 1
+            assert await adapter._session.attempt_count() == 1
+            assert adapter._pending_envelope.call_index == 0
+            after(_make_after_context(tool_name="canary", tool_input={"payload": "ping"}, tool_result="ok"))
+
+        executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+        assert executed, f"missing CALL_EXECUTED; got {[e.action for e in sink.events]}"
+        assert executed[0].call_index == 0
+        assert executed[0].session_attempt_count == 1
+        assert adapter._call_index == 1
+        assert await adapter._session.attempt_count() == 1
+        assert await adapter._session.execution_count() == 1

--- a/tests/test_adapter_crewai_smoke.py
+++ b/tests/test_adapter_crewai_smoke.py
@@ -143,9 +143,9 @@ def test_blocked_call_does_not_flip_canary():
     assert flag["flipped"] is False, f"canary ran under a block rule (crewai {_crewai_version()})"
     text = _result_text(result).lower()
     assert "blocked by hook" in text, f"framework did not surface a block: {text!r}"
-    denied = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
-    assert denied, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
-    assert any("canary blocked" in (e.reason or "") for e in denied)
+    blocked = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
+    assert blocked, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
+    assert any("canary blocked" in (e.reason or "") for e in blocked)
 
 
 def test_allowed_call_does_flip_canary():
@@ -215,6 +215,8 @@ def test_observe_exception_allows_loudly():
     assert events[0].decision_source == "adapter"
     assert events[0].policy_error is True
     assert adapter._internal_exception_count == 1
+    executed = [e for e in sink.events if e.action == AuditAction.CALL_EXECUTED]
+    assert executed, f"observe exception must record CALL_EXECUTED; got {[e.action for e in sink.events]}"
 
 
 def test_observe_ask_does_not_ping_approval_backend():


### PR DESCRIPTION
## Summary

Follow-up to #243. Alice merged #243 as `2be21b11934d686cfa6712ff1ff7706b2e3a9292` before Codex reviewed `27dae9b`. This PR fixes the three Codex P1s, smallest fail-closed.

**Base SHA:** `2be21b11934d686cfa6712ff1ff7706b2e3a9292` (current `origin/main`, merge of #243).

### P1 1 — Track executions allowed after observe-mode exceptions

When a registered pre-hook raises in observe mode before pending fields exist, we still return `None` so CrewAI runs the tool. `_after_hook` used to exit with no pending envelope: no `CALL_EXECUTED`, session execution counts stayed stale.

Fix: after the loud exception audit, seed enough pending correlation (envelope + span + allow `PreDecision`) so `_after_hook` records the actual execution.

### P1 2 — Validate tool names before exception telemetry

The exception path only normalized whitespace/hyphens, then republished still-invalid names (control chars, path separators) into audit + OTel.

Fix: normalize, then `_validate_tool_name`; replace still-invalid names with the fixed value `unknown_tool` before emit.

### P1 3 — Rename the residual banned identifier

Smoke test local collection `denied` → `blocked` (three lines). Glossary is **blocked**, no exceptions.

## Revert-red

Proved once for (1) and (2) by temporarily reverting the production changes:

- `test_observe_exception_records_execution_on_after_hook` went red (`_pending_envelope is None` → no `CALL_EXECUTED`).
- `test_internal_exception_replaces_invalid_tool_name` went red (`foo/bar` republished instead of `unknown_tool`).

Both restored and green. Floor + latest CrewAI smokes pass, including the new `CALL_EXECUTED` assertion on the observe-exception smoke.

## What this PR does NOT do

- Does **not** address the sibling observe+ask-across-adapters P1 (later L1.1 slices).
- Does **not** start Claude Python or any other adapter.
- Does **not** merge. Does **not** `@codex` review (Alice will wait for Codex on this SHA).

## Test plan

- [x] `pytest tests/test_adapter_crewai.py` (includes revert-red tests)
- [x] `pytest tests/test_behavior/test_crewai_block_behavior.py tests/test_adapter_parity.py`
- [x] `EDICTUM_CREWAI_SMOKE=1 pytest tests/test_adapter_crewai_smoke.py` at floor and latest
- [ ] Codex review on this HEAD SHA