### PR TITLE
chore(deps): group updates under Renovate with a 15-day floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,48 @@
+# Dependabot owns pip version updates. GitHub Actions version updates
+# are owned by Renovate (renovate.json) — one bot per ecosystem.
+#
+# Security updates (GHSA/CVE) are not subject to cooldown or
+# open-pull-requests-limit and still open immediately.
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 15
+    groups:
+      python-majors-and-adapters:
+        applies-to: version-updates
+        patterns:
+          - "crewai*"
+          - "langchain-core*"
+          - "opentelemetry*"
+          - "starlette*"
+      python-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "crewai*"
+          - "langchain-core*"
+          - "opentelemetry*"
+          - "starlette*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-majors:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "crewai*"
+          - "langchain-core*"
+          - "opentelemetry*"
+          - "starlette*"
+        update-types:
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,7 @@
-# Dependabot owns pip version updates. GitHub Actions version updates
-# are owned by Renovate (renovate.json) — one bot per ecosystem.
-#
-# Security updates (GHSA/CVE) are not subject to cooldown or
-# open-pull-requests-limit and still open immediately.
 version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 15
-    groups:
-      python-majors-and-adapters:
-        applies-to: version-updates
-        patterns:
-          - "crewai*"
-          - "langchain-core*"
-          - "opentelemetry*"
-          - "starlette*"
-      python-minor-patch:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "crewai*"
-          - "langchain-core*"
-          - "opentelemetry*"
-          - "starlette*"
-        update-types:
-          - "minor"
-          - "patch"
-      python-majors:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "crewai*"
-          - "langchain-core*"
-          - "opentelemetry*"
-          - "starlette*"
-        update-types:
-          - "major"
+# Dependabot SECURITY alerts (CVEs) stay on via GitHub's Advisories toggle,
+# not this file — they arrive as alerts regardless.
+#
+# Version-update PRs are handled by Renovate (renovate.json) with
+# minimumReleaseAge: 15 days — the floor Dependabot cannot enforce.
+# Install the Renovate GitHub App (https://github.com/apps/renovate) to activate it.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"],
+  "minimumReleaseAge": "15 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
+  "timezone": "Europe/Berlin",
+  "schedule": ["after 9am on monday"],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "description": "GitHub Actions: pin to commit SHA (the repo already SHA-pins; Renovate updates the SHA + the version comment), batch into one PR, 15-day release-age floor (matches the dependency-ledger 15-day rule).",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "pinDigests": true,
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "description": "First-party acartag7 packages: exempt from the 15-day release-age floor so hardening fixes propagate immediately. Scoped exclusion per the dependency-ledger 'my own packages are exempt' rule — never a blanket disable.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^acartag7\\//"],
+      "minimumReleaseAge": "0"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,27 +1,73 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["github-actions"],
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "pep621",
+    "uv"
+  ],
   "minimumReleaseAge": "15 days",
   "internalChecksFilter": "strict",
   "prCreation": "not-pending",
   "timezone": "Europe/Berlin",
-  "schedule": ["after 9am on monday"],
-  "labels": ["dependencies"],
+  "schedule": [
+    "after 9am on monday"
+  ],
+  "labels": [
+    "dependencies"
+  ],
   "dependencyDashboard": true,
   "packageRules": [
     {
-      "description": "GitHub Actions: pin to commit SHA (the repo already SHA-pins; Renovate updates the SHA + the version comment), batch into one PR, 15-day release-age floor (matches the dependency-ledger 15-day rule).",
-      "matchManagers": ["github-actions"],
+      "description": "GitHub Actions: pin to commit SHA, batch into one PR, 15-day floor.",
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessagePrefix": "chore(deps):"
     },
     {
-      "description": "First-party acartag7 packages: exempt from the 15-day release-age floor so hardening fixes propagate immediately. Scoped exclusion per the dependency-ledger 'my own packages are exempt' rule — never a blanket disable.",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["/^acartag7\\//"],
+      "description": "First-party acartag7 actions: skip the 15-day floor. Scoped, never a blanket disable.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "/^acartag7\\//"
+      ],
       "minimumReleaseAge": "0"
+    },
+    {
+      "description": "Python minor/patch group. Adapter-hosts and majors stay out.",
+      "matchManagers": [
+        "pep621",
+        "uv"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "excludePackageNames": [
+        "crewai",
+        "langchain-core",
+        "starlette",
+        "cryptography"
+      ],
+      "groupName": "python-minor-patch"
+    },
+    {
+      "description": "Majors and adapter-hosts. Visible, not mixed with ordinary bumps. Do not merge without Alice/Arnold.",
+      "matchPackageNames": [
+        "crewai",
+        "langchain-core",
+        "starlette",
+        "cryptography",
+        "/^opentelemetry-/"
+      ],
+      "groupName": "python-majors-and-adapters",
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
- Stops the Dependabot one-off flood (we just closed 16 stale PRs on edictum)
- Matches acartag7/mcp-sso: Dependabot version updates off; Renovate minimumReleaseAge 15 days; Monday 9am Europe/Berlin; Actions SHA-pinned and grouped
- First-party acartag7 actions may skip the floor; nothing else may
- Majors/adapter-hosts (crewai, langchain-core, starlette, cryptography, otel) are a separate dashboard-approval group
- GHSA/CVE still adopted immediately (GitHub security alerts + manual exception); this config does not weaken the floor
- Alice verifies. Do not merge to main without her.
- Remaining held Dependabot: edictum #213 crewai, #212 ruff, #210 otel; edictum-ts #165, #145, #144, #143, #142
- Related security PR: edictum#246
