### PR TITLE
chore(deps): switch to Renovate (15-day floor auto-enforced)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
-updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: weekly
+# Dependabot SECURITY alerts (CVEs) are configured via GitHub's Security &
+# Advisories toggle, not here — they arrive as alerts regardless of this file.
+#
+# Version-update ecosystems are disabled. Dependabot cannot enforce
+# minimumReleaseAge, so pip and github-actions version bumps are owned by
+# Renovate (renovate.json, minimumReleaseAge: 15 days). One bot per
+# ecosystem: leaving Dependabot version updates on would open double PRs.
+# Install the Renovate GitHub App (https://github.com/apps/renovate) to
+# activate version updates.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "pep621"
+  ],
+  "minimumReleaseAge": "15 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
+  "timezone": "Europe/Berlin",
+  "schedule": [
+    "after 9am on monday"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "description": "GitHub Actions: pin to commit SHA (the repo already SHA-pins; Renovate updates the SHA + the version comment), batch into one PR. The 15-day release-age floor is global and is never weakened here.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "pinDigests": true,
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "description": "First-party acartag7/* only: exempt from the 15-day release-age floor so hardening fixes propagate immediately. Scoped exclusion — never a blanket disable.",
+      "matchPackageNames": [
+        "/^acartag7\\//"
+      ],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": "pip (pep621/pyproject.toml + uv.lock) minor+patch together.",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "pip minor+patch"
+    },
+    {
+      "description": "Adapter hosts (crewai, langchain-core, starlette, otel 1->2 / experimental OTLP) — separate group, not automerged.",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchPackageNames": [
+        "crewai",
+        "langchain-core",
+        "starlette",
+        "/^opentelemetry-/"
+      ],
+      "groupName": "pip majors and adapter-hosts",
+      "automerge": false
+    },
+    {
+      "description": "Remaining pip majors join the non-automerge majors/adapter-hosts group.",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "pip majors and adapter-hosts",
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Disable Dependabot **version updates** (pip / github-actions). Security alerts stay on GitHub's Advisories toggle — Dependabot cannot enforce `minimumReleaseAge`.
- Add `renovate.json` matching mcp-sso hygiene: `minimumReleaseAge: "15 days"` (never weakened except first-party `acartag7/*`), `internalChecksFilter: strict` + `prCreation: not-pending`, timezone `Europe/Berlin`, schedule after 9am Monday, `dependencies` label, dependency dashboard.
- GitHub Actions: one grouped PR, `pinDigests: true`.
- pip ecosystem via Renovate's `pep621` manager (pyproject.toml + uv.lock): minor+patch grouped together; majors and adapter-hosts (`crewai`, `langchain-core`, `starlette`, `opentelemetry-*` including 1→2 / experimental OTLP) in a separate group that is not automerged.
- One bot per ecosystem: Renovate owns version bumps so we do not get double PRs.

Requires: install the Renovate GitHub App on this repo (https://github.com/apps/renovate).

## Test plan

- [ ] Confirm `.github/dependabot.yml` has no `updates:` ecosystems (version-update PRs stop; security alerts unchanged)
- [ ] Confirm `renovate.json` keeps `minimumReleaseAge: "15 days"` and only `acartag7/*` uses `"0"`
- [ ] After the Renovate app is installed, onboarding / dashboard issue opens
- [ ] No new Dependabot version-update PRs; no double PRs for the same bump