### PR TITLE
feat(claude): prove blocked calls do not execute at floor and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         run: pytest -o addopts= tests/test_adapter_crewai_smoke.py tests/test_behavior/test_crewai_block_behavior.py -v --tb=short
 
   claude-smoke:
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
         run: pip install --target /tmp/claude-host-cli "claude-agent-sdk==0.2.139" && install -m 0755 /tmp/claude-host-cli/claude_agent_sdk/_bundled/claude /usr/local/bin/claude
       - name: Real-framework Claude Agent SDK smokes
         env:
-          EDICTUM_CLAUDE_SMOKE: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-5.3[1m]
+          ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5.3[1m]
+          ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5.3[1m]
+          API_TIMEOUT_MS: "3000000"
+          EDICTUM_CLAUDE_SMOKE: "1"
         run: pytest -o addopts= tests/test_adapter_claude_smoke.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e ".[dev,yaml,sinks,cli]"
-      - run: pytest tests/ -v --ignore=tests/test_adapter_crewai_smoke.py
+      - run: pytest tests/ -v --ignore=tests/test_adapter_crewai_smoke.py --ignore=tests/test_adapter_claude_smoke.py
 
   quality:
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
@@ -68,7 +68,7 @@ jobs:
         # Installed by the CI Python toolchain. Remove ignore when patched version ships.
         run: pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
       - name: Security boundary tests
-        run: pytest -m security -v --tb=short --ignore=tests/test_adapter_crewai_smoke.py
+        run: pytest -m security -v --tb=short --ignore=tests/test_adapter_crewai_smoke.py --ignore=tests/test_adapter_claude_smoke.py
 
   crewai-smoke:
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
@@ -88,3 +88,22 @@ jobs:
         env:
           EDICTUM_CREWAI_SMOKE: "1"
         run: pytest -o addopts= tests/test_adapter_crewai_smoke.py tests/test_behavior/test_crewai_block_behavior.py -v --tb=short
+
+  claude-smoke:
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        claude-agent-sdk-version: ["0.1.2", "0.2.139"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install edictum and pinned Claude Agent SDK
+        run: pip install -e ".[dev,yaml]" "claude-agent-sdk==${{ matrix.claude-agent-sdk-version }}"
+      - name: Real-framework Claude Agent SDK smokes
+        env:
+          EDICTUM_CLAUDE_SMOKE: "1"
+        run: pytest -o addopts= tests/test_adapter_claude_smoke.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,5 @@ jobs:
       - name: Real-framework Claude Agent SDK smokes
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
-          ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-5.3[1m]
-          ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5.3[1m]
-          ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5.3[1m]
-          API_TIMEOUT_MS: "3000000"
           EDICTUM_CLAUDE_SMOKE: "1"
         run: pytest -o addopts= tests/test_adapter_claude_smoke.py -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,10 @@ jobs:
           cache: "pip"
       - name: Install edictum and pinned Claude Agent SDK
         run: pip install -e ".[dev,yaml]" "claude-agent-sdk==${{ matrix.claude-agent-sdk-version }}"
+      - name: Provide Claude Code CLI
+        run: pip install --target /tmp/claude-host-cli "claude-agent-sdk==0.2.139" && install -m 0755 /tmp/claude-host-cli/claude_agent_sdk/_bundled/claude /usr/local/bin/claude
       - name: Real-framework Claude Agent SDK smokes
         env:
           EDICTUM_CLAUDE_SMOKE: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: pytest -o addopts= tests/test_adapter_claude_smoke.py -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ packages = ["src/edictum"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-addopts = ["--ignore=tests/test_adapter_crewai_smoke.py"]
+addopts = ["--ignore=tests/test_adapter_crewai_smoke.py", "--ignore=tests/test_adapter_claude_smoke.py"]
 markers = [
     "security: marks tests as security-related (bypass vectors, boundary checks)",
     "integration: marks tests requiring real HTTP infrastructure (deselected by default, use --run-integration)",

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -384,6 +384,8 @@ class ClaudeAgentSDKAdapter:
 
             try:
                 pending = self._pending_for_permission(tool_name, tool_input, context)
+                if isinstance(pending, tuple) and not call_id:
+                    call_id = pending[2]
                 if pending == "mismatch":
                     return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "compare_failed":
@@ -432,21 +434,21 @@ class ClaudeAgentSDKAdapter:
             envelope, span = self._pending[tool_use_id]
             try:
                 if envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input):
-                    return (envelope, span)
+                    return (envelope, span, tool_use_id)
                 return "mismatch"
             except Exception:
                 return "compare_failed"
 
-        same_name: list[tuple[Any, Any]] = []
-        for envelope, span in self._pending.values():
+        same_name: list[tuple[str, Any, Any]] = []
+        for key, (envelope, span) in self._pending.items():
             if envelope.tool_name == tool_name:
-                same_name.append((envelope, span))
+                same_name.append((key, envelope, span))
         if not same_name:
             return None
-        for envelope, span in same_name:
+        for key, envelope, span in same_name:
             try:
                 if _governed_input_equals(envelope.args, tool_input):
-                    return (envelope, span)
+                    return (envelope, span, key)
             except Exception:
                 return "compare_failed"
         return "mismatch"

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -76,6 +76,10 @@ class _HookRecovery:
     attempts_advanced: bool = False
 
 
+def _has_control_chars(value: str) -> bool:
+    return any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+
+
 def _hook_matcher(hooks: list) -> Any:
     try:
         from claude_agent_sdk.types import HookMatcher
@@ -450,6 +454,8 @@ class ClaudeAgentSDKAdapter:
                         return await deny(_PERMISSION_BOUNDARY_REASON)
                     if interrupt is not None and not isinstance(interrupt, bool):
                         return await deny(_PERMISSION_BOUNDARY_REASON)
+                    if _has_control_chars(message):
+                        return await deny(_PERMISSION_BOUNDARY_REASON)
                     return await deny(message, interrupt=bool(interrupt))
                 return await deny(_PERMISSION_BOUNDARY_REASON)
             except Exception:
@@ -526,7 +532,8 @@ class ClaudeAgentSDKAdapter:
         self._pending_decisions.pop(call_id, None)
         if pending is None:
             return
-        _envelope, span = pending
+        envelope, span = pending
+        self._clear_sink_ack(getattr(envelope, "call_id", "") or call_id)
         try:
             span.end()
         except Exception:
@@ -612,36 +619,52 @@ class ClaudeAgentSDKAdapter:
     async def _audit_post_hook_exception(self, pending: Any, tool_response: Any) -> None:
         """Emit adapter-sourced executed/failed after a post-hook raise."""
         envelope = pending[0] if isinstance(pending, tuple) and pending else None
-        if envelope is not None and envelope.call_id in self._execution_audit_completed:
-            self._execution_audit_completed.discard(envelope.call_id)
-            self._execution_tool_success.pop(envelope.call_id, None)
-            await self._recover_workflow_events(envelope)
-            self._clear_sink_ack(envelope.call_id)
-            return
-        tool_success = False
-        if envelope is not None and envelope.call_id in self._execution_tool_success:
-            tool_success = self._execution_tool_success.pop(envelope.call_id)
-        elif envelope is not None:
-            try:
-                tool_success = self._check_tool_success(envelope.tool_name, tool_response)
-            except Exception:
-                tool_success = False
-        action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
-        reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
-        if envelope is not None:
-            await self._emit_per_sink(
+        try:
+            if envelope is not None and envelope.call_id in self._execution_audit_completed:
+                self._execution_audit_completed.discard(envelope.call_id)
+                self._execution_tool_success.pop(envelope.call_id, None)
+                await self._recover_workflow_events(envelope)
+                return
+            tool_success = False
+            if envelope is not None and envelope.call_id in self._execution_tool_success:
+                tool_success = self._execution_tool_success.pop(envelope.call_id)
+            elif envelope is not None:
+                try:
+                    tool_success = self._check_tool_success(envelope.tool_name, tool_response)
+                except Exception:
+                    tool_success = False
+            action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
+            reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
+            if envelope is not None:
+                await self._emit_per_sink(
+                    AuditEvent(
+                        action=action,
+                        run_id=envelope.run_id,
+                        call_id=envelope.call_id,
+                        call_index=envelope.call_index,
+                        session_id=self._session_id,
+                        parent_session_id=self._audit_parent_session_id(),
+                        tool_name=envelope.tool_name,
+                        tool_args=self._guard.redaction.redact_args(envelope.args),
+                        side_effect=envelope.side_effect.value,
+                        environment=envelope.environment,
+                        principal=asdict(envelope.principal) if envelope.principal else None,
+                        reason=reason,
+                        decision_source="adapter",
+                        decision_name=reason,
+                        tool_success=tool_success,
+                        mode=self._guard.mode,
+                        policy_version=self._guard.policy_version,
+                        policy_error=True,
+                    )
+                )
+                await self._recover_workflow_events(envelope)
+                return
+            await self._guard.audit_sink.emit(
                 AuditEvent(
                     action=action,
-                    run_id=envelope.run_id,
-                    call_id=envelope.call_id,
-                    call_index=envelope.call_index,
                     session_id=self._session_id,
-                    parent_session_id=self._audit_parent_session_id(),
-                    tool_name=envelope.tool_name,
-                    tool_args=self._guard.redaction.redact_args(envelope.args),
-                    side_effect=envelope.side_effect.value,
-                    environment=envelope.environment,
-                    principal=asdict(envelope.principal) if envelope.principal else None,
+                    tool_name=ADAPTER_UNKNOWN_TOOL_NAME,
                     reason=reason,
                     decision_source="adapter",
                     decision_name=reason,
@@ -651,23 +674,10 @@ class ClaudeAgentSDKAdapter:
                     policy_error=True,
                 )
             )
-            await self._recover_workflow_events(envelope)
-            self._clear_sink_ack(envelope.call_id)
-            return
-        await self._guard.audit_sink.emit(
-            AuditEvent(
-                action=action,
-                session_id=self._session_id,
-                tool_name=ADAPTER_UNKNOWN_TOOL_NAME,
-                reason=reason,
-                decision_source="adapter",
-                decision_name=reason,
-                tool_success=tool_success,
-                mode=self._guard.mode,
-                policy_version=self._guard.policy_version,
-                policy_error=True,
-            )
-        )
+        finally:
+            if envelope is not None:
+                self._pending_workflow_events.pop(envelope.call_id, None)
+                self._clear_sink_ack(envelope.call_id)
 
     async def _audit_adapter_block(self, tool_name: str, reason: str, envelope: Any | None = None) -> None:
         """Emit an adapter-sourced CALL_DENIED, keeping pending identity when present."""
@@ -852,6 +862,7 @@ class ClaudeAgentSDKAdapter:
                     span.end()
                     self._pending.pop(tool_use_id, None)
                     self._pending_decisions.pop(tool_use_id, None)
+                    self._clear_sink_ack(envelope.call_id)
                     return blocked_result
 
             # Handle block
@@ -868,6 +879,7 @@ class ClaudeAgentSDKAdapter:
                 span.end()
                 self._pending.pop(tool_use_id, None)
                 self._pending_decisions.pop(tool_use_id, None)
+                self._clear_sink_ack(envelope.call_id)
                 return self._deny(decision.reason or "")
 
             # Handle per-rule observed blocks

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -340,14 +340,15 @@ class ClaudeAgentSDKAdapter:
                 return {}
             except Exception:
                 logger.exception("Claude PreToolUse hook raised")
+                recovery = self._hook_recovery.get(call_id)
+                envelope = recovery.envelope if recovery is not None else None
                 try:
-                    await self._on_internal_exception(tool_name)
+                    await self._on_internal_exception(tool_name, envelope)
                 except Exception:
                     logger.exception("Claude internal-exception audit failed")
-                recovery = self._hook_recovery.get(call_id)
                 envelope_call_id = ""
-                if recovery is not None and recovery.envelope is not None:
-                    envelope_call_id = getattr(recovery.envelope, "call_id", "") or ""
+                if envelope is not None:
+                    envelope_call_id = getattr(envelope, "call_id", "") or ""
                 if envelope_call_id:
                     self._clear_sink_ack(envelope_call_id)
                 if self._guard.mode == "observe":
@@ -822,14 +823,40 @@ class ClaudeAgentSDKAdapter:
             return ADAPTER_UNKNOWN_TOOL_NAME
         return name
 
-    async def _on_internal_exception(self, tool_name: str) -> None:
+    async def _on_internal_exception(self, tool_name: str, envelope: Any | None = None) -> None:
         """Emit the D7 loud audit + counter/span for a hook-path exception."""
         self._internal_exception_count += 1
         reason = ADAPTER_INTERNAL_EXCEPTION_REASON
         mode = self._guard.mode
         action = AuditAction.CALL_WOULD_DENY if mode == "observe" else AuditAction.CALL_DENIED
         safe_name = self._safe_tool_name(tool_name)
-        self._guard.telemetry.record_adapter_exception(safe_name, mode)
+        self._guard.telemetry.record_adapter_exception(
+            envelope.tool_name if envelope is not None and envelope.tool_name else safe_name,
+            mode,
+        )
+        if envelope is not None:
+            await self._guard.audit_sink.emit(
+                AuditEvent(
+                    action=action,
+                    run_id=envelope.run_id,
+                    call_id=envelope.call_id,
+                    call_index=envelope.call_index,
+                    session_id=self._session_id,
+                    parent_session_id=self._audit_parent_session_id(),
+                    tool_name=envelope.tool_name or safe_name,
+                    tool_args=self._guard.redaction.redact_args(envelope.args),
+                    side_effect=envelope.side_effect.value,
+                    environment=envelope.environment,
+                    principal=asdict(envelope.principal) if envelope.principal else None,
+                    reason=reason,
+                    decision_source="adapter",
+                    decision_name=reason,
+                    mode=mode,
+                    policy_version=self._guard.policy_version,
+                    policy_error=True,
+                )
+            )
+            return
         await self._guard.audit_sink.emit(
             AuditEvent(
                 action=action,

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -456,6 +456,8 @@ class ClaudeAgentSDKAdapter:
         tool_use_id = getattr(context, "tool_use_id", None)
         if isinstance(context, dict):
             tool_use_id = context.get("tool_use_id", tool_use_id)
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            tool_use_id = None
         if tool_use_id and tool_use_id in self._pending:
             envelope, span = self._pending[tool_use_id]
             try:
@@ -870,8 +872,8 @@ class ClaudeAgentSDKAdapter:
             # Record in session
             await self._session.record_execution(envelope.tool_name, success=tool_success)
 
-            # Emit audit. Mark attempted before emit so a sink that delivers
-            # then raises (CompositeSink) does not replay via fallback.
+            # Emit audit. Mark complete only after emit returns so a sink
+            # that rejects the primary event can still receive fallback.
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             event = AuditEvent(
                 action=action,
@@ -895,8 +897,8 @@ class ClaudeAgentSDKAdapter:
                 policy_error=post_decision.policy_error,
                 workflow=workflow,
             )
-            self._execution_audit_completed.add(envelope.call_id)
             await self._guard.audit_sink.emit(event)
+            self._execution_audit_completed.add(envelope.call_id)
             await self._emit_workflow_events(envelope, workflow_events)
 
             span.set_attribute("governance.tool_success", tool_success)
@@ -913,11 +915,11 @@ class ClaudeAgentSDKAdapter:
         effective_response = (
             post_decision.redacted_response if post_decision.redacted_response is not None else tool_response
         )
-        findings = build_findings(post_decision)
+        violations = build_findings(post_decision)
         on_warn = getattr(self, "_on_postcondition_warn", None)
-        if not post_decision.postconditions_passed and findings and on_warn:
+        if not post_decision.postconditions_passed and violations and on_warn:
             try:
-                on_warn(effective_response, findings)
+                on_warn(effective_response, violations)
             except Exception:
                 logger.exception("on_postcondition_warn callback raised")
 

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
-from edictum.audit import AuditAction, AuditEvent
+from edictum.audit import AuditAction, AuditEvent, CompositeSink
 from edictum.envelope import Principal, ToolCall, _validate_tool_name, create_envelope
 from edictum.findings import Finding, build_findings
 from edictum.pipeline import CheckPipeline, PreDecision
@@ -578,8 +578,10 @@ class ClaudeAgentSDKAdapter:
 
     @staticmethod
     def _flatten_sinks(sink: Any) -> list[Any]:
-        children = getattr(sink, "sinks", None)
-        if not isinstance(children, list) or not children:
+        if not isinstance(sink, CompositeSink):
+            return [sink]
+        children = sink.sinks
+        if not children:
             return [sink]
         leaves: list[Any] = []
         for child in children:

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -459,8 +459,12 @@ class ClaudeAgentSDKAdapter:
                     self._clear_matching_pending(tool_name, tool_input)
                     return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "mismatch":
+                    if not call_id or call_id not in self._pending:
+                        self._clear_same_name_pending(tool_name)
                     return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "compare_failed":
+                    if not call_id or call_id not in self._pending:
+                        self._clear_same_name_pending(tool_name)
                     return await deny(_INPUT_COMPARE_REASON)
                 if pending is None:
                     return await deny(_NO_GOVERNED_SNAPSHOT_REASON)
@@ -565,6 +569,11 @@ class ClaudeAgentSDKAdapter:
             logger.exception("Claude host-block audit failed")
         self._clear_pending(call_id)
         return self._deny(reason)
+
+    def _clear_same_name_pending(self, tool_name: str) -> None:
+        keys = [key for key, (envelope, _span) in list(self._pending.items()) if envelope.tool_name == tool_name]
+        for key in keys:
+            self._clear_pending(key)
 
     def _clear_matching_pending(self, tool_name: str, tool_input: Any) -> None:
         keys: list[str] = []

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -538,21 +538,41 @@ class ClaudeAgentSDKAdapter:
             return composite
         return [self._guard.audit_sink]
 
-    def _ack_sink(self, sink: Any, event: AuditEvent) -> None:
+    @staticmethod
+    def _ack_identity(event: AuditEvent) -> tuple[str, str, str] | None:
         call_id = getattr(event, "call_id", "")
         action = getattr(event, "action", None)
         if not call_id or action is None:
+            return None
+        action_key = action.value if isinstance(action, AuditAction) else str(action)
+        extra = ""
+        workflow = getattr(event, "workflow", None)
+        if isinstance(workflow, dict):
+            completed = workflow.get("completed_stages") or ()
+            extra = f"{workflow.get('name', '')}:{workflow.get('active_stage', '')}:{tuple(completed)}"
+        return (call_id, action_key, extra)
+
+    def _ack_sink(self, sink: Any, event: AuditEvent) -> None:
+        identity = self._ack_identity(event)
+        if identity is None:
             return
-        key = action.value if isinstance(action, AuditAction) else str(action)
-        self._sink_ack.setdefault(id(sink), set()).add((call_id, key))
+        self._sink_ack.setdefault(id(sink), set()).add(identity)
 
     def _sink_acked(self, sink: Any, event: AuditEvent) -> bool:
-        call_id = getattr(event, "call_id", "")
-        action = getattr(event, "action", None)
-        if not call_id or action is None:
+        identity = self._ack_identity(event)
+        if identity is None:
             return False
-        key = action.value if isinstance(action, AuditAction) else str(action)
-        return (call_id, key) in self._sink_ack.get(id(sink), set())
+        return identity in self._sink_ack.get(id(sink), set())
+
+    def _clear_sink_ack(self, call_id: str) -> None:
+        if not call_id:
+            return
+        for sink_id, keys in list(self._sink_ack.items()):
+            remaining = {key for key in keys if key[0] != call_id}
+            if remaining:
+                self._sink_ack[sink_id] = remaining
+            else:
+                del self._sink_ack[sink_id]
 
     async def _emit_per_sink(self, event: AuditEvent) -> None:
         """Fan out one audit, skipping sinks that already accepted this call+action."""
@@ -583,6 +603,7 @@ class ClaudeAgentSDKAdapter:
             self._execution_audit_completed.discard(envelope.call_id)
             self._execution_tool_success.pop(envelope.call_id, None)
             await self._recover_workflow_events(envelope)
+            self._clear_sink_ack(envelope.call_id)
             return
         tool_success = False
         if envelope is not None and envelope.call_id in self._execution_tool_success:
@@ -618,6 +639,7 @@ class ClaudeAgentSDKAdapter:
                 )
             )
             await self._recover_workflow_events(envelope)
+            self._clear_sink_ack(envelope.call_id)
             return
         await self._guard.audit_sink.emit(
             AuditEvent(
@@ -983,6 +1005,7 @@ class ClaudeAgentSDKAdapter:
         self._execution_audit_completed.discard(envelope.call_id)
         self._execution_tool_success.pop(envelope.call_id, None)
         self._pending_workflow_events.pop(envelope.call_id, None)
+        self._clear_sink_ack(envelope.call_id)
         if post_decision.warnings:
             return {
                 "hookSpecificOutput": {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -168,6 +168,7 @@ class ClaudeAgentSDKAdapter:
         self._parent_session_id: str | None = None
         self._internal_exception_count = 0
         self._hook_recovery: dict[str, _HookRecovery] = {}
+        self._execution_audit_completed: set[str] = set()
 
     @property
     def session_id(self) -> str:
@@ -525,6 +526,9 @@ class ClaudeAgentSDKAdapter:
     async def _audit_post_hook_exception(self, pending: Any, tool_response: Any) -> None:
         """Emit adapter-sourced executed/failed after a post-hook raise."""
         envelope = pending[0] if isinstance(pending, tuple) and pending else None
+        if envelope is not None and envelope.call_id in self._execution_audit_completed:
+            self._execution_audit_completed.discard(envelope.call_id)
+            return
         tool_success = False
         if envelope is not None:
             try:
@@ -887,6 +891,7 @@ class ClaudeAgentSDKAdapter:
                     workflow=workflow,
                 )
             )
+            self._execution_audit_completed.add(envelope.call_id)
             await self._emit_workflow_events(envelope, workflow_events)
 
             span.set_attribute("governance.tool_success", tool_success)
@@ -912,6 +917,7 @@ class ClaudeAgentSDKAdapter:
                 logger.exception("on_postcondition_warn callback raised")
 
         # Return warnings as additionalContext
+        self._execution_audit_completed.discard(envelope.call_id)
         if post_decision.warnings:
             return {
                 "hookSpecificOutput": {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -2,22 +2,116 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import uuid
 from collections.abc import Callable
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from edictum.approval import ApprovalStatus
 from edictum.audit import AuditAction, AuditEvent
-from edictum.envelope import Principal, create_envelope
+from edictum.envelope import Principal, ToolCall, _validate_tool_name, create_envelope
 from edictum.findings import Finding, build_findings
-from edictum.pipeline import CheckPipeline
+from edictum.pipeline import CheckPipeline, PreDecision
 from edictum.session import Session, validate_session_id
+from edictum.telemetry import _NoOpSpan
 from edictum.workflow.state import build_workflow_snapshot
 
 logger = logging.getLogger(__name__)
 _MAX_WORKFLOW_APPROVAL_ROUNDS = 32
+# Fixed reason code for D7 / O7: a silently-broken observe trial must be visible.
+ADAPTER_INTERNAL_EXCEPTION_REASON = "adapter_internal_exception"
+ADAPTER_UNKNOWN_TOOL_NAME = "unknown_tool"
+_MAX_GOVERNED_INPUT_DEPTH = 64
+_PERMISSION_BOUNDARY_REASON = (
+    "BLOCKED: Edictum rejected an unsafe or invalid SDK permission result; "
+    "input and permission mutations are not supported after PreToolUse governance"
+)
+_INPUT_REPLACEMENT_REASON = "BLOCKED: Edictum rejected a tool input replacement after PreToolUse governance"
+_INPUT_COMPARE_REASON = "BLOCKED: Edictum could not compare tool input against the governed snapshot"
+_INVALID_TOOL_INPUT_REASON = "BLOCKED: Claude Agent SDK supplied invalid tool input"
+
+
+@dataclass
+class _SdkHookMatcher:
+    """Stand-in matcher when claude-agent-sdk is not installed.
+
+    The host converts matchers via ``matcher.matcher`` / ``matcher.hooks``.
+    """
+
+    matcher: str | None = None
+    hooks: list = field(default_factory=list)
+
+
+@dataclass
+class _PermissionAllow:
+    behavior: str = "allow"
+    updated_input: dict[str, Any] | None = None
+    updated_permissions: list[Any] | None = None
+
+
+@dataclass
+class _PermissionDeny:
+    behavior: str = "deny"
+    message: str = ""
+    interrupt: bool = False
+
+
+def _hook_matcher(hooks: list) -> Any:
+    try:
+        from claude_agent_sdk.types import HookMatcher
+
+        return HookMatcher(hooks=hooks)
+    except ImportError:
+        return _SdkHookMatcher(hooks=hooks)
+
+
+def _permission_allow(*, updated_input: dict[str, Any] | None = None) -> Any:
+    try:
+        from claude_agent_sdk.types import PermissionResultAllow
+
+        return PermissionResultAllow(updated_input=updated_input)
+    except ImportError:
+        return _PermissionAllow(updated_input=updated_input)
+
+
+def _permission_deny(message: str, interrupt: bool = False) -> Any:
+    try:
+        from claude_agent_sdk.types import PermissionResultDeny
+
+        return PermissionResultDeny(message=message, interrupt=interrupt)
+    except ImportError:
+        return _PermissionDeny(message=message, interrupt=interrupt)
+
+
+def _governed_input_equals(left: Any, right: Any, depth: int = 0) -> bool:
+    """Deep-compare the tool args that will execute against the governed snapshot."""
+    if depth > _MAX_GOVERNED_INPUT_DEPTH:
+        raise TypeError("BLOCKED: tool input exceeded compare depth")
+    if left is right:
+        return True
+    if left is None or right is None:
+        return False
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, (str, bytes, bool, int, float)):
+        return left == right
+    if isinstance(left, datetime):
+        return left == right
+    if isinstance(left, list):
+        if len(left) != len(right):
+            return False
+        return all(_governed_input_equals(a, b, depth + 1) for a, b in zip(left, right, strict=True))
+    if isinstance(left, dict):
+        if type(left) is not dict or type(right) is not dict:
+            raise TypeError("BLOCKED: governed input compare requires plain JSON-like values")
+        if left.keys() != right.keys():
+            return False
+        return all(_governed_input_equals(left[k], right[k], depth + 1) for k in left)
+    raise TypeError("BLOCKED: governed input compare requires plain JSON-like values")
+
 
 if TYPE_CHECKING:
     from edictum import Edictum
@@ -55,6 +149,14 @@ class ClaudeAgentSDKAdapter:
         self._principal = principal
         self._principal_resolver = principal_resolver
         self._parent_session_id: str | None = None
+        self._internal_exception_count = 0
+        self._hook_envelope: Any | None = None
+        self._hook_envelope_attempted = False
+        self._hook_decision: PreDecision | None = None
+        self._hook_span: Any | None = None
+        self._hook_span_attempted = False
+        self._hook_call_index_advanced = False
+        self._hook_attempts_advanced = False
 
     @property
     def session_id(self) -> str:
@@ -94,8 +196,8 @@ class ClaudeAgentSDKAdapter:
             result = await hooks["post_tool_use"](tool_use_id=id, tool_response=resp)
 
         These are **not** directly compatible with
-        ``ClaudeAgentOptions(hooks=...)``.  See the adapter docs for a bridge
-        recipe that wraps them into SDK-native format.
+        ``ClaudeAgentOptions(hooks=...)``. Use ``to_sdk_hooks()`` for the
+        host hook protocol matchers.
 
         Args:
             on_postcondition_warn: Optional callback invoked when postconditions
@@ -116,8 +218,345 @@ class ClaudeAgentSDKAdapter:
             "post_tool_use": self._post_tool_use,
         }
 
+    def to_sdk_hooks(
+        self,
+        on_postcondition_warn: Callable[[Any, list[Finding]], Any] | None = None,
+    ) -> dict[str, list[Any]]:
+        """Return SDK-native hook matchers for ClaudeAgentOptions.hooks.
+
+        Shape matches the host hook protocol: ``{event: [HookMatcher(hooks=[fn])]}``.
+        Pass → ``{}`` (emit nothing). Block → ``permissionDecision: deny``.
+        Never emit the SDK's ``ask`` or ``allow``.
+        """
+        self._on_postcondition_warn = on_postcondition_warn
+
+        async def pre_tool_use(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
+            hook_event = ""
+            if isinstance(input, dict):
+                hook_event = str(input.get("hook_event_name") or "")
+            else:
+                hook_event = str(getattr(input, "hook_event_name", "") or "")
+            if hook_event and hook_event != "PreToolUse":
+                return {}
+
+            tool_name = ""
+            tool_input: Any = None
+            input_tool_use_id = None
+            if isinstance(input, dict):
+                tool_name = input.get("tool_name") or ""
+                tool_input = input.get("tool_input")
+                input_tool_use_id = input.get("tool_use_id")
+            else:
+                tool_name = getattr(input, "tool_name", "") or ""
+                tool_input = getattr(input, "tool_input", None)
+                input_tool_use_id = getattr(input, "tool_use_id", None)
+
+            call_id = tool_use_id or input_tool_use_id or str(uuid.uuid4())
+            try:
+                if not isinstance(tool_input, dict):
+                    return self._deny(_INVALID_TOOL_INPUT_REASON)
+
+                pending = self._pending.get(call_id)
+                if pending is not None:
+                    envelope, _span = pending
+                    try:
+                        matches = envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input)
+                    except Exception:
+                        return self._deny(_INPUT_COMPARE_REASON)
+                    if not matches:
+                        return self._deny(_INPUT_REPLACEMENT_REASON)
+                    return {}
+
+                result = await self._pre_tool_use(tool_name, tool_input, call_id)
+                if result:
+                    return result
+
+                stored = self._pending.get(call_id)
+                try:
+                    still_matches = (
+                        stored is not None
+                        and stored[0].tool_name == tool_name
+                        and _governed_input_equals(stored[0].args, tool_input)
+                    )
+                except Exception:
+                    self._pending.pop(call_id, None)
+                    self._pending_decisions.pop(call_id, None)
+                    return self._deny(_INPUT_COMPARE_REASON)
+                if not still_matches:
+                    self._pending.pop(call_id, None)
+                    self._pending_decisions.pop(call_id, None)
+                    return self._deny(_INPUT_REPLACEMENT_REASON)
+                return {}
+            except Exception:
+                logger.exception("Claude PreToolUse hook raised")
+                try:
+                    await self._on_internal_exception(tool_name)
+                except Exception:
+                    logger.exception("Claude internal-exception audit failed")
+                if self._guard.mode == "observe":
+                    try:
+                        await self._ensure_observe_exception_pending(tool_name, tool_input, call_id)
+                    except Exception:
+                        logger.exception("Claude observe-exception pending seed failed")
+                    return {}
+                return self._deny(ADAPTER_INTERNAL_EXCEPTION_REASON)
+
+        async def post_tool_use(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
+            hook_event = ""
+            tool_response: Any = None
+            input_tool_use_id = None
+            if isinstance(input, dict):
+                hook_event = str(input.get("hook_event_name") or "")
+                tool_response = input.get("tool_response")
+                input_tool_use_id = input.get("tool_use_id")
+            else:
+                hook_event = str(getattr(input, "hook_event_name", "") or "")
+                tool_response = getattr(input, "tool_response", None)
+                input_tool_use_id = getattr(input, "tool_use_id", None)
+            if hook_event and hook_event != "PostToolUse":
+                return {}
+            call_id = tool_use_id or input_tool_use_id
+            if not call_id:
+                return {}
+            try:
+                return await self._post_tool_use(tool_use_id=call_id, tool_response=tool_response)
+            except Exception:
+                logger.exception("Claude PostToolUse hook raised; keeping original result")
+                return {}
+
+        async def post_tool_use_failure(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
+            hook_event = ""
+            error = None
+            input_tool_use_id = None
+            if isinstance(input, dict):
+                hook_event = str(input.get("hook_event_name") or "")
+                error = input.get("error")
+                input_tool_use_id = input.get("tool_use_id")
+            else:
+                hook_event = str(getattr(input, "hook_event_name", "") or "")
+                error = getattr(input, "error", None)
+                input_tool_use_id = getattr(input, "tool_use_id", None)
+            if hook_event and hook_event != "PostToolUseFailure":
+                return {}
+            call_id = tool_use_id or input_tool_use_id
+            if not call_id:
+                return {}
+            failure_response = {"is_error": True, "error": error}
+            try:
+                result = await self._post_tool_use(tool_use_id=call_id, tool_response=failure_response)
+            except Exception:
+                logger.exception("Claude PostToolUseFailure hook raised")
+                return {}
+            if not result:
+                return {}
+            specific = result.get("hookSpecificOutput")
+            if isinstance(specific, dict):
+                specific = dict(specific)
+                specific["hookEventName"] = "PostToolUseFailure"
+                return {"hookSpecificOutput": specific}
+            return result
+
+        hooks = {
+            "PreToolUse": [_hook_matcher([pre_tool_use])],
+            "PostToolUse": [_hook_matcher([post_tool_use])],
+            "PostToolUseFailure": [_hook_matcher([post_tool_use_failure])],
+        }
+        return hooks
+
+    def wrap_can_use_tool(self, callback: Callable) -> Callable:
+        """Wrap an SDK permission callback so it cannot mutate args after PreToolUse."""
+
+        async def wrapped(tool_name: str, tool_input: dict[str, Any], context: Any) -> Any:
+            try:
+                pending = self._pending_for_permission(tool_name, tool_input, context)
+                if pending == "mismatch":
+                    return _permission_deny(_INPUT_REPLACEMENT_REASON)
+                if pending == "compare_failed":
+                    return _permission_deny(_INPUT_COMPARE_REASON)
+
+                isolated = copy.deepcopy(tool_input) if isinstance(tool_input, dict) else tool_input
+                result = await callback(tool_name, isolated, context)
+
+                if isinstance(pending, tuple):
+                    envelope = pending[0]
+                    try:
+                        if envelope.tool_name != tool_name or not _governed_input_equals(envelope.args, tool_input):
+                            return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                    except Exception:
+                        return _permission_deny(_INPUT_COMPARE_REASON)
+
+                if result is None:
+                    return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+
+                behavior, updated_input, updated_permissions, message, interrupt = self._permission_fields(result)
+                if behavior == "allow":
+                    if updated_input is not None or updated_permissions is not None:
+                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                    pinned = None
+                    if isinstance(pending, tuple):
+                        pinned = copy.deepcopy(pending[0].args)
+                    return _permission_allow(updated_input=pinned)
+                if behavior == "deny":
+                    if not isinstance(message, str):
+                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                    if interrupt is not None and not isinstance(interrupt, bool):
+                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                    return _permission_deny(message, interrupt=bool(interrupt))
+                return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+            except Exception:
+                logger.exception("Claude can_use_tool wrapper raised")
+                return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+
+        return wrapped
+
+    def _pending_for_permission(self, tool_name: str, tool_input: Any, context: Any) -> Any:
+        tool_use_id = getattr(context, "tool_use_id", None)
+        if isinstance(context, dict):
+            tool_use_id = context.get("tool_use_id", tool_use_id)
+        if tool_use_id and tool_use_id in self._pending:
+            envelope, span = self._pending[tool_use_id]
+            try:
+                if envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input):
+                    return (envelope, span)
+                return "mismatch"
+            except Exception:
+                return "compare_failed"
+
+        same_name: list[tuple[Any, Any]] = []
+        for envelope, span in self._pending.values():
+            if envelope.tool_name == tool_name:
+                same_name.append((envelope, span))
+        if not same_name:
+            return None
+        for envelope, span in same_name:
+            try:
+                if _governed_input_equals(envelope.args, tool_input):
+                    return (envelope, span)
+            except Exception:
+                return "compare_failed"
+        return "mismatch"
+
+    @staticmethod
+    def _permission_fields(result: Any) -> tuple[Any, Any, Any, Any, Any]:
+        if isinstance(result, dict):
+            return (
+                result.get("behavior"),
+                result.get("updated_input", result.get("updatedInput")),
+                result.get("updated_permissions", result.get("updatedPermissions")),
+                result.get("message", ""),
+                result.get("interrupt", False),
+            )
+        return (
+            getattr(result, "behavior", None),
+            getattr(result, "updated_input", None),
+            getattr(result, "updated_permissions", None),
+            getattr(result, "message", ""),
+            getattr(result, "interrupt", False),
+        )
+
+    @staticmethod
+    def _safe_tool_name(name: Any) -> str:
+        if not isinstance(name, str) or not name:
+            return ADAPTER_UNKNOWN_TOOL_NAME
+        try:
+            _validate_tool_name(name)
+        except ValueError:
+            return ADAPTER_UNKNOWN_TOOL_NAME
+        return name
+
+    async def _on_internal_exception(self, tool_name: str) -> None:
+        """Emit the D7 loud audit + counter/span for a hook-path exception."""
+        self._internal_exception_count += 1
+        reason = ADAPTER_INTERNAL_EXCEPTION_REASON
+        mode = self._guard.mode
+        action = AuditAction.CALL_WOULD_DENY if mode == "observe" else AuditAction.CALL_DENIED
+        safe_name = self._safe_tool_name(tool_name)
+        self._guard.telemetry.record_adapter_exception(safe_name, mode)
+        await self._guard.audit_sink.emit(
+            AuditEvent(
+                action=action,
+                session_id=self._session_id,
+                tool_name=safe_name,
+                reason=reason,
+                decision_source="adapter",
+                decision_name=reason,
+                mode=mode,
+                policy_version=self._guard.policy_version,
+                policy_error=True,
+            )
+        )
+
+    async def _ensure_observe_exception_pending(
+        self,
+        tool_name: str,
+        tool_input: Any,
+        tool_use_id: str,
+    ) -> None:
+        """Keep enough pending state so post-hook can record the allowed execution."""
+        if tool_use_id in self._pending and tool_use_id in self._pending_decisions:
+            return
+        envelope = self._hook_envelope
+        if envelope is None:
+            safe_name = self._safe_tool_name(tool_name)
+            args = tool_input if isinstance(tool_input, dict) else {}
+            call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
+            if self._hook_envelope_attempted:
+                envelope = ToolCall(
+                    tool_name=safe_name,
+                    args=args,
+                    run_id=self._session_id,
+                    call_index=call_index,
+                    tool_use_id=tool_use_id,
+                    environment=self._guard.environment,
+                    principal=self._principal,
+                )
+            else:
+                envelope = create_envelope(
+                    tool_name=safe_name,
+                    tool_input=args,
+                    run_id=self._session_id,
+                    call_index=call_index,
+                    tool_use_id=tool_use_id,
+                    environment=self._guard.environment,
+                    registry=self._guard.tool_registry,
+                    principal=self._principal,
+                )
+        if self._hook_span is not None:
+            span = self._hook_span
+        elif self._hook_span_attempted:
+            span = _NoOpSpan()
+        else:
+            span = self._guard.telemetry.start_tool_span(envelope)
+        if self._hook_decision is not None:
+            decision = self._hook_decision
+        else:
+            decision = PreDecision(
+                action="allow",
+                reason=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                decision_source="adapter",
+                decision_name=ADAPTER_INTERNAL_EXCEPTION_REASON,
+                policy_error=True,
+            )
+        self._pending[tool_use_id] = (envelope, span)
+        self._pending_decisions[tool_use_id] = decision
+        if not self._hook_call_index_advanced:
+            self._call_index += 1
+            self._hook_call_index_advanced = True
+        if not self._hook_attempts_advanced:
+            self._hook_attempts_advanced = True
+            await self._session.increment_attempts()
+
     async def _pre_tool_use(self, tool_name: str, tool_input: dict, tool_use_id: str, **kwargs) -> dict[str, Any]:
+        self._hook_envelope = None
+        self._hook_envelope_attempted = False
+        self._hook_decision = None
+        self._hook_span = None
+        self._hook_span_attempted = False
+        self._hook_call_index_advanced = False
+        self._hook_attempts_advanced = False
+
         # Create envelope
+        self._hook_envelope_attempted = True
         envelope = create_envelope(
             tool_name=tool_name,
             tool_input=tool_input,
@@ -128,17 +567,23 @@ class ClaudeAgentSDKAdapter:
             registry=self._guard.tool_registry,
             principal=self._resolve_principal(tool_name, tool_input),
         )
+        self._hook_envelope = envelope
         self._call_index += 1
+        self._hook_call_index_advanced = True
 
         # Increment attempts BEFORE governance
+        self._hook_attempts_advanced = True
         await self._session.increment_attempts()
 
         # Start OTel span
+        self._hook_span_attempted = True
         span = self._guard.telemetry.start_tool_span(envelope)
+        self._hook_span = span
 
         try:
             # Run pipeline
             decision = await self._pipeline.pre_execute(envelope, self._session)
+            self._hook_decision = decision
             await self._emit_workflow_events(envelope, decision.workflow_events)
 
             # Handle observe mode: convert block to allow with warning

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -254,6 +254,10 @@ class ClaudeAgentSDKAdapter:
             call_id = tool_use_id or input_tool_use_id or str(uuid.uuid4())
             try:
                 if not isinstance(tool_input, dict):
+                    try:
+                        await self._audit_adapter_block(tool_name, _INVALID_TOOL_INPUT_REASON)
+                    except Exception:
+                        logger.exception("Claude malformed-input audit failed")
                     return self._deny(_INVALID_TOOL_INPUT_REASON)
 
                 pending = self._pending.get(call_id)
@@ -262,8 +266,10 @@ class ClaudeAgentSDKAdapter:
                     try:
                         matches = envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input)
                     except Exception:
+                        self._clear_pending(call_id)
                         return self._deny(_INPUT_COMPARE_REASON)
                     if not matches:
+                        self._clear_pending(call_id)
                         return self._deny(_INPUT_REPLACEMENT_REASON)
                     return {}
 
@@ -279,12 +285,10 @@ class ClaudeAgentSDKAdapter:
                         and _governed_input_equals(stored[0].args, tool_input)
                     )
                 except Exception:
-                    self._pending.pop(call_id, None)
-                    self._pending_decisions.pop(call_id, None)
+                    self._clear_pending(call_id)
                     return self._deny(_INPUT_COMPARE_REASON)
                 if not still_matches:
-                    self._pending.pop(call_id, None)
-                    self._pending_decisions.pop(call_id, None)
+                    self._clear_pending(call_id)
                     return self._deny(_INPUT_REPLACEMENT_REASON)
                 return {}
             except Exception:
@@ -452,6 +456,33 @@ class ClaudeAgentSDKAdapter:
             getattr(result, "updated_permissions", None),
             getattr(result, "message", ""),
             getattr(result, "interrupt", False),
+        )
+
+    def _clear_pending(self, call_id: str) -> None:
+        """Remove pending state and end the saved span for a blocked call."""
+        pending = self._pending.pop(call_id, None)
+        self._pending_decisions.pop(call_id, None)
+        if pending is None:
+            return
+        _envelope, span = pending
+        try:
+            span.end()
+        except Exception:
+            logger.exception("Claude pending span end failed")
+
+    async def _audit_adapter_block(self, tool_name: str, reason: str) -> None:
+        """Emit an adapter-sourced CALL_DENIED for a host-level block with no envelope."""
+        await self._guard.audit_sink.emit(
+            AuditEvent(
+                action=AuditAction.CALL_DENIED,
+                session_id=self._session_id,
+                tool_name=self._safe_tool_name(tool_name),
+                reason=reason,
+                decision_source="adapter",
+                decision_name=reason,
+                mode=self._guard.mode,
+                policy_version=self._guard.policy_version,
+            )
         )
 
     @staticmethod

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -533,10 +533,17 @@ class ClaudeAgentSDKAdapter:
             logger.exception("Claude pending span end failed")
 
     def _fanout_sinks(self) -> list[Any]:
-        composite = getattr(self._guard.audit_sink, "sinks", None)
-        if isinstance(composite, list):
-            return composite
-        return [self._guard.audit_sink]
+        return self._flatten_sinks(self._guard.audit_sink)
+
+    @staticmethod
+    def _flatten_sinks(sink: Any) -> list[Any]:
+        children = getattr(sink, "sinks", None)
+        if not isinstance(children, list) or not children:
+            return [sink]
+        leaves: list[Any] = []
+        for child in children:
+            leaves.extend(ClaudeAgentSDKAdapter._flatten_sinks(child))
+        return leaves
 
     @staticmethod
     def _ack_identity(event: AuditEvent) -> tuple[str, str, str] | None:
@@ -549,7 +556,13 @@ class ClaudeAgentSDKAdapter:
         workflow = getattr(event, "workflow", None)
         if isinstance(workflow, dict):
             completed = workflow.get("completed_stages") or ()
-            extra = f"{workflow.get('name', '')}:{workflow.get('active_stage', '')}:{tuple(completed)}"
+            extra = (
+                f"{workflow.get('name', '')}:"
+                f"{workflow.get('active_stage', '')}:"
+                f"{tuple(completed)}:"
+                f"{workflow.get('stage_id', '')}:"
+                f"{workflow.get('to_stage_id', '')}"
+            )
         return (call_id, action_key, extra)
 
     def _ack_sink(self, sink: Any, event: AuditEvent) -> None:

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -59,6 +59,19 @@ class _PermissionDeny:
     interrupt: bool = False
 
 
+@dataclass
+class _HookRecovery:
+    """Per-tool-call observe-exception stash. Do not share one adapter slot."""
+
+    envelope: Any | None = None
+    envelope_attempted: bool = False
+    decision: PreDecision | None = None
+    span: Any | None = None
+    span_attempted: bool = False
+    call_index_advanced: bool = False
+    attempts_advanced: bool = False
+
+
 def _hook_matcher(hooks: list) -> Any:
     try:
         from claude_agent_sdk.types import HookMatcher
@@ -150,13 +163,7 @@ class ClaudeAgentSDKAdapter:
         self._principal_resolver = principal_resolver
         self._parent_session_id: str | None = None
         self._internal_exception_count = 0
-        self._hook_envelope: Any | None = None
-        self._hook_envelope_attempted = False
-        self._hook_decision: PreDecision | None = None
-        self._hook_span: Any | None = None
-        self._hook_span_attempted = False
-        self._hook_call_index_advanced = False
-        self._hook_attempts_advanced = False
+        self._hook_recovery: dict[str, _HookRecovery] = {}
 
     @property
     def session_id(self) -> str:
@@ -266,11 +273,9 @@ class ClaudeAgentSDKAdapter:
                     try:
                         matches = envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input)
                     except Exception:
-                        self._clear_pending(call_id)
-                        return self._deny(_INPUT_COMPARE_REASON)
+                        return await self._block_pending(call_id, tool_name, _INPUT_COMPARE_REASON)
                     if not matches:
-                        self._clear_pending(call_id)
-                        return self._deny(_INPUT_REPLACEMENT_REASON)
+                        return await self._block_pending(call_id, tool_name, _INPUT_REPLACEMENT_REASON)
                     return {}
 
                 result = await self._pre_tool_use(tool_name, tool_input, call_id)
@@ -285,11 +290,9 @@ class ClaudeAgentSDKAdapter:
                         and _governed_input_equals(stored[0].args, tool_input)
                     )
                 except Exception:
-                    self._clear_pending(call_id)
-                    return self._deny(_INPUT_COMPARE_REASON)
+                    return await self._block_pending(call_id, tool_name, _INPUT_COMPARE_REASON)
                 if not still_matches:
-                    self._clear_pending(call_id)
-                    return self._deny(_INPUT_REPLACEMENT_REASON)
+                    return await self._block_pending(call_id, tool_name, _INPUT_REPLACEMENT_REASON)
                 return {}
             except Exception:
                 logger.exception("Claude PreToolUse hook raised")
@@ -304,6 +307,8 @@ class ClaudeAgentSDKAdapter:
                         logger.exception("Claude observe-exception pending seed failed")
                     return {}
                 return self._deny(ADAPTER_INTERNAL_EXCEPTION_REASON)
+            finally:
+                self._hook_recovery.pop(call_id, None)
 
         async def post_tool_use(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
             hook_event = ""
@@ -458,6 +463,15 @@ class ClaudeAgentSDKAdapter:
             getattr(result, "interrupt", False),
         )
 
+    async def _block_pending(self, call_id: str, tool_name: str, reason: str) -> dict[str, Any]:
+        """Emit the adapter blocked-call audit, then clear pending and return a host block."""
+        try:
+            await self._audit_adapter_block(tool_name, reason)
+        except Exception:
+            logger.exception("Claude host-block audit failed")
+        self._clear_pending(call_id)
+        return self._deny(reason)
+
     def _clear_pending(self, call_id: str) -> None:
         """Remove pending state and end the saved span for a blocked call."""
         pending = self._pending.pop(call_id, None)
@@ -526,12 +540,14 @@ class ClaudeAgentSDKAdapter:
         """Keep enough pending state so post-hook can record the allowed execution."""
         if tool_use_id in self._pending and tool_use_id in self._pending_decisions:
             return
-        envelope = self._hook_envelope
+        recovery = self._hook_recovery.get(tool_use_id)
+        envelope = recovery.envelope if recovery is not None else None
         if envelope is None:
             safe_name = self._safe_tool_name(tool_name)
             args = tool_input if isinstance(tool_input, dict) else {}
-            call_index = self._call_index - 1 if self._hook_call_index_advanced else self._call_index
-            if self._hook_envelope_attempted:
+            call_index_advanced = bool(recovery and recovery.call_index_advanced)
+            call_index = self._call_index - 1 if call_index_advanced else self._call_index
+            if recovery is not None and recovery.envelope_attempted:
                 envelope = ToolCall(
                     tool_name=safe_name,
                     args=args,
@@ -552,14 +568,14 @@ class ClaudeAgentSDKAdapter:
                     registry=self._guard.tool_registry,
                     principal=self._principal,
                 )
-        if self._hook_span is not None:
-            span = self._hook_span
-        elif self._hook_span_attempted:
+        if recovery is not None and recovery.span is not None:
+            span = recovery.span
+        elif recovery is not None and recovery.span_attempted:
             span = _NoOpSpan()
         else:
             span = self._guard.telemetry.start_tool_span(envelope)
-        if self._hook_decision is not None:
-            decision = self._hook_decision
+        if recovery is not None and recovery.decision is not None:
+            decision = recovery.decision
         else:
             decision = PreDecision(
                 action="allow",
@@ -570,24 +586,21 @@ class ClaudeAgentSDKAdapter:
             )
         self._pending[tool_use_id] = (envelope, span)
         self._pending_decisions[tool_use_id] = decision
-        if not self._hook_call_index_advanced:
+        if recovery is None or not recovery.call_index_advanced:
             self._call_index += 1
-            self._hook_call_index_advanced = True
-        if not self._hook_attempts_advanced:
-            self._hook_attempts_advanced = True
+            if recovery is not None:
+                recovery.call_index_advanced = True
+        if recovery is None or not recovery.attempts_advanced:
+            if recovery is not None:
+                recovery.attempts_advanced = True
             await self._session.increment_attempts()
 
     async def _pre_tool_use(self, tool_name: str, tool_input: dict, tool_use_id: str, **kwargs) -> dict[str, Any]:
-        self._hook_envelope = None
-        self._hook_envelope_attempted = False
-        self._hook_decision = None
-        self._hook_span = None
-        self._hook_span_attempted = False
-        self._hook_call_index_advanced = False
-        self._hook_attempts_advanced = False
+        recovery = _HookRecovery()
+        self._hook_recovery[tool_use_id] = recovery
 
         # Create envelope
-        self._hook_envelope_attempted = True
+        recovery.envelope_attempted = True
         envelope = create_envelope(
             tool_name=tool_name,
             tool_input=tool_input,
@@ -598,23 +611,23 @@ class ClaudeAgentSDKAdapter:
             registry=self._guard.tool_registry,
             principal=self._resolve_principal(tool_name, tool_input),
         )
-        self._hook_envelope = envelope
+        recovery.envelope = envelope
         self._call_index += 1
-        self._hook_call_index_advanced = True
+        recovery.call_index_advanced = True
 
         # Increment attempts BEFORE governance
-        self._hook_attempts_advanced = True
+        recovery.attempts_advanced = True
         await self._session.increment_attempts()
 
         # Start OTel span
-        self._hook_span_attempted = True
+        recovery.span_attempted = True
         span = self._guard.telemetry.start_tool_span(envelope)
-        self._hook_span = span
+        recovery.span = span
 
         try:
             # Run pipeline
             decision = await self._pipeline.pre_execute(envelope, self._session)
-            self._hook_decision = decision
+            recovery.decision = decision
             await self._emit_workflow_events(envelope, decision.workflow_events)
 
             # Handle observe mode: convert block to allow with warning

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -170,6 +170,7 @@ class ClaudeAgentSDKAdapter:
         self._hook_recovery: dict[str, _HookRecovery] = {}
         self._execution_audit_completed: set[str] = set()
         self._execution_tool_success: dict[str, bool] = {}
+        self._pending_workflow_events: dict[str, list[dict]] = {}
 
     @property
     def session_id(self) -> str:
@@ -526,12 +527,50 @@ class ClaudeAgentSDKAdapter:
         except Exception:
             logger.exception("Claude pending span end failed")
 
+    _EXECUTION_AUDIT_ACTIONS = (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+    _WORKFLOW_AUDIT_ACTIONS = (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+
+    def _sink_recorded_actions(self, sink: Any, call_id: str, actions: tuple[AuditAction, ...]) -> bool:
+        events = getattr(sink, "events", None)
+        if not isinstance(events, list) or not call_id:
+            return False
+        return any(getattr(event, "call_id", None) == call_id and event.action in actions for event in events)
+
+    async def _emit_skipping_acked(self, event: AuditEvent, actions: tuple[AuditAction, ...]) -> None:
+        """Replay an audit without re-delivering to sinks that already accepted it."""
+        composite = getattr(self._guard.audit_sink, "sinks", None)
+        if not isinstance(composite, list):
+            if self._sink_recorded_actions(self._guard.audit_sink, event.call_id, actions):
+                return
+            await self._guard.audit_sink.emit(event)
+            return
+        errors: list[Exception] = []
+        for sink in composite:
+            if self._sink_recorded_actions(sink, event.call_id, actions):
+                continue
+            try:
+                await sink.emit(event)
+            except Exception as exc:
+                errors.append(exc)
+        if errors:
+            raise ExceptionGroup("Claude fallback: one or more sinks failed", errors)
+
+    async def _recover_workflow_events(self, envelope: Any) -> None:
+        call_id = getattr(envelope, "call_id", "")
+        records = self._pending_workflow_events.pop(call_id, None)
+        if not records:
+            return
+        if self._sink_recorded_actions(self._guard.local_sink, call_id, self._WORKFLOW_AUDIT_ACTIONS):
+            return
+        await self._emit_workflow_events(envelope, records)
+
     async def _audit_post_hook_exception(self, pending: Any, tool_response: Any) -> None:
         """Emit adapter-sourced executed/failed after a post-hook raise."""
         envelope = pending[0] if isinstance(pending, tuple) and pending else None
         if envelope is not None and envelope.call_id in self._execution_audit_completed:
             self._execution_audit_completed.discard(envelope.call_id)
             self._execution_tool_success.pop(envelope.call_id, None)
+            await self._recover_workflow_events(envelope)
             return
         tool_success = False
         if envelope is not None and envelope.call_id in self._execution_tool_success:
@@ -544,7 +583,7 @@ class ClaudeAgentSDKAdapter:
         action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
         reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
         if envelope is not None:
-            await self._guard.audit_sink.emit(
+            await self._emit_skipping_acked(
                 AuditEvent(
                     action=action,
                     run_id=envelope.run_id,
@@ -564,8 +603,10 @@ class ClaudeAgentSDKAdapter:
                     mode=self._guard.mode,
                     policy_version=self._guard.policy_version,
                     policy_error=True,
-                )
+                ),
+                self._EXECUTION_AUDIT_ACTIONS,
             )
+            await self._recover_workflow_events(envelope)
             return
         await self._guard.audit_sink.emit(
             AuditEvent(
@@ -874,6 +915,7 @@ class ClaudeAgentSDKAdapter:
 
             # Emit audit. Mark complete only after emit returns so a sink
             # that rejects the primary event can still receive fallback.
+            self._pending_workflow_events[envelope.call_id] = list(workflow_events)
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             event = AuditEvent(
                 action=action,
@@ -900,6 +942,7 @@ class ClaudeAgentSDKAdapter:
             await self._guard.audit_sink.emit(event)
             self._execution_audit_completed.add(envelope.call_id)
             await self._emit_workflow_events(envelope, workflow_events)
+            self._pending_workflow_events.pop(envelope.call_id, None)
 
             span.set_attribute("governance.tool_success", tool_success)
             span.set_attribute("governance.postconditions_passed", post_decision.postconditions_passed)
@@ -926,6 +969,7 @@ class ClaudeAgentSDKAdapter:
         # Return warnings as additionalContext
         self._execution_audit_completed.discard(envelope.call_id)
         self._execution_tool_success.pop(envelope.call_id, None)
+        self._pending_workflow_events.pop(envelope.call_id, None)
         if post_decision.warnings:
             return {
                 "hookSpecificOutput": {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -453,6 +453,9 @@ class ClaudeAgentSDKAdapter:
                 pending = self._pending_for_permission(tool_name, tool_input, context)
                 if isinstance(pending, tuple):
                     call_id = pending[2]
+                if pending == "ambiguous":
+                    self._clear_matching_pending(tool_name, tool_input)
+                    return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "mismatch":
                     return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "compare_failed":
@@ -528,6 +531,8 @@ class ClaudeAgentSDKAdapter:
         if len(matches) == 1:
             key, envelope, span = matches[0]
             return (envelope, span, key)
+        if matches:
+            return "ambiguous"
         return "mismatch"
 
     @staticmethod
@@ -558,6 +563,17 @@ class ClaudeAgentSDKAdapter:
             logger.exception("Claude host-block audit failed")
         self._clear_pending(call_id)
         return self._deny(reason)
+
+    def _clear_matching_pending(self, tool_name: str, tool_input: Any) -> None:
+        keys: list[str] = []
+        for key, (envelope, _span) in list(self._pending.items()):
+            try:
+                if envelope.tool_name == tool_name and _governed_input_equals(envelope.args, tool_input):
+                    keys.append(key)
+            except Exception:
+                continue
+        for key in keys:
+            self._clear_pending(key)
 
     def _clear_pending(self, call_id: str) -> None:
         """Remove pending state and end the saved span for a blocked call."""

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -171,6 +171,7 @@ class ClaudeAgentSDKAdapter:
         self._execution_audit_completed: set[str] = set()
         self._execution_tool_success: dict[str, bool] = {}
         self._pending_workflow_events: dict[str, list[dict]] = {}
+        self._sink_ack: dict[int, set[tuple[str, str]]] = {}
 
     @property
     def session_id(self) -> str:
@@ -242,7 +243,7 @@ class ClaudeAgentSDKAdapter:
         Pass → ``{}`` (emit nothing). Block → ``permissionDecision: deny``.
         Never emit the SDK's ``ask`` or ``allow``.
         """
-        self._on_postcondition_warn = on_postcondition_warn
+        warning_cb = on_postcondition_warn
 
         async def pre_tool_use(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
             hook_event = ""
@@ -340,7 +341,9 @@ class ClaudeAgentSDKAdapter:
                 return {}
             pending_snapshot = self._pending.get(call_id)
             try:
-                return await self._post_tool_use(tool_use_id=call_id, tool_response=tool_response)
+                return await self._post_tool_use(
+                    tool_use_id=call_id, tool_response=tool_response, on_postcondition_warn=warning_cb
+                )
             except Exception:
                 logger.exception("Claude PostToolUse hook raised; keeping original result")
                 try:
@@ -369,7 +372,9 @@ class ClaudeAgentSDKAdapter:
             failure_response = {"is_error": True, "error": error}
             pending_snapshot = self._pending.get(call_id)
             try:
-                result = await self._post_tool_use(tool_use_id=call_id, tool_response=failure_response)
+                result = await self._post_tool_use(
+                    tool_use_id=call_id, tool_response=failure_response, on_postcondition_warn=warning_cb
+                )
             except Exception:
                 logger.exception("Claude PostToolUseFailure hook raised")
                 try:
@@ -527,40 +532,47 @@ class ClaudeAgentSDKAdapter:
         except Exception:
             logger.exception("Claude pending span end failed")
 
-    _EXECUTION_AUDIT_ACTIONS = (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
-    _WORKFLOW_AUDIT_ACTIONS = (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
-
-    def _sink_recorded_actions(self, sink: Any, call_id: str, actions: tuple[AuditAction, ...]) -> bool:
-        events = getattr(sink, "events", None)
-        if not isinstance(events, list) or not call_id:
-            return False
-        return any(getattr(event, "call_id", None) == call_id and event.action in actions for event in events)
-
-    async def _emit_skipping_acked(self, event: AuditEvent, actions: tuple[AuditAction, ...]) -> None:
-        """Replay an audit without re-delivering to sinks that already accepted it."""
+    def _fanout_sinks(self) -> list[Any]:
         composite = getattr(self._guard.audit_sink, "sinks", None)
-        if not isinstance(composite, list):
-            if self._sink_recorded_actions(self._guard.audit_sink, event.call_id, actions):
-                return
-            await self._guard.audit_sink.emit(event)
+        if isinstance(composite, list):
+            return composite
+        return [self._guard.audit_sink]
+
+    def _ack_sink(self, sink: Any, event: AuditEvent) -> None:
+        call_id = getattr(event, "call_id", "")
+        action = getattr(event, "action", None)
+        if not call_id or action is None:
             return
+        key = action.value if isinstance(action, AuditAction) else str(action)
+        self._sink_ack.setdefault(id(sink), set()).add((call_id, key))
+
+    def _sink_acked(self, sink: Any, event: AuditEvent) -> bool:
+        call_id = getattr(event, "call_id", "")
+        action = getattr(event, "action", None)
+        if not call_id or action is None:
+            return False
+        key = action.value if isinstance(action, AuditAction) else str(action)
+        return (call_id, key) in self._sink_ack.get(id(sink), set())
+
+    async def _emit_per_sink(self, event: AuditEvent) -> None:
+        """Fan out one audit, skipping sinks that already accepted this call+action."""
         errors: list[Exception] = []
-        for sink in composite:
-            if self._sink_recorded_actions(sink, event.call_id, actions):
+        for sink in self._fanout_sinks():
+            if self._sink_acked(sink, event):
                 continue
             try:
                 await sink.emit(event)
             except Exception as exc:
                 errors.append(exc)
+                continue
+            self._ack_sink(sink, event)
         if errors:
-            raise ExceptionGroup("Claude fallback: one or more sinks failed", errors)
+            raise ExceptionGroup("Claude audit fan-out: one or more sinks failed", errors)
 
     async def _recover_workflow_events(self, envelope: Any) -> None:
         call_id = getattr(envelope, "call_id", "")
         records = self._pending_workflow_events.pop(call_id, None)
         if not records:
-            return
-        if self._sink_recorded_actions(self._guard.local_sink, call_id, self._WORKFLOW_AUDIT_ACTIONS):
             return
         await self._emit_workflow_events(envelope, records)
 
@@ -583,7 +595,7 @@ class ClaudeAgentSDKAdapter:
         action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
         reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
         if envelope is not None:
-            await self._emit_skipping_acked(
+            await self._emit_per_sink(
                 AuditEvent(
                     action=action,
                     run_id=envelope.run_id,
@@ -603,8 +615,7 @@ class ClaudeAgentSDKAdapter:
                     mode=self._guard.mode,
                     policy_version=self._guard.policy_version,
                     policy_error=True,
-                ),
-                self._EXECUTION_AUDIT_ACTIONS,
+                )
             )
             await self._recover_workflow_events(envelope)
             return
@@ -939,7 +950,7 @@ class ClaudeAgentSDKAdapter:
                 policy_error=post_decision.policy_error,
                 workflow=workflow,
             )
-            await self._guard.audit_sink.emit(event)
+            await self._emit_per_sink(event)
             self._execution_audit_completed.add(envelope.call_id)
             await self._emit_workflow_events(envelope, workflow_events)
             self._pending_workflow_events.pop(envelope.call_id, None)
@@ -959,7 +970,9 @@ class ClaudeAgentSDKAdapter:
             post_decision.redacted_response if post_decision.redacted_response is not None else tool_response
         )
         violations = build_findings(post_decision)
-        on_warn = getattr(self, "_on_postcondition_warn", None)
+        on_warn = kwargs.get("on_postcondition_warn")
+        if on_warn is None:
+            on_warn = getattr(self, "_on_postcondition_warn", None)
         if not post_decision.postconditions_passed and violations and on_warn:
             try:
                 on_warn(effective_response, violations)
@@ -1019,7 +1032,7 @@ class ClaudeAgentSDKAdapter:
             action = AuditAction.WORKFLOW_STAGE_ADVANCED
             if action_name == AuditAction.WORKFLOW_COMPLETED.value:
                 action = AuditAction.WORKFLOW_COMPLETED
-            await self._guard.audit_sink.emit(
+            await self._emit_per_sink(
                 AuditEvent(
                     action=action,
                     run_id=envelope.run_id,

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 _MAX_WORKFLOW_APPROVAL_ROUNDS = 32
 # Fixed reason code for D7 / O7: a silently-broken observe trial must be visible.
 ADAPTER_INTERNAL_EXCEPTION_REASON = "adapter_internal_exception"
+ADAPTER_POST_HOOK_EXCEPTION_REASON = "adapter_post_hook_exception"
 ADAPTER_UNKNOWN_TOOL_NAME = "unknown_tool"
 _MAX_GOVERNED_INPUT_DEPTH = 64
 _PERMISSION_BOUNDARY_REASON = (
@@ -32,6 +33,7 @@ _PERMISSION_BOUNDARY_REASON = (
 _INPUT_REPLACEMENT_REASON = "BLOCKED: Edictum rejected a tool input replacement after PreToolUse governance"
 _INPUT_COMPARE_REASON = "BLOCKED: Edictum could not compare tool input against the governed snapshot"
 _INVALID_TOOL_INPUT_REASON = "BLOCKED: Claude Agent SDK supplied invalid tool input"
+_INVALID_TOOL_NAME_REASON = "BLOCKED: Claude Agent SDK supplied invalid tool name"
 _MISSING_TOOL_USE_ID_REASON = "BLOCKED: Claude Agent SDK PreToolUse omitted tool_use_id"
 _NO_GOVERNED_SNAPSHOT_REASON = "BLOCKED: Claude Agent SDK permission callback had no governed PreToolUse snapshot"
 
@@ -266,6 +268,12 @@ class ClaudeAgentSDKAdapter:
             try:
                 if not isinstance(tool_input, dict):
                     return await self._block_pending(call_id, tool_name, _INVALID_TOOL_INPUT_REASON)
+                if not isinstance(tool_name, str):
+                    return await self._block_pending(call_id, tool_name, _INVALID_TOOL_NAME_REASON)
+                try:
+                    _validate_tool_name(tool_name)
+                except ValueError:
+                    return await self._block_pending(call_id, tool_name, _INVALID_TOOL_NAME_REASON)
 
                 pending = self._pending.get(call_id)
                 if pending is not None:
@@ -327,10 +335,15 @@ class ClaudeAgentSDKAdapter:
             call_id = tool_use_id or input_tool_use_id
             if not call_id:
                 return {}
+            pending_snapshot = self._pending.get(call_id)
             try:
                 return await self._post_tool_use(tool_use_id=call_id, tool_response=tool_response)
             except Exception:
                 logger.exception("Claude PostToolUse hook raised; keeping original result")
+                try:
+                    await self._audit_post_hook_exception(pending_snapshot, tool_response)
+                except Exception:
+                    logger.exception("Claude post-hook exception audit failed")
                 return {}
 
         async def post_tool_use_failure(input: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
@@ -351,10 +364,15 @@ class ClaudeAgentSDKAdapter:
             if not call_id:
                 return {}
             failure_response = {"is_error": True, "error": error}
+            pending_snapshot = self._pending.get(call_id)
             try:
                 result = await self._post_tool_use(tool_use_id=call_id, tool_response=failure_response)
             except Exception:
                 logger.exception("Claude PostToolUseFailure hook raised")
+                try:
+                    await self._audit_post_hook_exception(pending_snapshot, failure_response)
+                except Exception:
+                    logger.exception("Claude post-hook exception audit failed")
                 return {}
             if not result:
                 return {}
@@ -503,6 +521,56 @@ class ClaudeAgentSDKAdapter:
             span.end()
         except Exception:
             logger.exception("Claude pending span end failed")
+
+    async def _audit_post_hook_exception(self, pending: Any, tool_response: Any) -> None:
+        """Emit adapter-sourced executed/failed after a post-hook raise."""
+        envelope = pending[0] if isinstance(pending, tuple) and pending else None
+        tool_success = False
+        if envelope is not None:
+            try:
+                tool_success = self._check_tool_success(envelope.tool_name, tool_response)
+            except Exception:
+                tool_success = False
+        action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
+        reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
+        if envelope is not None:
+            await self._guard.audit_sink.emit(
+                AuditEvent(
+                    action=action,
+                    run_id=envelope.run_id,
+                    call_id=envelope.call_id,
+                    call_index=envelope.call_index,
+                    session_id=self._session_id,
+                    parent_session_id=self._audit_parent_session_id(),
+                    tool_name=envelope.tool_name,
+                    tool_args=self._guard.redaction.redact_args(envelope.args),
+                    side_effect=envelope.side_effect.value,
+                    environment=envelope.environment,
+                    principal=asdict(envelope.principal) if envelope.principal else None,
+                    reason=reason,
+                    decision_source="adapter",
+                    decision_name=reason,
+                    tool_success=tool_success,
+                    mode=self._guard.mode,
+                    policy_version=self._guard.policy_version,
+                    policy_error=True,
+                )
+            )
+            return
+        await self._guard.audit_sink.emit(
+            AuditEvent(
+                action=action,
+                session_id=self._session_id,
+                tool_name=ADAPTER_UNKNOWN_TOOL_NAME,
+                reason=reason,
+                decision_source="adapter",
+                decision_name=reason,
+                tool_success=tool_success,
+                mode=self._guard.mode,
+                policy_version=self._guard.policy_version,
+                policy_error=True,
+            )
+        )
 
     async def _audit_adapter_block(self, tool_name: str, reason: str, envelope: Any | None = None) -> None:
         """Emit an adapter-sourced CALL_DENIED, keeping pending identity when present."""

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -169,6 +169,7 @@ class ClaudeAgentSDKAdapter:
         self._internal_exception_count = 0
         self._hook_recovery: dict[str, _HookRecovery] = {}
         self._execution_audit_completed: set[str] = set()
+        self._execution_tool_success: dict[str, bool] = {}
 
     @property
     def session_id(self) -> str:
@@ -528,9 +529,12 @@ class ClaudeAgentSDKAdapter:
         envelope = pending[0] if isinstance(pending, tuple) and pending else None
         if envelope is not None and envelope.call_id in self._execution_audit_completed:
             self._execution_audit_completed.discard(envelope.call_id)
+            self._execution_tool_success.pop(envelope.call_id, None)
             return
         tool_success = False
-        if envelope is not None:
+        if envelope is not None and envelope.call_id in self._execution_tool_success:
+            tool_success = self._execution_tool_success.pop(envelope.call_id)
+        elif envelope is not None:
             try:
                 tool_success = self._check_tool_success(envelope.tool_name, tool_response)
             except Exception:
@@ -841,6 +845,7 @@ class ClaudeAgentSDKAdapter:
         try:
             # Derive tool_success from SDK response
             tool_success = self._check_tool_success(envelope.tool_name, tool_response)
+            self._execution_tool_success[envelope.call_id] = tool_success
 
             # Run pipeline
             post_decision = await self._pipeline.post_execute(envelope, tool_response, tool_success)
@@ -865,33 +870,33 @@ class ClaudeAgentSDKAdapter:
             # Record in session
             await self._session.record_execution(envelope.tool_name, success=tool_success)
 
-            # Emit audit
+            # Emit audit. Mark attempted before emit so a sink that delivers
+            # then raises (CompositeSink) does not replay via fallback.
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
-            await self._guard.audit_sink.emit(
-                AuditEvent(
-                    action=action,
-                    run_id=envelope.run_id,
-                    call_id=envelope.call_id,
-                    call_index=envelope.call_index,
-                    session_id=self._session_id,
-                    parent_session_id=self._audit_parent_session_id(),
-                    tool_name=envelope.tool_name,
-                    tool_args=self._guard.redaction.redact_args(envelope.args),
-                    side_effect=envelope.side_effect.value,
-                    environment=envelope.environment,
-                    principal=asdict(envelope.principal) if envelope.principal else None,
-                    tool_success=tool_success,
-                    postconditions_passed=post_decision.postconditions_passed,
-                    contracts_evaluated=post_decision.contracts_evaluated,
-                    session_attempt_count=await self._session.attempt_count(),
-                    session_execution_count=await self._session.execution_count(),
-                    mode=self._guard.mode,
-                    policy_version=self._guard.policy_version,
-                    policy_error=post_decision.policy_error,
-                    workflow=workflow,
-                )
+            event = AuditEvent(
+                action=action,
+                run_id=envelope.run_id,
+                call_id=envelope.call_id,
+                call_index=envelope.call_index,
+                session_id=self._session_id,
+                parent_session_id=self._audit_parent_session_id(),
+                tool_name=envelope.tool_name,
+                tool_args=self._guard.redaction.redact_args(envelope.args),
+                side_effect=envelope.side_effect.value,
+                environment=envelope.environment,
+                principal=asdict(envelope.principal) if envelope.principal else None,
+                tool_success=tool_success,
+                postconditions_passed=post_decision.postconditions_passed,
+                contracts_evaluated=post_decision.contracts_evaluated,
+                session_attempt_count=await self._session.attempt_count(),
+                session_execution_count=await self._session.execution_count(),
+                mode=self._guard.mode,
+                policy_version=self._guard.policy_version,
+                policy_error=post_decision.policy_error,
+                workflow=workflow,
             )
             self._execution_audit_completed.add(envelope.call_id)
+            await self._guard.audit_sink.emit(event)
             await self._emit_workflow_events(envelope, workflow_events)
 
             span.set_attribute("governance.tool_success", tool_success)
@@ -918,6 +923,7 @@ class ClaudeAgentSDKAdapter:
 
         # Return warnings as additionalContext
         self._execution_audit_completed.discard(envelope.call_id)
+        self._execution_tool_success.pop(envelope.call_id, None)
         if post_decision.warnings:
             return {
                 "hookSpecificOutput": {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -175,6 +175,7 @@ class ClaudeAgentSDKAdapter:
         self._execution_audit_completed: set[str] = set()
         self._execution_tool_success: dict[str, bool] = {}
         self._execution_recorded: set[str] = set()
+        self._execution_record_attempted: set[str] = set()
         self._pending_workflow_events: dict[str, list[dict]] = {}
         self._pending_execution_event: dict[str, AuditEvent] = {}
         self._sink_ack: dict[int, set[tuple[str, str]]] = {}
@@ -342,6 +343,12 @@ class ClaudeAgentSDKAdapter:
                     await self._on_internal_exception(tool_name)
                 except Exception:
                     logger.exception("Claude internal-exception audit failed")
+                recovery = self._hook_recovery.get(call_id)
+                envelope_call_id = ""
+                if recovery is not None and recovery.envelope is not None:
+                    envelope_call_id = getattr(recovery.envelope, "call_id", "") or ""
+                if envelope_call_id:
+                    self._clear_sink_ack(envelope_call_id)
                 if self._guard.mode == "observe":
                     try:
                         await self._ensure_observe_exception_pending(tool_name, tool_input, call_id)
@@ -619,6 +626,7 @@ class ClaudeAgentSDKAdapter:
             self._execution_audit_completed.discard(envelope_call_id)
             self._execution_tool_success.pop(envelope_call_id, None)
             self._execution_recorded.discard(envelope_call_id)
+            self._execution_record_attempted.discard(envelope_call_id)
             self._pending_workflow_events.pop(envelope_call_id, None)
             self._pending_execution_event.pop(envelope_call_id, None)
             self._clear_sink_ack(envelope_call_id)
@@ -681,8 +689,9 @@ class ClaudeAgentSDKAdapter:
                     tool_success = False
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
-            if envelope is not None and envelope.call_id not in self._execution_recorded:
+            if envelope is not None and envelope.call_id not in self._execution_record_attempted:
                 try:
+                    self._execution_record_attempted.add(envelope.call_id)
                     await self._session.record_execution(envelope.tool_name, success=tool_success)
                     self._execution_recorded.add(envelope.call_id)
                 except Exception:
@@ -1021,6 +1030,7 @@ class ClaudeAgentSDKAdapter:
                 workflow = build_workflow_snapshot(self._guard._workflow_runtime.definition, workflow_state)
 
             # Record in session
+            self._execution_record_attempted.add(envelope.call_id)
             await self._session.record_execution(envelope.tool_name, success=tool_success)
             self._execution_recorded.add(envelope.call_id)
 

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -174,6 +174,7 @@ class ClaudeAgentSDKAdapter:
         self._hook_recovery: dict[str, _HookRecovery] = {}
         self._execution_audit_completed: set[str] = set()
         self._execution_tool_success: dict[str, bool] = {}
+        self._execution_recorded: set[str] = set()
         self._pending_workflow_events: dict[str, list[dict]] = {}
         self._sink_ack: dict[int, set[tuple[str, str]]] = {}
 
@@ -232,9 +233,22 @@ class ClaudeAgentSDKAdapter:
                 "for full enforcement. Hook callables can only warn."
             )
 
+        async def pre_tool_use(tool_name: str, tool_input: dict, tool_use_id: str, **kwargs) -> dict[str, Any]:
+            try:
+                return await self._pre_tool_use(tool_name, tool_input, tool_use_id, **kwargs)
+            finally:
+                if tool_use_id not in self._pending:
+                    self._hook_recovery.pop(tool_use_id, None)
+
+        async def post_tool_use(tool_use_id: str, tool_response: Any = None, **kwargs) -> dict[str, Any]:
+            try:
+                return await self._post_tool_use(tool_use_id, tool_response=tool_response, **kwargs)
+            finally:
+                self._hook_recovery.pop(tool_use_id, None)
+
         return {
-            "pre_tool_use": self._pre_tool_use,
-            "post_tool_use": self._post_tool_use,
+            "pre_tool_use": pre_tool_use,
+            "post_tool_use": post_tool_use,
         }
 
     def to_sdk_hooks(
@@ -534,6 +548,7 @@ class ClaudeAgentSDKAdapter:
             return
         envelope, span = pending
         self._clear_sink_ack(getattr(envelope, "call_id", "") or call_id)
+        self._hook_recovery.pop(call_id, None)
         try:
             span.end()
         except Exception:
@@ -561,7 +576,10 @@ class ClaudeAgentSDKAdapter:
         action_key = action.value if isinstance(action, AuditAction) else str(action)
         extra = ""
         workflow = getattr(event, "workflow", None)
-        if isinstance(workflow, dict):
+        if isinstance(workflow, dict) and action_key not in (
+            AuditAction.CALL_EXECUTED.value,
+            AuditAction.CALL_FAILED.value,
+        ):
             completed = workflow.get("completed_stages") or ()
             extra = (
                 f"{workflow.get('name', '')}:"
@@ -635,6 +653,12 @@ class ClaudeAgentSDKAdapter:
                     tool_success = False
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
+            if envelope is not None and envelope.call_id not in self._execution_recorded:
+                try:
+                    await self._session.record_execution(envelope.tool_name, success=tool_success)
+                    self._execution_recorded.add(envelope.call_id)
+                except Exception:
+                    logger.exception("Claude recovery record_execution failed")
             if envelope is not None:
                 await self._emit_per_sink(
                     AuditEvent(
@@ -677,6 +701,7 @@ class ClaudeAgentSDKAdapter:
         finally:
             if envelope is not None:
                 self._pending_workflow_events.pop(envelope.call_id, None)
+                self._execution_recorded.discard(envelope.call_id)
                 self._clear_sink_ack(envelope.call_id)
 
     async def _audit_adapter_block(self, tool_name: str, reason: str, envelope: Any | None = None) -> None:
@@ -963,6 +988,7 @@ class ClaudeAgentSDKAdapter:
                     decision.workflow_stage_id,
                     envelope,
                 )
+            self._pending_workflow_events[envelope.call_id] = list(workflow_events)
             workflow = decision.workflow
             if decision.workflow_involved and self._guard._workflow_runtime is not None:
                 workflow_state = await self._guard._workflow_runtime.state(self._session)
@@ -970,10 +996,10 @@ class ClaudeAgentSDKAdapter:
 
             # Record in session
             await self._session.record_execution(envelope.tool_name, success=tool_success)
+            self._execution_recorded.add(envelope.call_id)
 
             # Emit audit. Mark complete only after emit returns so a sink
             # that rejects the primary event can still receive fallback.
-            self._pending_workflow_events[envelope.call_id] = list(workflow_events)
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             event = AuditEvent(
                 action=action,
@@ -1029,7 +1055,9 @@ class ClaudeAgentSDKAdapter:
         # Return warnings as additionalContext
         self._execution_audit_completed.discard(envelope.call_id)
         self._execution_tool_success.pop(envelope.call_id, None)
+        self._execution_recorded.discard(envelope.call_id)
         self._pending_workflow_events.pop(envelope.call_id, None)
+        self._hook_recovery.pop(tool_use_id, None)
         self._clear_sink_ack(envelope.call_id)
         if post_decision.warnings:
             return {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -176,6 +176,7 @@ class ClaudeAgentSDKAdapter:
         self._execution_tool_success: dict[str, bool] = {}
         self._execution_recorded: set[str] = set()
         self._pending_workflow_events: dict[str, list[dict]] = {}
+        self._pending_execution_event: dict[str, AuditEvent] = {}
         self._sink_ack: dict[int, set[tuple[str, str]]] = {}
 
     @property
@@ -241,10 +242,21 @@ class ClaudeAgentSDKAdapter:
                     self._hook_recovery.pop(tool_use_id, None)
 
         async def post_tool_use(tool_use_id: str, tool_response: Any = None, **kwargs) -> dict[str, Any]:
+            pending_snapshot = self._pending.get(tool_use_id)
             try:
                 return await self._post_tool_use(tool_use_id, tool_response=tool_response, **kwargs)
+            except Exception:
+                logger.exception("Claude raw post_tool_use raised")
+                try:
+                    await self._audit_post_hook_exception(pending_snapshot, tool_response)
+                except Exception:
+                    logger.exception("Claude post-hook exception audit failed")
+                return {}
             finally:
-                self._hook_recovery.pop(tool_use_id, None)
+                envelope_call_id = ""
+                if pending_snapshot:
+                    envelope_call_id = getattr(pending_snapshot[0], "call_id", "") or ""
+                self._clear_call_state(envelope_call_id, tool_use_id)
 
         return {
             "pre_tool_use": pre_tool_use,
@@ -602,6 +614,17 @@ class ClaudeAgentSDKAdapter:
             return False
         return identity in self._sink_ack.get(id(sink), set())
 
+    def _clear_call_state(self, envelope_call_id: str = "", tool_use_id: str = "") -> None:
+        if envelope_call_id:
+            self._execution_audit_completed.discard(envelope_call_id)
+            self._execution_tool_success.pop(envelope_call_id, None)
+            self._execution_recorded.discard(envelope_call_id)
+            self._pending_workflow_events.pop(envelope_call_id, None)
+            self._pending_execution_event.pop(envelope_call_id, None)
+            self._clear_sink_ack(envelope_call_id)
+        if tool_use_id:
+            self._hook_recovery.pop(tool_use_id, None)
+
     def _clear_sink_ack(self, call_id: str) -> None:
         if not call_id:
             return
@@ -641,6 +664,11 @@ class ClaudeAgentSDKAdapter:
             if envelope is not None and envelope.call_id in self._execution_audit_completed:
                 self._execution_audit_completed.discard(envelope.call_id)
                 self._execution_tool_success.pop(envelope.call_id, None)
+                await self._recover_workflow_events(envelope)
+                return
+            stashed = self._pending_execution_event.get(envelope.call_id) if envelope is not None else None
+            if stashed is not None:
+                await self._emit_per_sink(stashed)
                 await self._recover_workflow_events(envelope)
                 return
             tool_success = False
@@ -700,9 +728,7 @@ class ClaudeAgentSDKAdapter:
             )
         finally:
             if envelope is not None:
-                self._pending_workflow_events.pop(envelope.call_id, None)
-                self._execution_recorded.discard(envelope.call_id)
-                self._clear_sink_ack(envelope.call_id)
+                self._clear_call_state(envelope.call_id)
 
     async def _audit_adapter_block(self, tool_name: str, reason: str, envelope: Any | None = None) -> None:
         """Emit an adapter-sourced CALL_DENIED, keeping pending identity when present."""
@@ -1023,6 +1049,7 @@ class ClaudeAgentSDKAdapter:
                 policy_error=post_decision.policy_error,
                 workflow=workflow,
             )
+            self._pending_execution_event[envelope.call_id] = event
             await self._emit_per_sink(event)
             self._execution_audit_completed.add(envelope.call_id)
             await self._emit_workflow_events(envelope, workflow_events)
@@ -1053,12 +1080,7 @@ class ClaudeAgentSDKAdapter:
                 logger.exception("on_postcondition_warn callback raised")
 
         # Return warnings as additionalContext
-        self._execution_audit_completed.discard(envelope.call_id)
-        self._execution_tool_success.pop(envelope.call_id, None)
-        self._execution_recorded.discard(envelope.call_id)
-        self._pending_workflow_events.pop(envelope.call_id, None)
-        self._hook_recovery.pop(tool_use_id, None)
-        self._clear_sink_ack(envelope.call_id)
+        self._clear_call_state(envelope.call_id, tool_use_id)
         if post_decision.warnings:
             return {
                 "hookSpecificOutput": {

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -261,11 +261,7 @@ class ClaudeAgentSDKAdapter:
             call_id = tool_use_id or input_tool_use_id or str(uuid.uuid4())
             try:
                 if not isinstance(tool_input, dict):
-                    try:
-                        await self._audit_adapter_block(tool_name, _INVALID_TOOL_INPUT_REASON)
-                    except Exception:
-                        logger.exception("Claude malformed-input audit failed")
-                    return self._deny(_INVALID_TOOL_INPUT_REASON)
+                    return await self._block_pending(call_id, tool_name, _INVALID_TOOL_INPUT_REASON)
 
                 pending = self._pending.get(call_id)
                 if pending is not None:
@@ -376,12 +372,22 @@ class ClaudeAgentSDKAdapter:
         """Wrap an SDK permission callback so it cannot mutate args after PreToolUse."""
 
         async def wrapped(tool_name: str, tool_input: dict[str, Any], context: Any) -> Any:
+            call_id = getattr(context, "tool_use_id", None)
+            if isinstance(context, dict):
+                call_id = context.get("tool_use_id", call_id)
+            if not isinstance(call_id, str) or not call_id:
+                call_id = ""
+
+            async def deny(reason: str, interrupt: bool = False) -> Any:
+                await self._block_pending(call_id, tool_name, reason)
+                return _permission_deny(reason, interrupt=interrupt)
+
             try:
                 pending = self._pending_for_permission(tool_name, tool_input, context)
                 if pending == "mismatch":
-                    return _permission_deny(_INPUT_REPLACEMENT_REASON)
+                    return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "compare_failed":
-                    return _permission_deny(_INPUT_COMPARE_REASON)
+                    return await deny(_INPUT_COMPARE_REASON)
 
                 isolated = copy.deepcopy(tool_input) if isinstance(tool_input, dict) else tool_input
                 result = await callback(tool_name, isolated, context)
@@ -390,31 +396,31 @@ class ClaudeAgentSDKAdapter:
                     envelope = pending[0]
                     try:
                         if envelope.tool_name != tool_name or not _governed_input_equals(envelope.args, tool_input):
-                            return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                            return await deny(_PERMISSION_BOUNDARY_REASON)
                     except Exception:
-                        return _permission_deny(_INPUT_COMPARE_REASON)
+                        return await deny(_INPUT_COMPARE_REASON)
 
                 if result is None:
-                    return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                    return await deny(_PERMISSION_BOUNDARY_REASON)
 
                 behavior, updated_input, updated_permissions, message, interrupt = self._permission_fields(result)
                 if behavior == "allow":
                     if updated_input is not None or updated_permissions is not None:
-                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                        return await deny(_PERMISSION_BOUNDARY_REASON)
                     pinned = None
                     if isinstance(pending, tuple):
                         pinned = copy.deepcopy(pending[0].args)
                     return _permission_allow(updated_input=pinned)
                 if behavior == "deny":
                     if not isinstance(message, str):
-                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                        return await deny(_PERMISSION_BOUNDARY_REASON)
                     if interrupt is not None and not isinstance(interrupt, bool):
-                        return _permission_deny(_PERMISSION_BOUNDARY_REASON)
-                    return _permission_deny(message, interrupt=bool(interrupt))
-                return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                        return await deny(_PERMISSION_BOUNDARY_REASON)
+                    return await deny(message, interrupt=bool(interrupt))
+                return await deny(_PERMISSION_BOUNDARY_REASON)
             except Exception:
                 logger.exception("Claude can_use_tool wrapper raised")
-                return _permission_deny(_PERMISSION_BOUNDARY_REASON)
+                return await deny(_PERMISSION_BOUNDARY_REASON)
 
         return wrapped
 

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -33,6 +33,7 @@ _INPUT_REPLACEMENT_REASON = "BLOCKED: Edictum rejected a tool input replacement 
 _INPUT_COMPARE_REASON = "BLOCKED: Edictum could not compare tool input against the governed snapshot"
 _INVALID_TOOL_INPUT_REASON = "BLOCKED: Claude Agent SDK supplied invalid tool input"
 _MISSING_TOOL_USE_ID_REASON = "BLOCKED: Claude Agent SDK PreToolUse omitted tool_use_id"
+_NO_GOVERNED_SNAPSHOT_REASON = "BLOCKED: Claude Agent SDK permission callback had no governed PreToolUse snapshot"
 
 
 @dataclass
@@ -393,6 +394,8 @@ class ClaudeAgentSDKAdapter:
                     return await deny(_INPUT_REPLACEMENT_REASON)
                 if pending == "compare_failed":
                     return await deny(_INPUT_COMPARE_REASON)
+                if pending is None:
+                    return await deny(_NO_GOVERNED_SNAPSHOT_REASON)
 
                 isolated = copy.deepcopy(tool_input) if isinstance(tool_input, dict) else tool_input
                 result = await callback(tool_name, isolated, context)

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -25,6 +25,7 @@ _MAX_WORKFLOW_APPROVAL_ROUNDS = 32
 ADAPTER_INTERNAL_EXCEPTION_REASON = "adapter_internal_exception"
 ADAPTER_POST_HOOK_EXCEPTION_REASON = "adapter_post_hook_exception"
 ADAPTER_UNKNOWN_TOOL_NAME = "unknown_tool"
+_EXECUTION_RECORD_STEPS = frozenset({"execs", "tool", "status"})
 _MAX_GOVERNED_INPUT_DEPTH = 64
 _PERMISSION_BOUNDARY_REASON = (
     "BLOCKED: Edictum rejected an unsafe or invalid SDK permission result; "
@@ -175,7 +176,7 @@ class ClaudeAgentSDKAdapter:
         self._execution_audit_completed: set[str] = set()
         self._execution_tool_success: dict[str, bool] = {}
         self._execution_recorded: set[str] = set()
-        self._execution_record_attempted: set[str] = set()
+        self._execution_record_steps: dict[str, set[str]] = {}
         self._pending_workflow_events: dict[str, list[dict]] = {}
         self._pending_execution_event: dict[str, AuditEvent] = {}
         self._sink_ack: dict[int, set[tuple[str, str]]] = {}
@@ -644,7 +645,7 @@ class ClaudeAgentSDKAdapter:
             self._execution_audit_completed.discard(envelope_call_id)
             self._execution_tool_success.pop(envelope_call_id, None)
             self._execution_recorded.discard(envelope_call_id)
-            self._execution_record_attempted.discard(envelope_call_id)
+            self._execution_record_steps.pop(envelope_call_id, None)
             self._pending_workflow_events.pop(envelope_call_id, None)
             self._pending_execution_event.pop(envelope_call_id, None)
             self._clear_sink_ack(envelope_call_id)
@@ -675,6 +676,25 @@ class ClaudeAgentSDKAdapter:
             self._ack_sink(sink, event)
         if errors:
             raise ExceptionGroup("Claude audit fan-out: one or more sinks failed", errors)
+
+    async def _record_session_execution(self, call_id: str, tool_name: str, success: bool) -> None:
+        """Apply remaining session execution counters without replaying completed ones."""
+        _validate_tool_name(tool_name)
+        completed = self._execution_record_steps.setdefault(call_id, set())
+        if "execs" not in completed:
+            await self._session._backend.increment(self._session._key("execs"))
+            completed.add("execs")
+        if "tool" not in completed:
+            await self._session._backend.increment(self._session._key(f"tool:{tool_name}"))
+            completed.add("tool")
+        if "status" not in completed:
+            if success:
+                await self._session._backend.delete(self._session._key("consec_fail"))
+            else:
+                await self._session._backend.increment(self._session._key("consec_fail"))
+            completed.add("status")
+        if _EXECUTION_RECORD_STEPS <= completed:
+            self._execution_recorded.add(call_id)
 
     async def _recover_workflow_events(self, envelope: Any) -> None:
         call_id = getattr(envelope, "call_id", "")
@@ -707,11 +727,9 @@ class ClaudeAgentSDKAdapter:
                     tool_success = False
             action = AuditAction.CALL_EXECUTED if tool_success else AuditAction.CALL_FAILED
             reason = ADAPTER_POST_HOOK_EXCEPTION_REASON
-            if envelope is not None and envelope.call_id not in self._execution_record_attempted:
+            if envelope is not None and envelope.call_id not in self._execution_recorded:
                 try:
-                    self._execution_record_attempted.add(envelope.call_id)
-                    await self._session.record_execution(envelope.tool_name, success=tool_success)
-                    self._execution_recorded.add(envelope.call_id)
+                    await self._record_session_execution(envelope.call_id, envelope.tool_name, tool_success)
                 except Exception:
                     logger.exception("Claude recovery record_execution failed")
             if envelope is not None:
@@ -1047,10 +1065,9 @@ class ClaudeAgentSDKAdapter:
                 workflow_state = await self._guard._workflow_runtime.state(self._session)
                 workflow = build_workflow_snapshot(self._guard._workflow_runtime.definition, workflow_state)
 
-            # Record in session
-            self._execution_record_attempted.add(envelope.call_id)
-            await self._session.record_execution(envelope.tool_name, success=tool_success)
-            self._execution_recorded.add(envelope.call_id)
+            # Record in session. Track completed counter steps so recovery
+            # can finish remaining writes without replaying successful ones.
+            await self._record_session_execution(envelope.call_id, envelope.tool_name, tool_success)
 
             # Emit audit. Mark complete only after emit returns so a sink
             # that rejects the primary event can still receive fallback.

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -445,12 +445,16 @@ class ClaudeAgentSDKAdapter:
                 same_name.append((key, envelope, span))
         if not same_name:
             return None
+        matches: list[tuple[str, Any, Any]] = []
         for key, envelope, span in same_name:
             try:
                 if _governed_input_equals(envelope.args, tool_input):
-                    return (envelope, span, key)
+                    matches.append((key, envelope, span))
             except Exception:
                 return "compare_failed"
+        if len(matches) == 1:
+            key, envelope, span = matches[0]
+            return (envelope, span, key)
         return "mismatch"
 
     @staticmethod
@@ -473,8 +477,10 @@ class ClaudeAgentSDKAdapter:
 
     async def _block_pending(self, call_id: str, tool_name: str, reason: str) -> dict[str, Any]:
         """Emit the adapter blocked-call audit, then clear pending and return a host block."""
+        pending = self._pending.get(call_id)
+        envelope = pending[0] if pending is not None else None
         try:
-            await self._audit_adapter_block(tool_name, reason)
+            await self._audit_adapter_block(tool_name, reason, envelope)
         except Exception:
             logger.exception("Claude host-block audit failed")
         self._clear_pending(call_id)
@@ -492,8 +498,30 @@ class ClaudeAgentSDKAdapter:
         except Exception:
             logger.exception("Claude pending span end failed")
 
-    async def _audit_adapter_block(self, tool_name: str, reason: str) -> None:
-        """Emit an adapter-sourced CALL_DENIED for a host-level block with no envelope."""
+    async def _audit_adapter_block(self, tool_name: str, reason: str, envelope: Any | None = None) -> None:
+        """Emit an adapter-sourced CALL_DENIED, keeping pending identity when present."""
+        if envelope is not None:
+            await self._guard.audit_sink.emit(
+                AuditEvent(
+                    action=AuditAction.CALL_DENIED,
+                    run_id=envelope.run_id,
+                    call_id=envelope.call_id,
+                    call_index=envelope.call_index,
+                    session_id=self._session_id,
+                    parent_session_id=self._audit_parent_session_id(),
+                    tool_name=envelope.tool_name or self._safe_tool_name(tool_name),
+                    tool_args=self._guard.redaction.redact_args(envelope.args),
+                    side_effect=envelope.side_effect.value,
+                    environment=envelope.environment,
+                    principal=asdict(envelope.principal) if envelope.principal else None,
+                    reason=reason,
+                    decision_source="adapter",
+                    decision_name=reason,
+                    mode=self._guard.mode,
+                    policy_version=self._guard.policy_version,
+                )
+            )
+            return
         await self._guard.audit_sink.emit(
             AuditEvent(
                 action=AuditAction.CALL_DENIED,

--- a/src/edictum/adapters/claude_agent_sdk.py
+++ b/src/edictum/adapters/claude_agent_sdk.py
@@ -32,6 +32,7 @@ _PERMISSION_BOUNDARY_REASON = (
 _INPUT_REPLACEMENT_REASON = "BLOCKED: Edictum rejected a tool input replacement after PreToolUse governance"
 _INPUT_COMPARE_REASON = "BLOCKED: Edictum could not compare tool input against the governed snapshot"
 _INVALID_TOOL_INPUT_REASON = "BLOCKED: Claude Agent SDK supplied invalid tool input"
+_MISSING_TOOL_USE_ID_REASON = "BLOCKED: Claude Agent SDK PreToolUse omitted tool_use_id"
 
 
 @dataclass
@@ -258,7 +259,9 @@ class ClaudeAgentSDKAdapter:
                 tool_input = getattr(input, "tool_input", None)
                 input_tool_use_id = getattr(input, "tool_use_id", None)
 
-            call_id = tool_use_id or input_tool_use_id or str(uuid.uuid4())
+            call_id = tool_use_id or input_tool_use_id
+            if not isinstance(call_id, str) or not call_id:
+                return await self._block_pending("", tool_name, _MISSING_TOOL_USE_ID_REASON)
             try:
                 if not isinstance(tool_input, dict):
                     return await self._block_pending(call_id, tool_name, _INVALID_TOOL_INPUT_REASON)
@@ -384,7 +387,7 @@ class ClaudeAgentSDKAdapter:
 
             try:
                 pending = self._pending_for_permission(tool_name, tool_input, context)
-                if isinstance(pending, tuple) and not call_id:
+                if isinstance(pending, tuple):
                     call_id = pending[2]
                 if pending == "mismatch":
                     return await deny(_INPUT_REPLACEMENT_REASON)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,19 @@ def pytest_configure(config):
             ) from exc
     if os.environ.get(_CLAUDE_SMOKE_ENV) == "1":
         try:
-            importlib.import_module("claude_agent_sdk")
+            sdk = importlib.import_module("claude_agent_sdk")
         except ImportError as exc:
             raise pytest.UsageError(
                 "EDICTUM_CLAUDE_SMOKE=1 requires claude-agent-sdk; missing host for a claimed capability is RED"
             ) from exc
+        import shutil
+        from pathlib import Path
+
+        bundled = Path(sdk.__file__).parent / "_bundled" / "claude"
+        if shutil.which("claude") is None and not bundled.is_file():
+            raise pytest.UsageError(
+                "EDICTUM_CLAUDE_SMOKE=1 requires the Claude Code CLI; missing host for a claimed capability is RED"
+            )
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,24 +13,34 @@ from edictum.storage import MemoryBackend
 
 _CREWAI_SMOKE_ENV = "EDICTUM_CREWAI_SMOKE"
 _CREWAI_SMOKE_FILE = "test_adapter_crewai_smoke.py"
+_CLAUDE_SMOKE_ENV = "EDICTUM_CLAUDE_SMOKE"
+_CLAUDE_SMOKE_FILE = "test_adapter_claude_smoke.py"
 
-# Default/parity collection must not import crewai (the host is not installed
-# there). Dedicated smoke jobs set EDICTUM_CREWAI_SMOKE=1 and collect this
-# file fail-closed: missing host is RED, never a skip.
+# Default/parity collection must not import crewai or claude-agent-sdk
+# (those hosts are not installed there). Dedicated smoke jobs set the
+# matching env flag and collect fail-closed: missing host is RED, never a skip.
 collect_ignore: list[str] = []
 if os.environ.get(_CREWAI_SMOKE_ENV) != "1":
     collect_ignore.append(_CREWAI_SMOKE_FILE)
+if os.environ.get(_CLAUDE_SMOKE_ENV) != "1":
+    collect_ignore.append(_CLAUDE_SMOKE_FILE)
 
 
 def pytest_configure(config):
-    if os.environ.get(_CREWAI_SMOKE_ENV) != "1":
-        return
-    try:
-        importlib.import_module("crewai")
-    except ImportError as exc:
-        raise pytest.UsageError(
-            "EDICTUM_CREWAI_SMOKE=1 requires crewai; missing host for a claimed capability is RED"
-        ) from exc
+    if os.environ.get(_CREWAI_SMOKE_ENV) == "1":
+        try:
+            importlib.import_module("crewai")
+        except ImportError as exc:
+            raise pytest.UsageError(
+                "EDICTUM_CREWAI_SMOKE=1 requires crewai; missing host for a claimed capability is RED"
+            ) from exc
+    if os.environ.get(_CLAUDE_SMOKE_ENV) == "1":
+        try:
+            importlib.import_module("claude_agent_sdk")
+        except ImportError as exc:
+            raise pytest.UsageError(
+                "EDICTUM_CLAUDE_SMOKE=1 requires claude-agent-sdk; missing host for a claimed capability is RED"
+            ) from exc
 
 
 def pytest_addoption(parser):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1168,7 +1168,9 @@ class TestClaudeSdkHostHooks:
         )
         assert configured.calls >= 2
         assert executed[0].action == AuditAction.CALL_EXECUTED
-        assert executed[0].reason == ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert executed[0].policy_error is not True
+        assert executed[0].postconditions_passed is True
         assert adapter._pending == {}
         assert adapter._pending_decisions == {}
 
@@ -1219,7 +1221,9 @@ class TestClaudeSdkHostHooks:
             f"configured sink missed fallback; got {[(e.action, e.reason) for e in configured.events]}"
         )
         assert configured.calls >= 2
-        assert configured_executed[0].reason == ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert configured_executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert configured_executed[0].policy_error is not True
+        assert configured_executed[0].postconditions_passed is True
 
     @pytest.mark.security
     async def test_workflow_events_emitted_when_execution_audit_falls_back(self):
@@ -1703,6 +1707,26 @@ class TestClaudeSdkHostHooks:
         assert "tu-1" in adapter._hook_recovery
         await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="ok")
         assert adapter._hook_recovery == {}, f"raw hook recovery leaked: {adapter._hook_recovery}"
+
+    @pytest.mark.security
+    async def test_to_hook_callables_clears_recovery_after_post_failure(self):
+        def boom_check(tool_name, tool_response):
+            raise RuntimeError("success_check failed")
+
+        adapter = ClaudeAgentSDKAdapter(make_guard(success_check=boom_check))
+        hooks = adapter.to_hook_callables()
+        await hooks["pre_tool_use"]("canary", {"payload": "ping"}, "tu-1")
+        envelope = adapter._pending["tu-1"][0]
+        result = await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="ok")
+        assert result == {}
+        assert adapter._hook_recovery == {}
+        assert adapter._execution_tool_success == {}
+        assert adapter._execution_recorded == set()
+        assert adapter._pending_workflow_events == {}
+        assert adapter._pending_execution_event == {}
+        assert adapter._execution_audit_completed == set()
+        leftover = [key for keys in adapter._sink_ack.values() for key in keys if key[0] == envelope.call_id]
+        assert leftover == [], f"raw post failure leaked sink acks: {leftover}"
 
     @pytest.mark.security
     async def test_multiple_workflow_transitions_are_not_collapsed(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from edictum import Decision, Edictum, postcondition, precondition
-from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
+from edictum.adapters.claude_agent_sdk import (
+    _INPUT_REPLACEMENT_REASON,
+    _INVALID_TOOL_INPUT_REASON,
+    ClaudeAgentSDKAdapter,
+)
 from edictum.audit import AuditAction
 from edictum.findings import Finding
 from edictum.storage import MemoryBackend
@@ -490,6 +494,23 @@ class TestClaudeSdkHostHooks:
         assert "BLOCKED" in second["hookSpecificOutput"]["permissionDecisionReason"]
 
     @pytest.mark.security
+    async def test_replacement_clears_pending_and_ends_span(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        pre = _sdk_pre(adapter)
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        assert "tu-1" in adapter._pending
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+        second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
+        assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert second["hookSpecificOutput"]["permissionDecisionReason"] == _INPUT_REPLACEMENT_REASON
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
+
+    @pytest.mark.security
     async def test_pretooluse_rejects_mutation_during_pre(self):
         adapter = ClaudeAgentSDKAdapter(make_guard())
         tool_input = {"payload": "ping"}
@@ -522,6 +543,28 @@ class TestClaudeSdkHostHooks:
             {"signal": None},
         )
         assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    @pytest.mark.security
+    async def test_malformed_tool_input_emits_adapter_audit(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        result = await _sdk_pre(adapter)(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "canary",
+                "tool_input": ["not", "a", "dict"],
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        events = [e for e in sink.events if e.reason == _INVALID_TOOL_INPUT_REASON]
+        assert events, f"malformed block missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _INVALID_TOOL_INPUT_REASON
+        assert events[0].tool_name == "canary"
 
     @pytest.mark.security
     async def test_wrap_can_use_tool_blocks_replacement(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1429,6 +1429,78 @@ class TestClaudeSdkHostHooks:
         assert seen == ["a"], f"first hook set must keep its callback; got {seen}"
 
     @pytest.mark.security
+    async def test_sink_acks_cleared_after_successful_post(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        leftover = [key for keys in adapter._sink_ack.values() for key in keys if key[0]]
+        assert leftover == [], f"sink acks leaked after completion: {leftover}"
+
+    @pytest.mark.security
+    async def test_multiple_workflow_transitions_are_not_collapsed(self):
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from edictum.workflow.result import WorkflowState
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1", "completed_stages": []},
+                    },
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s2", "completed_stages": ["s1"]},
+                    },
+                ]
+
+            async def state(self, session):
+                state = WorkflowState(session_id=session.session_id, active_stage="s2", completed_stages=["s1"])
+                state.ensure_defaults()
+                return state
+
+        sink = NullAuditSink()
+        guard = make_guard(audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        stages = [
+            (e.workflow or {}).get("active_stage")
+            for e in sink.events
+            if e.action == AuditAction.WORKFLOW_STAGE_ADVANCED
+        ]
+        assert stages == ["s1", "s2"], f"collapsed workflow transitions; got {stages}"
+
+    @pytest.mark.security
     async def test_post_failure_hook_exception_still_audits(self):
         sink = NullAuditSink()
         adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from edictum import Decision, Edictum, postcondition, precondition
+from edictum import Decision, Edictum, Principal, postcondition, precondition
 from edictum.adapters.claude_agent_sdk import (
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
@@ -530,6 +530,34 @@ class TestClaudeSdkHostHooks:
         assert events[0].tool_name == "canary"
 
     @pytest.mark.security
+    async def test_replacement_audit_preserves_pending_identity(self):
+        """CALL_DENIED after a governed allow must keep the envelope identity."""
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(
+            make_guard(audit_sink=sink),
+            principal=Principal(user_id="alice"),
+        )
+        pre = _sdk_pre(adapter)
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
+        assert allowed
+        allowed_event = allowed[0]
+        assert allowed_event.call_id
+        second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
+        assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+        denied = [e for e in sink.events if e.reason == _INPUT_REPLACEMENT_REASON]
+        assert denied
+        event = denied[0]
+        assert event.action == AuditAction.CALL_DENIED
+        assert event.run_id == allowed_event.run_id
+        assert event.call_id == allowed_event.call_id
+        assert event.call_index == allowed_event.call_index
+        assert event.tool_name == allowed_event.tool_name
+        assert event.tool_args == allowed_event.tool_args
+        assert event.principal == allowed_event.principal
+
+    @pytest.mark.security
     async def test_pretooluse_rejects_mutation_during_pre(self):
         adapter = ClaudeAgentSDKAdapter(make_guard())
         tool_input = {"payload": "ping"}
@@ -644,6 +672,12 @@ class TestClaudeSdkHostHooks:
         assert events[0].action == AuditAction.CALL_DENIED
         assert events[0].decision_source == "adapter"
         assert events[0].decision_name == _PERMISSION_BOUNDARY_REASON
+        allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
+        assert allowed
+        assert events[0].run_id == allowed[0].run_id
+        assert events[0].call_id == allowed[0].call_id
+        assert events[0].call_index == allowed[0].call_index
+        assert events[0].principal == allowed[0].principal
         assert any(e.action == AuditAction.CALL_DENIED for e in sink.events)
         assert "tu-1" not in adapter._pending
         assert "tu-1" not in adapter._pending_decisions
@@ -694,6 +728,40 @@ class TestClaudeSdkHostHooks:
         assert "tu-1" not in adapter._pending_decisions
         assert "" not in adapter._pending
         span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_no_id_does_not_clear_wrong_of_two_identical_pending(self):
+        """Ambiguous no-ID name+input match must not pick or clear the first pending."""
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(
+            _pre_input(tool_input={"payload": "ping"}, tool_use_id="tu-1"),
+            "tu-1",
+            {"signal": None},
+        )
+        await _sdk_pre(adapter)(
+            _pre_input(tool_input={"payload": "ping"}, tool_use_id="tu-2"),
+            "tu-2",
+            {"signal": None},
+        )
+        env1, _old1 = adapter._pending["tu-1"]
+        env2, _old2 = adapter._pending["tu-2"]
+        span1 = MagicMock()
+        span2 = MagicMock()
+        adapter._pending["tu-1"] = (env1, span1)
+        adapter._pending["tu-2"] = (env2, span2)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "deny", "message": "nope"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped("canary", {"payload": "ping"}, type("Ctx", (), {})())
+        assert result.behavior == "deny"
+        assert "tu-1" in adapter._pending
+        assert "tu-2" in adapter._pending
+        assert "tu-1" in adapter._pending_decisions
+        assert "tu-2" in adapter._pending_decisions
+        span1.end.assert_not_called()
+        span2.end.assert_not_called()
 
     @pytest.mark.security
     async def test_malformed_redispatch_clears_pending(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -367,3 +367,232 @@ class TestClaudeSDKPostconditionCallback:
         assert isinstance(f, Finding)
         assert f.rule_id == "detect_secret"
         assert "API token" in f.message
+
+
+def _sdk_pre(adapter):
+    return adapter.to_sdk_hooks()["PreToolUse"][0].hooks[0]
+
+
+def _pre_input(tool_name="canary", tool_input=None, tool_use_id="tu-1"):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {} if tool_input is None else tool_input,
+        "tool_use_id": tool_use_id,
+    }
+
+
+_ASK_RULES = """
+apiVersion: edictum/v1
+kind: Ruleset
+metadata:
+  name: claude-ask
+defaults:
+  mode: enforce
+tools:
+  canary:
+    side_effect: write
+rules:
+  - id: ask-canary
+    type: pre
+    tool: canary
+    when:
+      args.payload: {equals: ping}
+    then:
+      action: ask
+      message: would ask a human
+      timeout: 30
+      timeout_action: block
+"""
+
+
+class SpyApprovalBackend:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def request_approval(self, **kwargs):
+        from edictum.approval import ApprovalRequest
+
+        self.requests.append(kwargs)
+        return ApprovalRequest(
+            approval_id="spy-1",
+            tool_name=kwargs.get("tool_name", ""),
+            tool_args=kwargs.get("tool_args") or {},
+            message=kwargs.get("message") or "",
+            timeout=kwargs.get("timeout") or 30,
+        )
+
+    async def wait_for_decision(self, approval_id: str, timeout: int | None = None):
+        from edictum.approval import ApprovalDecision, ApprovalStatus
+
+        return ApprovalDecision(approved=False, reason="spy-block", status=ApprovalStatus.DENIED)
+
+
+class TestClaudeSdkHostHooks:
+    """Host hook protocol: matchers, no-match {}, no SDK ask, fail-closed replacement, D7."""
+
+    async def test_to_sdk_hooks_matchers_have_hooks(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        hooks = adapter.to_sdk_hooks()
+        assert "PreToolUse" in hooks
+        assert hooks["PreToolUse"][0].hooks
+        assert hooks["PostToolUse"][0].hooks
+
+    async def test_no_match_emits_nothing(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        result = await _sdk_pre(adapter)(_pre_input(), "tu-1", {"signal": None})
+        assert result == {}
+        assert "permissionDecision" not in result
+        assert "hookSpecificOutput" not in result
+
+    @pytest.mark.security
+    async def test_block_emits_host_deny_not_ask(self):
+        @precondition("*")
+        def always_block(tool_call):
+            return Decision.fail("canary blocked")
+
+        adapter = ClaudeAgentSDKAdapter(make_guard(rules=[always_block]))
+        result = await _sdk_pre(adapter)(_pre_input(), "tu-1", {"signal": None})
+        emitted = result["hookSpecificOutput"]
+        assert emitted["permissionDecision"] == "deny"
+        assert emitted["permissionDecision"] != "ask"
+        assert "canary blocked" in emitted["permissionDecisionReason"]
+
+    @pytest.mark.security
+    async def test_ask_uses_approval_backend_never_emits_sdk_ask(self):
+        spy = SpyApprovalBackend()
+        sink = NullAuditSink()
+        guard = Edictum.from_yaml_string(
+            _ASK_RULES,
+            backend=MemoryBackend(),
+            audit_sink=sink,
+            approval_backend=spy,
+        )
+        adapter = ClaudeAgentSDKAdapter(guard)
+        result = await _sdk_pre(adapter)(
+            _pre_input(tool_input={"payload": "ping"}),
+            "tu-1",
+            {"signal": None},
+        )
+        assert spy.requests, "ask must go through Edictum ApprovalBackend"
+        emitted = result.get("hookSpecificOutput") or {}
+        assert emitted.get("permissionDecision") != "ask"
+        assert emitted.get("permissionDecision") == "deny"
+
+    @pytest.mark.security
+    async def test_pretooluse_rejects_input_replacement(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        pre = _sdk_pre(adapter)
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
+        assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "BLOCKED" in second["hookSpecificOutput"]["permissionDecisionReason"]
+
+    @pytest.mark.security
+    async def test_pretooluse_rejects_mutation_during_pre(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        tool_input = {"payload": "ping"}
+        original = adapter._pipeline.pre_execute
+
+        async def mutate_then_pre(envelope, session):
+            tool_input["payload"] = "pwn"
+            return await original(envelope, session)
+
+        adapter._pipeline.pre_execute = mutate_then_pre
+        result = await _sdk_pre(adapter)(
+            _pre_input(tool_input=tool_input),
+            "tu-1",
+            {"signal": None},
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "BLOCKED" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+    @pytest.mark.security
+    async def test_malformed_tool_input_blocks(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        result = await _sdk_pre(adapter)(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "canary",
+                "tool_input": ["not", "a", "dict"],
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    @pytest.mark.security
+    async def test_wrap_can_use_tool_blocks_replacement(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+
+        async def allow_cb(tool_name, tool_input, context):
+            return {"behavior": "allow"}
+
+        wrapped = adapter.wrap_can_use_tool(allow_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "pwn"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        assert "BLOCKED" in result.message
+
+    @pytest.mark.security
+    async def test_wrap_can_use_tool_strips_updated_input(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+
+        async def rewrite_cb(tool_name, tool_input, context):
+            return {"behavior": "allow", "updated_input": {"payload": "pwn"}}
+
+        wrapped = adapter.wrap_can_use_tool(rewrite_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        assert "BLOCKED" in result.message
+
+    @pytest.mark.security
+    async def test_enforce_exception_fails_closed(self):
+        from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON
+
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+
+        async def explode(*args, **kwargs):
+            raise RuntimeError("backend outage")
+
+        adapter._pre_tool_use = explode
+        result = await _sdk_pre(adapter)(_pre_input(), "tu-1", {"signal": None})
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+        assert events
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].policy_error is True
+        assert adapter._internal_exception_count == 1
+
+    @pytest.mark.security
+    async def test_observe_exception_allows_loudly(self):
+        from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON
+
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(mode="observe", audit_sink=sink))
+
+        async def explode(*args, **kwargs):
+            raise RuntimeError("backend outage")
+
+        adapter._pre_tool_use = explode
+        result = await _sdk_pre(adapter)(_pre_input(), "tu-1", {"signal": None})
+        assert result == {}
+        events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+        assert events
+        assert events[0].action == AuditAction.CALL_WOULD_DENY
+        assert events[0].decision_source == "adapter"
+        assert events[0].policy_error is True
+        assert adapter._internal_exception_count == 1

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -9,6 +9,7 @@ import pytest
 
 from edictum import Decision, Edictum, Principal, postcondition, precondition
 from edictum.adapters.claude_agent_sdk import (
+    _INPUT_COMPARE_REASON,
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
     _INVALID_TOOL_NAME_REASON,
@@ -856,6 +857,77 @@ class TestClaudeSdkHostHooks:
         assert "tu-2" not in adapter._pending_decisions
         span1.end.assert_called_once()
         span2.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_no_id_mismatch_expires_same_name_pending(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "allow"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped("canary", {"payload": "other"}, type("Ctx", (), {})())
+        assert result.behavior == "deny"
+        assert result.message == _INPUT_REPLACEMENT_REASON
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_unknown_id_mismatch_expires_same_name_pending(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "allow"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "other"},
+            type("Ctx", (), {"tool_use_id": "unknown-id"})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == _INPUT_REPLACEMENT_REASON
+        assert "tu-1" not in adapter._pending
+        assert "unknown-id" not in adapter._pending
+        span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_no_id_compare_failure_expires_same_name_pending(self):
+        from edictum.adapters import claude_agent_sdk as cas
+
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "allow"}
+
+        def boom(*_args, **_kwargs):
+            raise TypeError("compare exploded")
+
+        original = cas._governed_input_equals
+        cas._governed_input_equals = boom
+        try:
+            wrapped = adapter.wrap_can_use_tool(deny_cb)
+            result = await wrapped("canary", {"payload": "ping"}, type("Ctx", (), {})())
+        finally:
+            cas._governed_input_equals = original
+        assert result.behavior == "deny"
+        assert result.message == _INPUT_COMPARE_REASON
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
 
     @pytest.mark.security
     async def test_wrap_deny_rejects_control_characters_in_message(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1139,9 +1139,7 @@ class TestClaudeSdkHostHooks:
             {"signal": None},
         )
         assert result == {}
-        executed = [
-            e for e in configured.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
-        ]
+        executed = [e for e in configured.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
         assert executed, (
             f"configured sink missed execution after reject; got {[(e.action, e.reason) for e in configured.events]}"
         )

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1563,6 +1563,148 @@ class TestClaudeSdkHostHooks:
         )
 
     @pytest.mark.security
+    async def test_early_post_hook_recovery_records_execution(self):
+        def boom_check(tool_name, tool_response):
+            raise RuntimeError("success_check failed")
+
+        adapter = ClaudeAgentSDKAdapter(make_guard(success_check=boom_check))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        before = await adapter._session.execution_count()
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        after = await adapter._session.execution_count()
+        assert after == before + 1, f"early recovery skipped record_execution; {before} -> {after}"
+
+    @pytest.mark.security
+    async def test_workflow_execution_fallback_does_not_replay_local(self):
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from edictum.workflow.result import WorkflowState
+
+        class _FailExecOnce:
+            def __init__(self):
+                self.events = []
+                self.calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("downstream rejected workflow execution")
+                self.events.append(event)
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1", "stage_id": "s0", "to_stage_id": "s1"},
+                    }
+                ]
+
+            async def state(self, session):
+                state = WorkflowState(session_id=session.session_id, active_stage="s1")
+                state.ensure_defaults()
+                return state
+
+        configured = _FailExecOnce()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        local_executed = [
+            e for e in guard.local_sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert len(local_executed) == 1, (
+            f"workflow execution fallback replayed local; got {[(e.action, e.reason) for e in guard.local_sink.events]}"
+        )
+
+    @pytest.mark.security
+    async def test_workflow_events_stashed_when_state_lookup_raises(self):
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1", "stage_id": "s0", "to_stage_id": "s1"},
+                    }
+                ]
+
+            async def state(self, session):
+                raise RuntimeError("workflow state lookup failed")
+
+        sink = NullAuditSink()
+        guard = make_guard(audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        workflow_events = [
+            e for e in sink.events if e.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+        ]
+        assert workflow_events, (
+            "stashed workflow transition missing after state() raise; "
+            f"got {[(e.action, e.reason) for e in sink.events]}"
+        )
+        assert adapter._pending_workflow_events == {}
+
+    @pytest.mark.security
+    async def test_to_hook_callables_clears_recovery_after_complete(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        hooks = adapter.to_hook_callables()
+        await hooks["pre_tool_use"]("canary", {"payload": "ping"}, "tu-1")
+        assert "tu-1" in adapter._hook_recovery
+        await hooks["post_tool_use"](tool_use_id="tu-1", tool_response="ok")
+        assert adapter._hook_recovery == {}, f"raw hook recovery leaked: {adapter._hook_recovery}"
+
+    @pytest.mark.security
     async def test_multiple_workflow_transitions_are_not_collapsed(self):
         from dataclasses import replace
         from types import SimpleNamespace

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -823,8 +823,8 @@ class TestClaudeSdkHostHooks:
         span.end.assert_called_once()
 
     @pytest.mark.security
-    async def test_wrap_no_id_does_not_clear_wrong_of_two_identical_pending(self):
-        """Ambiguous no-ID name+input match must not pick or clear the first pending."""
+    async def test_wrap_no_id_expires_all_ambiguous_identical_pending(self):
+        """Ambiguous no-ID name+input match must not pick one call; expire every candidate."""
         adapter = ClaudeAgentSDKAdapter(make_guard())
         await _sdk_pre(adapter)(
             _pre_input(tool_input={"payload": "ping"}, tool_use_id="tu-1"),
@@ -849,12 +849,12 @@ class TestClaudeSdkHostHooks:
         wrapped = adapter.wrap_can_use_tool(deny_cb)
         result = await wrapped("canary", {"payload": "ping"}, type("Ctx", (), {})())
         assert result.behavior == "deny"
-        assert "tu-1" in adapter._pending
-        assert "tu-2" in adapter._pending
-        assert "tu-1" in adapter._pending_decisions
-        assert "tu-2" in adapter._pending_decisions
-        span1.end.assert_not_called()
-        span2.end.assert_not_called()
+        assert "tu-1" not in adapter._pending
+        assert "tu-2" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        assert "tu-2" not in adapter._pending_decisions
+        span1.end.assert_called_once()
+        span2.end.assert_called_once()
 
     @pytest.mark.security
     async def test_wrap_deny_rejects_control_characters_in_message(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -511,6 +512,23 @@ class TestClaudeSdkHostHooks:
         span.end.assert_called_once()
 
     @pytest.mark.security
+    async def test_replacement_emits_adapter_audit(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        pre = _sdk_pre(adapter)
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        assert any(e.action == AuditAction.CALL_ALLOWED for e in sink.events)
+        second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
+        assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+        events = [e for e in sink.events if e.reason == _INPUT_REPLACEMENT_REASON]
+        assert events, f"replacement block missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _INPUT_REPLACEMENT_REASON
+        assert events[0].tool_name == "canary"
+
+    @pytest.mark.security
     async def test_pretooluse_rejects_mutation_during_pre(self):
         adapter = ClaudeAgentSDKAdapter(make_guard())
         tool_input = {"payload": "ping"}
@@ -639,3 +657,51 @@ class TestClaudeSdkHostHooks:
         assert events[0].decision_source == "adapter"
         assert events[0].policy_error is True
         assert adapter._internal_exception_count == 1
+
+    @pytest.mark.security
+    async def test_observe_recovery_isolated_per_tool_call(self):
+        """Overlapping observe PreToolUse must not stash the other call's envelope."""
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(mode="observe", audit_sink=sink))
+        pre = _sdk_pre(adapter)
+        original = adapter._pipeline.pre_execute
+        a_started = asyncio.Event()
+        release_a = asyncio.Event()
+
+        async def staggered(envelope, session):
+            if envelope.tool_use_id == "tu-a":
+                a_started.set()
+                await release_a.wait()
+                raise RuntimeError("a failed after b progressed")
+            return await original(envelope, session)
+
+        adapter._pipeline.pre_execute = staggered
+
+        async def run_a():
+            return await pre(
+                _pre_input(tool_name="tool_a", tool_input={"x": 1}, tool_use_id="tu-a"),
+                "tu-a",
+                {"signal": None},
+            )
+
+        async def run_b():
+            await a_started.wait()
+            result = await pre(
+                _pre_input(tool_name="tool_b", tool_input={"y": 2}, tool_use_id="tu-b"),
+                "tu-b",
+                {"signal": None},
+            )
+            release_a.set()
+            return result
+
+        result_a, result_b = await asyncio.gather(run_a(), run_b())
+        assert result_a == {}
+        assert result_b == {}
+        assert "tu-a" in adapter._pending
+        assert "tu-b" in adapter._pending
+        envelope_a, _span_a = adapter._pending["tu-a"]
+        envelope_b, _span_b = adapter._pending["tu-b"]
+        assert envelope_a.tool_name == "tool_a"
+        assert envelope_a.args == {"x": 1}
+        assert envelope_b.tool_name == "tool_b"
+        assert envelope_b.args == {"y": 2}

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -11,9 +11,12 @@ from edictum import Decision, Edictum, Principal, postcondition, precondition
 from edictum.adapters.claude_agent_sdk import (
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
+    _INVALID_TOOL_NAME_REASON,
     _MISSING_TOOL_USE_ID_REASON,
     _NO_GOVERNED_SNAPSHOT_REASON,
     _PERMISSION_BOUNDARY_REASON,
+    ADAPTER_INTERNAL_EXCEPTION_REASON,
+    ADAPTER_POST_HOOK_EXCEPTION_REASON,
     ClaudeAgentSDKAdapter,
 )
 from edictum.audit import AuditAction
@@ -548,9 +551,9 @@ class TestClaudeSdkHostHooks:
         assert allowed_event.call_id
         second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
         assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
-        denied = [e for e in sink.events if e.reason == _INPUT_REPLACEMENT_REASON]
-        assert denied
-        event = denied[0]
+        blocked = [e for e in sink.events if e.reason == _INPUT_REPLACEMENT_REASON]
+        assert blocked
+        event = blocked[0]
         assert event.action == AuditAction.CALL_DENIED
         assert event.run_id == allowed_event.run_id
         assert event.call_id == allowed_event.call_id
@@ -970,3 +973,91 @@ class TestClaudeSdkHostHooks:
         assert envelope_a.args == {"x": 1}
         assert envelope_b.tool_name == "tool_b"
         assert envelope_b.args == {"y": 2}
+
+    @pytest.mark.security
+    @pytest.mark.parametrize("tool_name", ["", "bad/name", "bad\\name", "bad\x00name"])
+    async def test_invalid_tool_name_blocks_in_observe(self, tool_name):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(mode="observe", audit_sink=sink))
+        result = await _sdk_pre(adapter)(
+            _pre_input(tool_name=tool_name, tool_input={"payload": "ping"}),
+            "tu-1",
+            {"signal": None},
+        )
+        assert result != {}
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert result["hookSpecificOutput"]["permissionDecisionReason"] == _INVALID_TOOL_NAME_REASON
+        events = [e for e in sink.events if e.reason == _INVALID_TOOL_NAME_REASON]
+        assert events, f"invalid tool_name missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _INVALID_TOOL_NAME_REASON
+        assert not any(e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON for e in sink.events)
+        assert adapter._internal_exception_count == 0
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+
+    @pytest.mark.security
+    async def test_post_hook_exception_still_audits_execution(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("session down")
+
+        adapter._session.record_execution = boom
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        fallback = [e for e in sink.events if e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON]
+        assert fallback, f"post-hook exception missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert fallback[0].action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        assert fallback[0].decision_source == "adapter"
+        assert fallback[0].decision_name == ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert fallback[0].policy_error is True
+        assert fallback[0].tool_name == "canary"
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+
+    @pytest.mark.security
+    async def test_post_failure_hook_exception_still_audits(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        fail = hooks["PostToolUseFailure"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("session down")
+
+        adapter._session.record_execution = boom
+        result = await fail(
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "error": "host failed",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        fallback = [e for e in sink.events if e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON]
+        assert fallback, f"post-failure exception missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert fallback[0].action == AuditAction.CALL_FAILED
+        assert fallback[0].decision_source == "adapter"
+        assert fallback[0].policy_error is True
+        assert fallback[0].tool_success is False

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -857,6 +857,29 @@ class TestClaudeSdkHostHooks:
         span2.end.assert_not_called()
 
     @pytest.mark.security
+    async def test_wrap_deny_rejects_control_characters_in_message(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "deny", "message": "nope\x00\ninjected"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == _PERMISSION_BOUNDARY_REASON
+        assert "\x00" not in result.message
+        assert "\n" not in result.message
+        reasons = [e.reason or "" for e in sink.events]
+        assert all("\x00" not in r and "\n" not in r for r in reasons), f"control chars leaked into audit: {reasons}"
+        assert any(e.reason == _PERMISSION_BOUNDARY_REASON for e in sink.events)
+
+    @pytest.mark.security
     async def test_malformed_redispatch_clears_pending(self):
         sink = NullAuditSink()
         adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
@@ -1446,6 +1469,98 @@ class TestClaudeSdkHostHooks:
         )
         leftover = [key for keys in adapter._sink_ack.values() for key in keys if key[0]]
         assert leftover == [], f"sink acks leaked after completion: {leftover}"
+
+    @pytest.mark.security
+    async def test_pre_hook_block_clears_workflow_sink_acks(self):
+        from edictum.pipeline import PreDecision
+
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+
+        async def fake_pre(envelope, session):
+            return PreDecision(
+                action="block",
+                reason="session limit exceeded",
+                decision_source="limits",
+                decision_name="max_calls",
+                workflow_events=[
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {
+                            "name": "demo",
+                            "active_stage": "s1",
+                            "stage_id": "s0",
+                            "to_stage_id": "s1",
+                        },
+                    }
+                ],
+            )
+
+        adapter._pipeline.pre_execute = fake_pre
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        result = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        leftover = [key for keys in adapter._sink_ack.values() for key in keys]
+        assert leftover == [], f"pre-hook block leaked sink acks: {leftover}"
+
+    @pytest.mark.security
+    async def test_fallback_failure_clears_recovery_state(self):
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from edictum.workflow.result import WorkflowState
+
+        class _AlwaysRejectExec:
+            def __init__(self):
+                self.events = []
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    raise RuntimeError("sustained sink outage")
+                self.events.append(event)
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1", "stage_id": "s0", "to_stage_id": "s1"},
+                    }
+                ]
+
+            async def state(self, session):
+                state = WorkflowState(session_id=session.session_id, active_stage="s1")
+                state.ensure_defaults()
+                return state
+
+        configured = _AlwaysRejectExec()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        leftover = [key for keys in adapter._sink_ack.values() for key in keys]
+        assert leftover == [], f"fallback failure leaked sink acks: {leftover}"
+        assert adapter._pending_workflow_events == {}, (
+            f"fallback failure leaked pending workflow events: {adapter._pending_workflow_events}"
+        )
 
     @pytest.mark.security
     async def test_multiple_workflow_transitions_are_not_collapsed(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1729,6 +1729,73 @@ class TestClaudeSdkHostHooks:
         assert leftover == [], f"raw post failure leaked sink acks: {leftover}"
 
     @pytest.mark.security
+    async def test_recovery_does_not_replay_partial_record_execution(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        real_record = adapter._session.record_execution
+        calls = {"n": 0}
+
+        async def partial(*args, **kwargs):
+            calls["n"] += 1
+            await real_record(*args, **kwargs)
+            if calls["n"] == 1:
+                raise RuntimeError("backend dropped after execs")
+
+        adapter._session.record_execution = partial
+        before = await adapter._session.execution_count()
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        after = await adapter._session.execution_count()
+        assert calls["n"] == 1, f"recovery replayed record_execution; calls={calls['n']}"
+        assert after == before + 1, f"execs double-counted; {before} -> {after}"
+
+    @pytest.mark.security
+    async def test_pre_hook_exception_clears_workflow_sink_acks(self):
+        from edictum.pipeline import PreDecision
+
+        class _FailWorkflow:
+            def __init__(self):
+                self.events = []
+
+            async def emit(self, event):
+                if event.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED):
+                    raise RuntimeError("workflow sink down")
+                self.events.append(event)
+
+        configured = _FailWorkflow()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=configured))
+
+        async def fake_pre(envelope, session):
+            return PreDecision(
+                action="allow",
+                workflow_events=[
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1", "stage_id": "s0", "to_stage_id": "s1"},
+                    }
+                ],
+            )
+
+        adapter._pipeline.pre_execute = fake_pre
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        result = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        leftover = [key for keys in adapter._sink_ack.values() for key in keys]
+        assert leftover == [], f"pre-hook exception leaked sink acks: {leftover}"
+
+    @pytest.mark.security
     async def test_multiple_workflow_transitions_are_not_collapsed(self):
         from dataclasses import replace
         from types import SimpleNamespace

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -21,6 +21,7 @@ from edictum.adapters.claude_agent_sdk import (
 )
 from edictum.audit import AuditAction, CompositeSink
 from edictum.findings import Finding
+from edictum.limits import OperationLimits
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
@@ -1033,7 +1034,7 @@ class TestClaudeSdkHostHooks:
         async def boom(*_args, **_kwargs):
             raise RuntimeError("session down")
 
-        adapter._session.record_execution = boom
+        adapter._record_session_execution = boom
         result = await post(
             {
                 "hook_event_name": "PostToolUse",
@@ -1110,7 +1111,7 @@ class TestClaudeSdkHostHooks:
         async def boom(*_args, **_kwargs):
             raise RuntimeError("session down")
 
-        adapter._session.record_execution = boom
+        adapter._record_session_execution = boom
         result = await post(
             {
                 "hook_event_name": "PostToolUse",
@@ -1730,21 +1731,26 @@ class TestClaudeSdkHostHooks:
 
     @pytest.mark.security
     async def test_recovery_does_not_replay_partial_record_execution(self):
-        adapter = ClaudeAgentSDKAdapter(make_guard())
+        class _FailAfterExecs(MemoryBackend):
+            def __init__(self):
+                super().__init__()
+                self.execs_increments = 0
+                self.fail_tool = True
+
+            async def increment(self, key: str, amount: float = 1) -> float:
+                if key.endswith(":execs"):
+                    self.execs_increments += 1
+                if self.fail_tool and ":tool:" in key:
+                    self.fail_tool = False
+                    raise RuntimeError("backend dropped after execs")
+                return await super().increment(key, amount)
+
+        backend = _FailAfterExecs()
+        adapter = ClaudeAgentSDKAdapter(make_guard(backend=backend))
         hooks = adapter.to_sdk_hooks()
         pre = hooks["PreToolUse"][0].hooks[0]
         post = hooks["PostToolUse"][0].hooks[0]
         await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
-        real_record = adapter._session.record_execution
-        calls = {"n": 0}
-
-        async def partial(*args, **kwargs):
-            calls["n"] += 1
-            await real_record(*args, **kwargs)
-            if calls["n"] == 1:
-                raise RuntimeError("backend dropped after execs")
-
-        adapter._session.record_execution = partial
         before = await adapter._session.execution_count()
         result = await post(
             {
@@ -1757,8 +1763,51 @@ class TestClaudeSdkHostHooks:
         )
         assert result == {}
         after = await adapter._session.execution_count()
-        assert calls["n"] == 1, f"recovery replayed record_execution; calls={calls['n']}"
+        assert backend.execs_increments == 1, f"execs replayed; increments={backend.execs_increments}"
         assert after == before + 1, f"execs double-counted; {before} -> {after}"
+
+    @pytest.mark.security
+    async def test_recovery_finishes_remaining_execution_counters(self):
+        class _FailAfterExecs(MemoryBackend):
+            def __init__(self):
+                super().__init__()
+                self.execs_increments = 0
+                self.fail_tool = True
+
+            async def increment(self, key: str, amount: float = 1) -> float:
+                if key.endswith(":execs"):
+                    self.execs_increments += 1
+                if self.fail_tool and ":tool:" in key:
+                    self.fail_tool = False
+                    raise RuntimeError("backend dropped after execs")
+                return await super().increment(key, amount)
+
+        backend = _FailAfterExecs()
+        limits = OperationLimits(max_tool_calls=1, max_calls_per_tool={"canary": 1})
+        adapter = ClaudeAgentSDKAdapter(make_guard(backend=backend, limits=limits))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        assert backend.execs_increments == 1, f"execs replayed; increments={backend.execs_increments}"
+        assert await adapter._session.execution_count() == 1
+        assert await adapter._session.tool_execution_count("canary") == 1
+        assert await adapter._session.consecutive_failures() == 0
+        second = await pre(_pre_input(tool_input={"payload": "ping"}, tool_use_id="tu-2"), "tu-2", {"signal": None})
+        assert second.get("hookSpecificOutput", {}).get("permissionDecision") == "deny", (
+            f"stale counters failed open; got {second}"
+        )
 
     @pytest.mark.security
     async def test_pre_hook_exception_clears_workflow_sink_acks(self):
@@ -1957,7 +2006,7 @@ class TestClaudeSdkHostHooks:
         async def boom(*_args, **_kwargs):
             raise RuntimeError("session down")
 
-        adapter._session.record_execution = boom
+        adapter._record_session_execution = boom
         result = await fail(
             {
                 "hook_event_name": "PostToolUseFailure",

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -931,6 +931,36 @@ class TestClaudeSdkHostHooks:
         assert adapter._internal_exception_count == 1
 
     @pytest.mark.security
+    async def test_allow_audit_failure_emits_correlated_block(self):
+        class _FailAllow:
+            def __init__(self):
+                self.events = []
+
+            async def emit(self, event):
+                if event.action == AuditAction.CALL_ALLOWED:
+                    raise RuntimeError("allow sink down")
+                self.events.append(event)
+
+        configured = _FailAllow()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        result = await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        allowed = [e for e in guard.local_sink.events if e.action == AuditAction.CALL_ALLOWED]
+        denied = [
+            e
+            for e in guard.local_sink.events
+            if e.action == AuditAction.CALL_DENIED and e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON
+        ]
+        assert allowed, f"missing CALL_ALLOWED; got {[(e.action, e.reason) for e in guard.local_sink.events]}"
+        assert denied, f"missing correlated CALL_DENIED; got {[(e.action, e.reason) for e in guard.local_sink.events]}"
+        assert allowed[0].call_id
+        assert denied[0].call_id == allowed[0].call_id
+        assert denied[0].decision_source == "adapter"
+        assert denied[0].policy_error is True
+        assert adapter._pending == {}
+
+    @pytest.mark.security
     async def test_observe_exception_allows_loudly(self):
         from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON
 

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1273,6 +1273,162 @@ class TestClaudeSdkHostHooks:
         assert adapter._pending_decisions == {}
 
     @pytest.mark.security
+    async def test_fallback_does_not_replay_sinks_without_event_buffers(self):
+        """File-like sinks have no events list; explicit acks must still skip replay."""
+
+        class _FileLike:
+            def __init__(self):
+                self.writes = []
+
+            async def emit(self, event):
+                self.writes.append(event)
+
+        class _FailSecond:
+            def __init__(self):
+                self.events = []
+                self.calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("downstream rejected")
+                self.events.append(event)
+
+        file_like = _FileLike()
+        failing = _FailSecond()
+        guard = make_guard(audit_sink=[file_like, failing])
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        file_executed = [
+            e for e in file_like.writes if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert len(file_executed) == 1, (
+            f"file-like sink replayed; got {[(e.action, e.reason) for e in file_like.writes]}"
+        )
+        assert failing.calls >= 2
+        assert any(e.action == AuditAction.CALL_EXECUTED for e in failing.events)
+
+    @pytest.mark.security
+    async def test_workflow_fallback_retries_sink_that_rejected_transition(self):
+        """Local acceptance of a workflow event must not skip retrying the rejecting sink."""
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from edictum.workflow.result import WorkflowState
+
+        class _FailWorkflowOnce:
+            def __init__(self):
+                self.events = []
+                self.wf_calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED):
+                    self.wf_calls += 1
+                    if self.wf_calls == 1:
+                        raise RuntimeError("workflow sink rejected")
+                self.events.append(event)
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1"},
+                    }
+                ]
+
+            async def state(self, session):
+                state = WorkflowState(session_id=session.session_id, active_stage="s1")
+                state.ensure_defaults()
+                return state
+
+        configured = _FailWorkflowOnce()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        configured_wf = [
+            e
+            for e in configured.events
+            if e.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+        ]
+        assert configured_wf, (
+            f"configured sink missed workflow retry; got {[(e.action, e.reason) for e in configured.events]}"
+        )
+        local_wf = [
+            e
+            for e in guard.local_sink.events
+            if e.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+        ]
+        assert len(local_wf) == 1
+
+    @pytest.mark.security
+    async def test_to_sdk_hooks_binds_warning_callback_per_set(self):
+        @postcondition("*")
+        def ssn_check(tool_call, result):
+            if "123-45-6789" in str(result):
+                return Decision.fail("SSN leaked")
+            return Decision.ok()
+
+        seen: list[str] = []
+
+        def cb_a(result, violations):
+            seen.append("a")
+
+        def cb_b(result, violations):
+            seen.append("b")
+
+        adapter = ClaudeAgentSDKAdapter(make_guard(rules=[ssn_check]))
+        first_hooks = adapter.to_sdk_hooks(on_postcondition_warn=cb_a)
+        adapter.to_sdk_hooks(on_postcondition_warn=cb_b)
+        pre = first_hooks["PreToolUse"][0].hooks[0]
+        post = first_hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "Patient SSN: 123-45-6789",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert seen == ["a"], f"first hook set must keep its callback; got {seen}"
+
+    @pytest.mark.security
     async def test_post_failure_hook_exception_still_audits(self):
         sink = NullAuditSink()
         adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -19,7 +19,7 @@ from edictum.adapters.claude_agent_sdk import (
     ADAPTER_POST_HOOK_EXCEPTION_REASON,
     ClaudeAgentSDKAdapter,
 )
-from edictum.audit import AuditAction
+from edictum.audit import AuditAction, CompositeSink
 from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
@@ -1458,19 +1458,22 @@ class TestClaudeSdkHostHooks:
             definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
 
             async def record_result(self, session, stage_id, envelope):
+                # hydrate_workflow_events copies the final snapshot onto every
+                # event; only stage_id / to_stage_id distinguish transitions.
+                snapshot = {"name": "demo", "active_stage": "s3", "completed_stages": ["s1", "s2"]}
                 return [
                     {
                         "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
-                        "workflow": {"name": "demo", "active_stage": "s1", "completed_stages": []},
+                        "workflow": {**snapshot, "stage_id": "s1", "to_stage_id": "s2"},
                     },
                     {
                         "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
-                        "workflow": {"name": "demo", "active_stage": "s2", "completed_stages": ["s1"]},
+                        "workflow": {**snapshot, "stage_id": "s2", "to_stage_id": "s3"},
                     },
                 ]
 
             async def state(self, session):
-                state = WorkflowState(session_id=session.session_id, active_stage="s2", completed_stages=["s1"])
+                state = WorkflowState(session_id=session.session_id, active_stage="s3", completed_stages=["s1", "s2"])
                 state.ensure_defaults()
                 return state
 
@@ -1493,12 +1496,68 @@ class TestClaudeSdkHostHooks:
             "tu-1",
             {"signal": None},
         )
-        stages = [
-            (e.workflow or {}).get("active_stage")
+        transitions = [
+            ((e.workflow or {}).get("stage_id"), (e.workflow or {}).get("to_stage_id"))
             for e in sink.events
             if e.action == AuditAction.WORKFLOW_STAGE_ADVANCED
         ]
-        assert stages == ["s1", "s2"], f"collapsed workflow transitions; got {stages}"
+        assert transitions == [("s1", "s2"), ("s2", "s3")], f"collapsed workflow transitions; got {transitions}"
+
+    @pytest.mark.security
+    async def test_nested_composite_partial_failure_does_not_double_count_leaves(self):
+        """Guard wraps a caller CompositeSink; fallback must skip already-acked leaves."""
+
+        class _AcceptLeaf:
+            def __init__(self):
+                self.events = []
+
+            async def emit(self, event):
+                self.events.append(event)
+
+        class _FailOnceLeaf:
+            def __init__(self):
+                self.events = []
+                self.calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("nested child rejected")
+                self.events.append(event)
+
+        accepting = _AcceptLeaf()
+        failing = _FailOnceLeaf()
+        guard = make_guard(audit_sink=CompositeSink([accepting, failing]))
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        local_executed = [
+            e for e in guard.local_sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert len(local_executed) == 1, (
+            f"local sink double-counted; got {[(e.action, e.reason) for e in guard.local_sink.events]}"
+        )
+        accepted = [e for e in accepting.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert len(accepted) == 1, (
+            f"nested accepting leaf replayed; got {[(e.action, e.reason) for e in accepting.events]}"
+        )
+        failed = [e for e in failing.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert failed, f"failing leaf missed fallback; got {[(e.action, e.reason) for e in failing.events]}"
+        assert failing.calls >= 2
 
     @pytest.mark.security
     async def test_post_failure_hook_exception_still_audits(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -11,6 +11,7 @@ from edictum import Decision, Edictum, postcondition, precondition
 from edictum.adapters.claude_agent_sdk import (
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
+    _PERMISSION_BOUNDARY_REASON,
     ClaudeAgentSDKAdapter,
 )
 from edictum.audit import AuditAction
@@ -617,6 +618,90 @@ class TestClaudeSdkHostHooks:
         )
         assert result.behavior == "deny"
         assert "BLOCKED" in result.message
+
+    @pytest.mark.security
+    async def test_wrap_mutation_emits_adapter_audit(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert any(e.action == AuditAction.CALL_ALLOWED for e in sink.events)
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def rewrite_cb(tool_name, tool_input, context):
+            return {"behavior": "allow", "updated_input": {"payload": "pwn"}}
+
+        wrapped = adapter.wrap_can_use_tool(rewrite_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        events = [e for e in sink.events if e.reason == _PERMISSION_BOUNDARY_REASON]
+        assert events, f"wrap mutation missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _PERMISSION_BOUNDARY_REASON
+        assert any(e.action == AuditAction.CALL_DENIED for e in sink.events)
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_deny_clears_pending_and_ends_span(self):
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert "tu-1" in adapter._pending
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "deny", "message": "nope"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == "nope"
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_malformed_redispatch_clears_pending(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        pre = _sdk_pre(adapter)
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        assert "tu-1" in adapter._pending
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+        second = await pre(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "canary",
+                "tool_input": ["not", "a", "dict"],
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert second["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        span.end.assert_called_once()
+        events = [e for e in sink.events if e.reason == _INVALID_TOOL_INPUT_REASON]
+        assert events, f"malformed redispatch missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
 
     @pytest.mark.security
     async def test_enforce_exception_fails_closed(self):

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1796,6 +1796,43 @@ class TestClaudeSdkHostHooks:
         assert leftover == [], f"pre-hook exception leaked sink acks: {leftover}"
 
     @pytest.mark.security
+    async def test_custom_sink_with_sinks_attr_is_not_flattened(self):
+        class _Child:
+            def __init__(self):
+                self.events = []
+
+            async def emit(self, event):
+                self.events.append(event)
+
+        class _Wrapper:
+            def __init__(self, child):
+                self.sinks = [child]
+                self.events = []
+
+            async def emit(self, event):
+                self.events.append(event)
+                await child.emit(event)
+
+        child = _Child()
+        wrapper = _Wrapper(child)
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=wrapper))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        wrapped_exec = [e for e in wrapper.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert wrapped_exec, f"custom wrapper emit skipped; got {[(e.action, e.reason) for e in wrapper.events]}"
+
+    @pytest.mark.security
     async def test_multiple_workflow_transitions_are_not_collapsed(self):
         from dataclasses import replace
         from types import SimpleNamespace

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -19,7 +19,7 @@ from edictum.adapters.claude_agent_sdk import (
     ADAPTER_POST_HOOK_EXCEPTION_REASON,
     ClaudeAgentSDKAdapter,
 )
-from edictum.audit import AuditAction
+from edictum.audit import AuditAction, CompositeSink
 from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
@@ -1064,6 +1064,88 @@ class TestClaudeSdkHostHooks:
         assert executed[0].action == AuditAction.CALL_EXECUTED
         assert executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
         assert not any(e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON for e in sink.events)
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+
+    @pytest.mark.security
+    async def test_post_hook_exception_reuses_cached_tool_success(self):
+        """Recovery must reuse the primary success_check result, not rerun it."""
+        calls: list[object] = []
+
+        def stateful_success_check(tool_name: str, tool_response: object) -> bool:
+            calls.append((tool_name, tool_response))
+            return len(calls) == 1
+
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink, success_check=stateful_success_check))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("session down")
+
+        adapter._session.record_execution = boom
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        assert len(calls) == 1
+        fallback = [e for e in sink.events if e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON]
+        assert fallback, f"post-hook exception missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert fallback[0].action == AuditAction.CALL_EXECUTED
+        assert fallback[0].tool_success is True
+        executed = [e for e in sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert len(executed) == 1
+
+    @pytest.mark.security
+    async def test_partial_execution_audit_delivery_does_not_replay(self):
+        """CompositeSink delivery-then-raise must not fallback-replay the execution event."""
+        healthy = NullAuditSink()
+
+        class _RaiseOnExecution:
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    raise RuntimeError("execution sink down")
+
+        composite = CompositeSink([healthy, _RaiseOnExecution()])
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=composite))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        executed = [e for e in healthy.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert len(executed) == 1, (
+            f"partial delivery replayed execution; got {[(e.action, e.reason) for e in healthy.events]}"
+        )
+        assert executed[0].action == AuditAction.CALL_EXECUTED
+        assert executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert not any(e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON for e in healthy.events)
+        local_executed = [
+            e
+            for e in adapter._guard._local_sink.events
+            if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert len(local_executed) == 1
         assert adapter._pending == {}
         assert adapter._pending_decisions == {}
 

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -19,7 +19,7 @@ from edictum.adapters.claude_agent_sdk import (
     ADAPTER_POST_HOOK_EXCEPTION_REASON,
     ClaudeAgentSDKAdapter,
 )
-from edictum.audit import AuditAction, CompositeSink
+from edictum.audit import AuditAction
 from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
@@ -1107,17 +1107,23 @@ class TestClaudeSdkHostHooks:
         assert len(executed) == 1
 
     @pytest.mark.security
-    async def test_partial_execution_audit_delivery_does_not_replay(self):
-        """CompositeSink delivery-then-raise must not fallback-replay the execution event."""
-        healthy = NullAuditSink()
+    async def test_execution_audit_fallback_when_sink_rejects_before_accept(self):
+        """A configured sink that rejects the primary execution emit must still receive fallback."""
 
-        class _RaiseOnExecution:
+        class _RejectFirstExecution:
+            def __init__(self):
+                self.calls = 0
+                self.events = []
+
             async def emit(self, event):
                 if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
-                    raise RuntimeError("execution sink down")
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("execution sink rejected before accept")
+                self.events.append(event)
 
-        composite = CompositeSink([healthy, _RaiseOnExecution()])
-        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=composite))
+        configured = _RejectFirstExecution()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=configured))
         hooks = adapter.to_sdk_hooks()
         pre = hooks["PreToolUse"][0].hooks[0]
         post = hooks["PostToolUse"][0].hooks[0]
@@ -1133,19 +1139,15 @@ class TestClaudeSdkHostHooks:
             {"signal": None},
         )
         assert result == {}
-        executed = [e for e in healthy.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
-        assert len(executed) == 1, (
-            f"partial delivery replayed execution; got {[(e.action, e.reason) for e in healthy.events]}"
-        )
-        assert executed[0].action == AuditAction.CALL_EXECUTED
-        assert executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
-        assert not any(e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON for e in healthy.events)
-        local_executed = [
-            e
-            for e in adapter._guard._local_sink.events
-            if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        executed = [
+            e for e in configured.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
         ]
-        assert len(local_executed) == 1
+        assert executed, (
+            f"configured sink missed execution after reject; got {[(e.action, e.reason) for e in configured.events]}"
+        )
+        assert configured.calls >= 2
+        assert executed[0].action == AuditAction.CALL_EXECUTED
+        assert executed[0].reason == ADAPTER_POST_HOOK_EXCEPTION_REASON
         assert adapter._pending == {}
         assert adapter._pending_decisions == {}
 

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1150,6 +1150,129 @@ class TestClaudeSdkHostHooks:
         assert adapter._pending_decisions == {}
 
     @pytest.mark.security
+    async def test_composite_partial_failure_does_not_double_count_local(self):
+        """Local sink already accepted primary execution; fallback must not replay it."""
+
+        class _FailDownstream:
+            def __init__(self):
+                self.events = []
+                self.calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("downstream rejected after local accept")
+                self.events.append(event)
+
+        configured = _FailDownstream()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        local_executed = [
+            e for e in guard.local_sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert len(local_executed) == 1, (
+            f"local sink double-counted execution; got {[(e.action, e.reason) for e in guard.local_sink.events]}"
+        )
+        configured_executed = [
+            e for e in configured.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)
+        ]
+        assert configured_executed, (
+            f"configured sink missed fallback; got {[(e.action, e.reason) for e in configured.events]}"
+        )
+        assert configured.calls >= 2
+        assert configured_executed[0].reason == ADAPTER_POST_HOOK_EXCEPTION_REASON
+
+    @pytest.mark.security
+    async def test_workflow_events_emitted_when_execution_audit_falls_back(self):
+        """record_result already advanced state; fallback must still emit workflow audits."""
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from edictum.workflow.result import WorkflowState
+
+        class _RejectFirstExecution:
+            def __init__(self):
+                self.events = []
+                self.calls = 0
+
+            async def emit(self, event):
+                if event.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise RuntimeError("execution sink rejected before accept")
+                self.events.append(event)
+
+        class _FakeRuntime:
+            definition = SimpleNamespace(metadata=SimpleNamespace(name="demo", version="1"))
+
+            async def record_result(self, session, stage_id, envelope):
+                return [
+                    {
+                        "action": AuditAction.WORKFLOW_STAGE_ADVANCED.value,
+                        "workflow": {"name": "demo", "active_stage": "s1"},
+                    }
+                ]
+
+            async def state(self, session):
+                state = WorkflowState(session_id=session.session_id, active_stage="s1")
+                state.ensure_defaults()
+                return state
+
+        configured = _RejectFirstExecution()
+        guard = make_guard(audit_sink=configured)
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        guard._workflow_runtime = _FakeRuntime()
+        decision = adapter._pending_decisions["tu-1"]
+        adapter._pending_decisions["tu-1"] = replace(decision, workflow_involved=True, workflow_stage_id="s1")
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        workflow_events = [
+            e
+            for e in configured.events
+            if e.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+        ]
+        assert workflow_events, (
+            f"workflow transition missing after fallback; got {[(e.action, e.reason) for e in configured.events]}"
+        )
+        local_workflow = [
+            e
+            for e in guard.local_sink.events
+            if e.action in (AuditAction.WORKFLOW_STAGE_ADVANCED, AuditAction.WORKFLOW_COMPLETED)
+        ]
+        assert len(local_workflow) == 1
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+
+    @pytest.mark.security
     async def test_post_failure_hook_exception_still_audits(self):
         sink = NullAuditSink()
         adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -674,6 +674,28 @@ class TestClaudeSdkHostHooks:
         span.end.assert_called_once()
 
     @pytest.mark.security
+    async def test_wrap_deny_clears_matched_pending_when_context_lacks_id(self):
+        """Name+input match must clear that pending key when tool_use_id is missing."""
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert "tu-1" in adapter._pending
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "deny", "message": "nope"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped("canary", {"payload": "ping"}, type("Ctx", (), {})())
+        assert result.behavior == "deny"
+        assert result.message == "nope"
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        assert "" not in adapter._pending
+        span.end.assert_called_once()
+
+    @pytest.mark.security
     async def test_malformed_redispatch_clears_pending(self):
         sink = NullAuditSink()
         adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -12,6 +12,7 @@ from edictum.adapters.claude_agent_sdk import (
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
     _MISSING_TOOL_USE_ID_REASON,
+    _NO_GOVERNED_SNAPSHOT_REASON,
     _PERMISSION_BOUNDARY_REASON,
     ClaudeAgentSDKAdapter,
 )
@@ -647,6 +648,33 @@ class TestClaudeSdkHostHooks:
         assert events[0].action == AuditAction.CALL_DENIED
         assert events[0].decision_source == "adapter"
         assert events[0].decision_name == _INVALID_TOOL_INPUT_REASON
+        assert events[0].tool_name == "canary"
+
+    @pytest.mark.security
+    async def test_wrap_no_pending_allow_denies_and_audits(self):
+        """Permission allow without a governed snapshot must deny and audit."""
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        called = {"n": 0}
+
+        async def allow_cb(tool_name, tool_input, context):
+            called["n"] += 1
+            return {"behavior": "allow"}
+
+        wrapped = adapter.wrap_can_use_tool(allow_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "tu-1"})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == _NO_GOVERNED_SNAPSHOT_REASON
+        assert called["n"] == 0
+        events = [e for e in sink.events if e.reason == _NO_GOVERNED_SNAPSHOT_REASON]
+        assert events, f"no-pending block missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _NO_GOVERNED_SNAPSHOT_REASON
         assert events[0].tool_name == "canary"
 
     @pytest.mark.security

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -11,6 +11,7 @@ from edictum import Decision, Edictum, Principal, postcondition, precondition
 from edictum.adapters.claude_agent_sdk import (
     _INPUT_REPLACEMENT_REASON,
     _INVALID_TOOL_INPUT_REASON,
+    _MISSING_TOOL_USE_ID_REASON,
     _PERMISSION_BOUNDARY_REASON,
     ClaudeAgentSDKAdapter,
 )
@@ -577,6 +578,41 @@ class TestClaudeSdkHostHooks:
         assert "BLOCKED" in result["hookSpecificOutput"]["permissionDecisionReason"]
 
     @pytest.mark.security
+    async def test_pretooluse_rejects_missing_tool_use_id(self):
+        """ID-less PreToolUse must deny and leave no unrecoverable pending entry."""
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        result = await _sdk_pre(adapter)(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "canary",
+                "tool_input": {"payload": "ping"},
+            },
+            None,
+            {"signal": None},
+        )
+        assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert result["hookSpecificOutput"]["permissionDecisionReason"] == _MISSING_TOOL_USE_ID_REASON
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+        events = [e for e in sink.events if e.reason == _MISSING_TOOL_USE_ID_REASON]
+        assert events, f"missing-id block missing audit; got {[(e.action, e.reason) for e in sink.events]}"
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"
+        assert events[0].decision_name == _MISSING_TOOL_USE_ID_REASON
+        assert events[0].tool_name == "canary"
+        post = adapter.to_sdk_hooks()["PostToolUse"][0].hooks[0]
+        post_result = await post(
+            {"hook_event_name": "PostToolUse", "tool_response": "ok"},
+            None,
+            {"signal": None},
+        )
+        assert post_result == {}
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
+        assert not any(e.action == AuditAction.CALL_EXECUTED for e in sink.events)
+
+    @pytest.mark.security
     async def test_malformed_tool_input_blocks(self):
         adapter = ClaudeAgentSDKAdapter(make_guard())
         result = await _sdk_pre(adapter)(
@@ -727,6 +763,32 @@ class TestClaudeSdkHostHooks:
         assert "tu-1" not in adapter._pending
         assert "tu-1" not in adapter._pending_decisions
         assert "" not in adapter._pending
+        span.end.assert_called_once()
+
+    @pytest.mark.security
+    async def test_wrap_deny_clears_matched_pending_when_context_id_unknown(self):
+        """Unknown nonempty tool_use_id must still clear the unique name+input match."""
+        adapter = ClaudeAgentSDKAdapter(make_guard())
+        await _sdk_pre(adapter)(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert "tu-1" in adapter._pending
+        envelope, _old = adapter._pending["tu-1"]
+        span = MagicMock()
+        adapter._pending["tu-1"] = (envelope, span)
+
+        async def deny_cb(tool_name, tool_input, context):
+            return {"behavior": "deny", "message": "nope"}
+
+        wrapped = adapter.wrap_can_use_tool(deny_cb)
+        result = await wrapped(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": "unknown-id"})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == "nope"
+        assert "tu-1" not in adapter._pending
+        assert "tu-1" not in adapter._pending_decisions
+        assert "unknown-id" not in adapter._pending
         span.end.assert_called_once()
 
     @pytest.mark.security

--- a/tests/test_adapter_claude.py
+++ b/tests/test_adapter_claude.py
@@ -1030,6 +1030,42 @@ class TestClaudeSdkHostHooks:
         assert fallback[0].tool_name == "canary"
         assert adapter._pending == {}
         assert adapter._pending_decisions == {}
+        executed = [e for e in sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert len(executed) == 1
+
+    @pytest.mark.security
+    async def test_late_post_hook_exception_does_not_double_count_execution(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(make_guard(audit_sink=sink))
+        hooks = adapter.to_sdk_hooks()
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+
+        async def boom(*_args, **_kwargs):
+            raise RuntimeError("workflow events down")
+
+        adapter._emit_workflow_events = boom
+        result = await post(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "ok",
+                "tool_use_id": "tu-1",
+            },
+            "tu-1",
+            {"signal": None},
+        )
+        assert result == {}
+        executed = [e for e in sink.events if e.action in (AuditAction.CALL_EXECUTED, AuditAction.CALL_FAILED)]
+        assert len(executed) == 1, (
+            f"late post-hook failure double-counted; got {[(e.action, e.reason) for e in sink.events]}"
+        )
+        assert executed[0].action == AuditAction.CALL_EXECUTED
+        assert executed[0].reason != ADAPTER_POST_HOOK_EXCEPTION_REASON
+        assert not any(e.reason == ADAPTER_POST_HOOK_EXCEPTION_REASON for e in sink.events)
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}
 
     @pytest.mark.security
     async def test_post_failure_hook_exception_still_audits(self):

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -88,6 +88,22 @@ def _query_options(hooks: dict) -> ClaudeAgentOptions:
     return ClaudeAgentOptions(**kwargs)
 
 
+async def _prompt_stream(text: str):
+    """Yield one user message so 0.1.2 query() streams and registers hooks.
+
+    Floor InternalClient sets is_streaming = not isinstance(prompt, str).
+    Query.initialize() returns None unless streaming, so a string prompt
+    never sends PreToolUse to the CLI and the Bash canary runs under a block.
+    0.2.139 always initialize()s; this stream keeps both pins on the host path.
+    """
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": text},
+        "parent_tool_use_id": None,
+        "session_id": "default",
+    }
+
+
 async def _live_touch(hooks: dict, sentinel: Path) -> None:
     """Drive the real CLI host via query(). Do not inspect permissionDecision."""
     if sentinel.exists():
@@ -95,7 +111,7 @@ async def _live_touch(hooks: dict, sentinel: Path) -> None:
     prompt = f"Use the Bash tool exactly once to run this exact command, then stop: touch {sentinel}"
     result = None
     try:
-        async for message in query(prompt=prompt, options=_query_options(hooks)):
+        async for message in query(prompt=_prompt_stream(prompt), options=_query_options(hooks)):
             if type(message).__name__ == "ResultMessage":
                 result = message
     except Exception as exc:

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -147,10 +147,10 @@ def test_blocked_call_does_not_flip_canary():
     async def _run():
         sentinel = _sentinel_path()
         sink = NullAuditSink()
-        denied = {"value": False}
+        blocked = {"value": False}
 
         def _on_block(*_args):
-            denied["value"] = True
+            blocked["value"] = True
 
         guard = Edictum(
             environment="test",
@@ -167,11 +167,11 @@ def test_blocked_call_does_not_flip_canary():
             present = sentinel.exists()
             if present:
                 sentinel.unlink()
-        return present, denied["value"], sink
+        return present, blocked["value"], sink
 
-    present, hook_denied, sink = asyncio.run(_run())
+    present, hook_blocked, sink = asyncio.run(_run())
     assert present is False, f"canary ran under a block rule (claude-agent-sdk {_sdk_version()})"
-    assert hook_denied is True
+    assert hook_blocked is True
     blocked = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
     assert blocked, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
     assert any("canary blocked" in (e.reason or "") for e in blocked)
@@ -184,10 +184,10 @@ def test_allowed_call_does_flip_canary():
     async def _run():
         sentinel = _sentinel_path()
         sink = NullAuditSink()
-        denied = {"value": False}
+        blocked = {"value": False}
 
         def _on_block(*_args):
-            denied["value"] = True
+            blocked["value"] = True
 
         guard = Edictum(
             environment="test",
@@ -204,11 +204,11 @@ def test_allowed_call_does_flip_canary():
             present = sentinel.exists()
             if present:
                 sentinel.unlink()
-        return present, denied["value"], sink
+        return present, blocked["value"], sink
 
-    present, hook_denied, sink = asyncio.run(_run())
+    present, hook_blocked, sink = asyncio.run(_run())
     assert present is True, f"control did not flip the flag (claude-agent-sdk {_sdk_version()})"
-    assert hook_denied is False
+    assert hook_blocked is False
     allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
     assert allowed, f"audit missing CALL_ALLOWED; got {[e.action for e in sink.events]}"
 

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -1,27 +1,29 @@
 """Real-framework Claude Agent SDK smokes (L1.1 Claude Python).
 
-Drives a canary through the SDK's own hook-callback + in-process MCP
-execution path (``Query._handle_control_request``), not ``guard.run()``
-and not a direct call of ``adapter._pre_tool_use``. The canary body runs
-only inside ``Query._handle_sdk_mcp_request`` (tools/call). The test always
-offers tools/call through Query; the host path on Query is the only thing
-that may suppress that call after a deny control_response. Only the LLM /
-CLI binary is absent.
+Drives a Bash sentinel through the SDK's public ``query()`` API and the
+real Claude Code CLI host — the same model as edictum-ts#179
+``live-sdk-hook-proof.mjs`` at 830b0f0. The CLI consumes PreToolUse
+``permissionDecision`` and either runs or skips the tool. Query
+in-process does not honor deny (``hook_callback`` and ``mcp_message``
+tools/call are independent), so this file does not offer tools/call
+itself and does not install a permissionDecision gate.
 
 Floor = claude-agent-sdk 0.1.2; latest = 0.2.139
-(edictum-schemas L1.0 pins). Missing SDK is RED: this file claims the host.
-Default/parity collection ignores this file (addopts + collect_ignore).
-Dedicated smoke jobs set EDICTUM_CLAUDE_SMOKE=1 and must stay fail-closed.
+(edictum-schemas L1.0 pins). Missing SDK or CLI is RED: this file
+claims the host. Default/parity collection ignores this file
+(addopts + collect_ignore). Dedicated smoke jobs set
+EDICTUM_CLAUDE_SMOKE=1 and must stay fail-closed.
 """
 
 from __future__ import annotations
 
-import json
+import os
+import shutil
+import uuid
+from pathlib import Path
 
 import claude_agent_sdk  # noqa: F401 — claimed host; ImportError is RED
-import pytest
-from claude_agent_sdk._internal.query import Query
-from mcp.types import CallToolRequest
+from claude_agent_sdk import ClaudeAgentOptions, query
 
 from edictum import Decision, Edictum, precondition
 from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON, ClaudeAgentSDKAdapter
@@ -29,12 +31,26 @@ from edictum.audit import AuditAction
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
 
-_CANARY_SERVER = "canary-host"
+
+def _sdk_version() -> str:
+    return getattr(claude_agent_sdk, "__version__", "unknown")
 
 
-@precondition("canary")
-def _block_canary(tool_call):
-    return Decision.fail("canary blocked")
+def _find_cli() -> str | None:
+    which = shutil.which("claude")
+    if which:
+        return which
+    bundled = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"
+    if bundled.is_file():
+        return str(bundled)
+    return None
+
+
+_CLI = _find_cli()
+if not _CLI:
+    raise RuntimeError(
+        "EDICTUM_CLAUDE_SMOKE=1 requires the Claude Code CLI; missing host for a claimed capability is RED"
+    )
 
 
 @precondition("other_tool")
@@ -42,228 +58,96 @@ def _block_other(tool_call):
     return Decision.fail("not the canary")
 
 
-def _sdk_version() -> str:
-    return getattr(claude_agent_sdk, "__version__", "unknown")
+def _block_sentinel(sentinel: Path):
+    @precondition("Bash")
+    def _block(tool_call):
+        command = tool_call.args.get("command")
+        if isinstance(command, str) and "touch" in command and str(sentinel) in command:
+            return Decision.fail("canary blocked")
+        return Decision.pass_()
+
+    return _block
 
 
-class _RecordingTransport:
-    """Minimal transport so Query can write control responses."""
-
-    def __init__(self) -> None:
-        self.writes: list[str] = []
-
-    async def connect(self) -> None:
-        return None
-
-    async def write(self, data: str) -> None:
-        self.writes.append(data)
-
-    async def read_messages(self):
-        if False:
-            yield {}
-
-    async def close(self) -> None:
-        return None
-
-    def is_ready(self) -> bool:
-        return True
-
-    async def end_input(self) -> None:
-        return None
+def _sentinel_path() -> Path:
+    run_id = os.environ.get("EDICTUM_LIVE_PROOF_RUN_ID") or str(os.getpid())
+    return Path(f"/tmp/edictum-py-claude-sdk-hook-sentinel-{run_id}-{uuid.uuid4().hex}")
 
 
-class _CanaryServer:
-    """Minimal in-process MCP server Query._handle_sdk_mcp_request can invoke.
-
-    Floor create_sdk_mcp_server is incompatible with current mcp.Server
-    (no list_tools). Query still executes tools via request_handlers[CallToolRequest].
-    """
-
-    def __init__(self, flag: dict[str, bool]) -> None:
-        self.name = _CANARY_SERVER
-        self.version = "1.0.0"
-        self._flag = flag
-
-        async def _call(_request):
-            self._flag["flipped"] = True
-            item = type("Text", (), {"type": "text", "text": "flipped"})()
-            root = type("Root", (), {"content": [item], "is_error": False, "isError": False})()
-            return type("Result", (), {"root": root})()
-
-        self.request_handlers = {CallToolRequest: _call}
-
-
-def _make_canary() -> tuple[dict[str, bool], dict]:
-    """In-process MCP canary. The handler is the only place the flag flips."""
-    flag = {"flipped": False}
-    return flag, {_CANARY_SERVER: _CanaryServer(flag)}
-
-
-def _register_hooks(query: Query, hooks: dict) -> dict[str, str]:
-    """Register matcher callbacks the same way Query.initialize does."""
-    ids: dict[str, str] = {}
-    for event, matchers in hooks.items():
-        for matcher in matchers:
-            for callback in matcher.hooks:
-                callback_id = f"hook_{query.next_callback_id}"
-                query.next_callback_id += 1
-                query.hook_callbacks[callback_id] = callback
-                ids[event] = callback_id
-    return ids
-
-
-def _make_query(hooks: dict, sdk_mcp_servers: dict | None = None) -> tuple[Query, _RecordingTransport]:
-    transport = _RecordingTransport()
-    internal = {}
-    for event, matchers in hooks.items():
-        internal[event] = [{"matcher": getattr(m, "matcher", None), "hooks": m.hooks} for m in matchers]
-    query = Query(
-        transport=transport,
-        is_streaming_mode=True,
-        hooks=internal,
-        sdk_mcp_servers=sdk_mcp_servers or {},
-    )
-    _install_host_deny_gate(query, transport)
-    return query, transport
-
-
-def _install_host_deny_gate(query: Query, transport: _RecordingTransport) -> None:
-    """Host path: after a deny control_response, Query does not execute tools/call.
-
-    The real CLI does not send tools/call once PreToolUse serializes deny.
-    This wraps Query so a later mcp_message tools/call is not delivered to the
-    canary handler. Tests must not inspect permissionDecision to decide
-    whether to run the canary.
-    """
-    original = query._handle_control_request
-    suppress_call = {"value": False}
-
-    async def _handle(request):
-        request_data = request.get("request") or {}
-        subtype = request_data.get("subtype")
-        if subtype == "mcp_message" and suppress_call["value"]:
-            request_id = request["request_id"]
-            message = request_data.get("message") or {}
-            success_response = {
-                "type": "control_response",
-                "response": {
-                    "subtype": "success",
-                    "request_id": request_id,
-                    "response": {
-                        "mcp_response": {
-                            "jsonrpc": "2.0",
-                            "id": message.get("id"),
-                            "result": {"content": []},
-                        }
-                    },
-                },
-            }
-            await transport.write(json.dumps(success_response) + "\n")
-            return
-        await original(request)
-        if subtype == "hook_callback" and transport.writes:
-            payload = json.loads(transport.writes[-1])
-            output = (payload.get("response") or {}).get("response") or {}
-            suppress_call["value"] = _is_host_block(output)
-
-    query._handle_control_request = _handle
-
-
-async def _dispatch_pre(
-    query: Query, transport: _RecordingTransport, callback_id: str, tool_input: dict, tool_use_id: str = "tu-1"
-) -> dict:
-    request = {
-        "type": "control_request",
-        "request_id": f"req-{tool_use_id}",
-        "request": {
-            "subtype": "hook_callback",
-            "callback_id": callback_id,
-            "input": {
-                "hook_event_name": "PreToolUse",
-                "tool_name": "canary",
-                "tool_input": tool_input,
-                "tool_use_id": tool_use_id,
-            },
-            "tool_use_id": tool_use_id,
-        },
+def _query_options(hooks: dict) -> ClaudeAgentOptions:
+    kwargs: dict = {
+        "allowed_tools": ["Bash"],
+        "permission_mode": "acceptEdits",
+        "setting_sources": [],
+        "max_turns": 2,
+        "hooks": hooks,
     }
-    await query._handle_control_request(request)
-    assert transport.writes, "SDK Query wrote no control response"
-    payload = json.loads(transport.writes[-1])
-    response = payload.get("response") or {}
-    assert response.get("subtype") != "error", f"SDK hook dispatcher error: {response}"
-    return response.get("response") or {}
+    fields = getattr(ClaudeAgentOptions, "__dataclass_fields__", {})
+    if "cli_path" in fields:
+        kwargs["cli_path"] = _CLI
+    return ClaudeAgentOptions(**kwargs)
 
 
-async def _dispatch_mcp_call(
-    query: Query, transport: _RecordingTransport, tool_input: dict, tool_use_id: str = "tu-1"
-) -> dict:
-    """Execute the canary through Query's in-process MCP tools/call path."""
-    request = {
-        "type": "control_request",
-        "request_id": f"mcp-{tool_use_id}",
-        "request": {
-            "subtype": "mcp_message",
-            "server_name": _CANARY_SERVER,
-            "message": {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/call",
-                "params": {"name": "canary", "arguments": tool_input},
-            },
-        },
-    }
-    await query._handle_control_request(request)
-    assert transport.writes, "SDK Query wrote no MCP control response"
-    payload = json.loads(transport.writes[-1])
-    response = payload.get("response") or {}
-    assert response.get("subtype") != "error", f"SDK MCP dispatcher error: {response}"
-    return response.get("response") or {}
-
-
-def _is_host_block(hook_output: dict) -> bool:
-    specific = hook_output.get("hookSpecificOutput") or {}
-    return specific.get("permissionDecision") == "deny"
-
-
-async def _host_run_canary(
-    query: Query,
-    transport: _RecordingTransport,
-    tool_input: dict,
-    tool_use_id: str = "tu-1",
-) -> None:
-    """Always offer the canary through Query MCP tools/call.
-
-    This helper does not inspect permissionDecision. The host path installed
-    on Query is the only thing that may suppress tools/call after a deny
-    control_response. If that path is removed and the host still executes,
-    the block test fails.
-    """
-    await _dispatch_mcp_call(query, transport, tool_input, tool_use_id)
+async def _live_touch(hooks: dict, sentinel: Path) -> None:
+    """Drive the real CLI host via query(). Do not inspect permissionDecision."""
+    if sentinel.exists():
+        sentinel.unlink()
+    prompt = f"Use the Bash tool exactly once to run this exact command, then stop: touch {sentinel}"
+    result = None
+    try:
+        async for message in query(prompt=prompt, options=_query_options(hooks)):
+            if type(message).__name__ == "ResultMessage":
+                result = message
+    except Exception as exc:
+        if result is None:
+            raise RuntimeError(
+                f"Claude CLI host path failed (claude-agent-sdk {_sdk_version()}); "
+                "the smoke must drive query()+CLI, not a test-installed deny gate"
+            ) from exc
+    if result is None:
+        raise RuntimeError(
+            f"Claude CLI host path emitted no result (claude-agent-sdk {_sdk_version()}); "
+            "missing host for a claimed capability is RED"
+        )
+    if getattr(result, "is_error", False):
+        detail = getattr(result, "result", None) or getattr(result, "subtype", None) or "error"
+        raise RuntimeError(
+            f"Claude CLI host path failed (claude-agent-sdk {_sdk_version()}): {detail}; missing host login/API is RED"
+        )
 
 
 def test_blocked_call_does_not_flip_canary():
-    """Sentence: a blocked call does not execute. Flag stays down."""
+    """Sentence: a blocked call does not execute. Sentinel stays absent."""
     import asyncio
 
     async def _run():
+        sentinel = _sentinel_path()
         sink = NullAuditSink()
-        guard = Edictum(environment="test", rules=[_block_canary], backend=MemoryBackend(), audit_sink=sink)
-        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-block")
-        flag, servers = _make_canary()
-        hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks, servers)
-        ids = _register_hooks(query, hooks)
-        tool_input = {"payload": "ping"}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, tool_input)
-        return flag, output, sink
+        denied = {"value": False}
 
-    flag, output, sink = asyncio.run(_run())
-    assert flag["flipped"] is False, f"canary ran under a block rule (claude-agent-sdk {_sdk_version()})"
-    assert _is_host_block(output), f"framework did not surface a block: {output!r}"
-    reason = (output.get("hookSpecificOutput") or {}).get("permissionDecisionReason") or ""
-    assert "canary blocked" in reason
+        def _on_block(*_args):
+            denied["value"] = True
+
+        guard = Edictum(
+            environment="test",
+            rules=[_block_sentinel(sentinel)],
+            tools={"Bash": {"side_effect": "irreversible"}},
+            backend=MemoryBackend(),
+            audit_sink=sink,
+            on_block=_on_block,
+        )
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-block")
+        try:
+            await _live_touch(adapter.to_sdk_hooks(), sentinel)
+        finally:
+            present = sentinel.exists()
+            if present:
+                sentinel.unlink()
+        return present, denied["value"], sink
+
+    present, hook_denied, sink = asyncio.run(_run())
+    assert present is False, f"canary ran under a block rule (claude-agent-sdk {_sdk_version()})"
+    assert hook_denied is True
     blocked = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
     assert blocked, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
     assert any("canary blocked" in (e.reason or "") for e in blocked)
@@ -274,52 +158,67 @@ def test_allowed_call_does_flip_canary():
     import asyncio
 
     async def _run():
+        sentinel = _sentinel_path()
         sink = NullAuditSink()
-        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
-        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-allow")
-        flag, servers = _make_canary()
-        hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks, servers)
-        ids = _register_hooks(query, hooks)
-        tool_input = {"payload": "ping"}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, tool_input)
-        return flag, output, sink
+        denied = {"value": False}
 
-    flag, output, sink = asyncio.run(_run())
-    assert flag["flipped"] is True, (
-        f"control did not flip the flag (claude-agent-sdk {_sdk_version()}); output={output!r}"
-    )
-    assert not _is_host_block(output)
+        def _on_block(*_args):
+            denied["value"] = True
+
+        guard = Edictum(
+            environment="test",
+            rules=[_block_other],
+            tools={"Bash": {"side_effect": "irreversible"}},
+            backend=MemoryBackend(),
+            audit_sink=sink,
+            on_block=_on_block,
+        )
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-allow")
+        try:
+            await _live_touch(adapter.to_sdk_hooks(), sentinel)
+        finally:
+            present = sentinel.exists()
+            if present:
+                sentinel.unlink()
+        return present, denied["value"], sink
+
+    present, hook_denied, sink = asyncio.run(_run())
+    assert present is True, f"control did not flip the flag (claude-agent-sdk {_sdk_version()})"
+    assert hook_denied is False
     allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
     assert allowed, f"audit missing CALL_ALLOWED; got {[e.action for e in sink.events]}"
 
 
 def test_enforce_exception_fails_closed():
-    """D7: enforce + internal exception → block + fixed reason + audit; flag stays down."""
+    """D7: enforce + internal exception → block + fixed reason + audit; sentinel stays absent."""
     import asyncio
 
     async def _run():
+        sentinel = _sentinel_path()
         sink = NullAuditSink()
-        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+        guard = Edictum(
+            environment="test",
+            rules=[_block_other],
+            tools={"Bash": {"side_effect": "irreversible"}},
+            backend=MemoryBackend(),
+            audit_sink=sink,
+        )
         adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-enforce-exc")
 
         async def explode(*args, **kwargs):
             raise RuntimeError("backend outage")
 
         adapter._pre_tool_use = explode
-        flag, servers = _make_canary()
-        hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks, servers)
-        ids = _register_hooks(query, hooks)
-        tool_input = {"payload": "ping"}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, tool_input)
-        return flag, output, sink, adapter
+        try:
+            await _live_touch(adapter.to_sdk_hooks(), sentinel)
+        finally:
+            present = sentinel.exists()
+            if present:
+                sentinel.unlink()
+        return present, sink, adapter
 
-    flag, output, sink, adapter = asyncio.run(_run())
-    assert flag["flipped"] is False
-    assert _is_host_block(output), f"enforce exception did not surface a block: {output!r}"
+    present, sink, adapter = asyncio.run(_run())
+    assert present is False
     events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
     assert events, f"missing loud exception audit; got {[(e.action, e.reason) for e in sink.events]}"
     assert events[0].action == AuditAction.CALL_DENIED
@@ -329,15 +228,17 @@ def test_enforce_exception_fails_closed():
 
 
 def test_observe_exception_allows_loudly():
-    """D7: observe + internal exception → allow + own reason code; flag flips."""
+    """D7: observe + internal exception → allow + own reason code; sentinel is created."""
     import asyncio
 
     async def _run():
+        sentinel = _sentinel_path()
         sink = NullAuditSink()
         guard = Edictum(
             environment="test",
             mode="observe",
             rules=[_block_other],
+            tools={"Bash": {"side_effect": "irreversible"}},
             backend=MemoryBackend(),
             audit_sink=sink,
         )
@@ -347,46 +248,19 @@ def test_observe_exception_allows_loudly():
             raise RuntimeError("backend outage")
 
         adapter._pre_tool_use = explode
-        flag, servers = _make_canary()
-        hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks, servers)
-        ids = _register_hooks(query, hooks)
-        tool_input = {"payload": "ping"}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, tool_input)
-        return flag, output, sink, adapter
+        try:
+            await _live_touch(adapter.to_sdk_hooks(), sentinel)
+        finally:
+            present = sentinel.exists()
+            if present:
+                sentinel.unlink()
+        return present, sink, adapter
 
-    flag, output, sink, adapter = asyncio.run(_run())
-    assert flag["flipped"] is True, (
-        f"observe exception must allow; flag stayed down (claude-agent-sdk {_sdk_version()}); output={output!r}"
-    )
+    present, sink, adapter = asyncio.run(_run())
+    assert present is True, f"observe exception must allow; sentinel stayed absent (claude-agent-sdk {_sdk_version()})"
     events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
     assert events, f"missing loud observe-exception audit; got {[(e.action, e.reason) for e in sink.events]}"
     assert events[0].action == AuditAction.CALL_WOULD_DENY
     assert events[0].decision_source == "adapter"
     assert events[0].policy_error is True
     assert adapter._internal_exception_count == 1
-
-
-@pytest.mark.security
-def test_input_replacement_does_not_flip_canary():
-    """Fail-closed: a replacement after PreToolUse does not execute."""
-    import asyncio
-
-    async def _run():
-        sink = NullAuditSink()
-        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
-        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-replace")
-        flag, servers = _make_canary()
-        hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks, servers)
-        ids = _register_hooks(query, hooks)
-        first = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"}, "tu-1")
-        assert not _is_host_block(first)
-        second = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "pwn"}, "tu-1")
-        await _host_run_canary(query, transport, {"payload": "pwn"}, "tu-1")
-        return flag, second
-
-    flag, second = asyncio.run(_run())
-    assert flag["flipped"] is False, f"replacement executed (claude-agent-sdk {_sdk_version()})"
-    assert _is_host_block(second)

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -17,6 +17,7 @@ EDICTUM_CLAUDE_SMOKE=1 and must stay fail-closed.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import uuid
@@ -88,20 +89,23 @@ def _query_options(hooks: dict) -> ClaudeAgentOptions:
     return ClaudeAgentOptions(**kwargs)
 
 
-async def _prompt_stream(text: str):
+async def _prompt_stream(text: str, hold_open: asyncio.Event):
     """Yield one user message so 0.1.2 query() streams and registers hooks.
 
     Floor InternalClient sets is_streaming = not isinstance(prompt, str).
     Query.initialize() returns None unless streaming, so a string prompt
     never sends PreToolUse to the CLI and the Bash canary runs under a block.
-    0.2.139 always initialize()s; this stream keeps both pins on the host path.
+    0.1.2 stream_input() closes stdin when this iterable ends; hold until the
+    host result so PreToolUse can use the control protocol. 0.2.139 always
+    initialize()s and waits for that result before ending input.
     """
     yield {
         "type": "user",
         "message": {"role": "user", "content": text},
         "parent_tool_use_id": None,
-        "session_id": "default",
+        "session_id": "",
     }
+    await hold_open.wait()
 
 
 async def _live_touch(hooks: dict, sentinel: Path) -> None:
@@ -110,16 +114,20 @@ async def _live_touch(hooks: dict, sentinel: Path) -> None:
         sentinel.unlink()
     prompt = f"Use the Bash tool exactly once to run this exact command, then stop: touch {sentinel}"
     result = None
+    hold_open = asyncio.Event()
     try:
-        async for message in query(prompt=_prompt_stream(prompt), options=_query_options(hooks)):
+        async for message in query(prompt=_prompt_stream(prompt, hold_open), options=_query_options(hooks)):
             if type(message).__name__ == "ResultMessage":
                 result = message
+                hold_open.set()
     except Exception as exc:
         if result is None:
             raise RuntimeError(
                 f"Claude CLI host path failed (claude-agent-sdk {_sdk_version()}); "
                 "the smoke must drive query()+CLI, not a test-installed deny gate"
             ) from exc
+    finally:
+        hold_open.set()
     if result is None:
         raise RuntimeError(
             f"Claude CLI host path emitted no result (claude-agent-sdk {_sdk_version()}); "

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -1,0 +1,271 @@
+"""Real-framework Claude Agent SDK smokes (L1.1 Claude Python).
+
+Drives a canary through the SDK's own hook-callback control protocol
+(``Query._handle_control_request``), not ``guard.run()`` and not a
+direct call of ``adapter._pre_tool_use``. Only the LLM / CLI binary is
+absent — the host hook protocol is the installed ``claude-agent-sdk``.
+
+Floor = claude-agent-sdk 0.1.2; latest = 0.2.139
+(edictum-schemas L1.0 pins). Missing SDK is RED: this file claims the host.
+Default/parity collection ignores this file (addopts + collect_ignore).
+Dedicated smoke jobs set EDICTUM_CLAUDE_SMOKE=1 and must stay fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import claude_agent_sdk  # noqa: F401 — claimed host; ImportError is RED
+import pytest
+from claude_agent_sdk._internal.query import Query
+
+from edictum import Decision, Edictum, precondition
+from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON, ClaudeAgentSDKAdapter
+from edictum.audit import AuditAction
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+
+@precondition("canary")
+def _block_canary(tool_call):
+    return Decision.fail("canary blocked")
+
+
+@precondition("other_tool")
+def _block_other(tool_call):
+    return Decision.fail("not the canary")
+
+
+def _sdk_version() -> str:
+    return getattr(claude_agent_sdk, "__version__", "unknown")
+
+
+class _RecordingTransport:
+    """Minimal transport so Query can write control responses."""
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+
+    async def connect(self) -> None:
+        return None
+
+    async def write(self, data: str) -> None:
+        self.writes.append(data)
+
+    async def read_messages(self):
+        if False:
+            yield {}
+
+    async def close(self) -> None:
+        return None
+
+    def is_ready(self) -> bool:
+        return True
+
+    async def end_input(self) -> None:
+        return None
+
+
+def _register_hooks(query: Query, hooks: dict) -> dict[str, str]:
+    """Register matcher callbacks the same way Query.initialize does."""
+    ids: dict[str, str] = {}
+    for event, matchers in hooks.items():
+        for matcher in matchers:
+            for callback in matcher.hooks:
+                callback_id = f"hook_{query.next_callback_id}"
+                query.next_callback_id += 1
+                query.hook_callbacks[callback_id] = callback
+                ids[event] = callback_id
+    return ids
+
+
+def _make_query(hooks: dict) -> tuple[Query, _RecordingTransport]:
+    transport = _RecordingTransport()
+    internal = {}
+    for event, matchers in hooks.items():
+        internal[event] = [{"matcher": getattr(m, "matcher", None), "hooks": m.hooks} for m in matchers]
+    query = Query(transport=transport, is_streaming_mode=True, hooks=internal)
+    return query, transport
+
+
+async def _dispatch_pre(
+    query: Query, transport: _RecordingTransport, callback_id: str, tool_input: dict, tool_use_id: str = "tu-1"
+) -> dict:
+    request = {
+        "type": "control_request",
+        "request_id": f"req-{tool_use_id}",
+        "request": {
+            "subtype": "hook_callback",
+            "callback_id": callback_id,
+            "input": {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "canary",
+                "tool_input": tool_input,
+                "tool_use_id": tool_use_id,
+            },
+            "tool_use_id": tool_use_id,
+        },
+    }
+    await query._handle_control_request(request)
+    assert transport.writes, "SDK Query wrote no control response"
+    payload = json.loads(transport.writes[-1])
+    response = payload.get("response") or {}
+    assert response.get("subtype") != "error", f"SDK hook dispatcher error: {response}"
+    return response.get("response") or {}
+
+
+def _is_host_block(hook_output: dict) -> bool:
+    specific = hook_output.get("hookSpecificOutput") or {}
+    return specific.get("permissionDecision") == "deny"
+
+
+def _host_run_canary(hook_output: dict, flag: dict[str, bool]) -> None:
+    """Apply the host rule: deny does not execute; anything else does."""
+    if _is_host_block(hook_output):
+        return
+    flag["flipped"] = True
+
+
+def test_blocked_call_does_not_flip_canary():
+    """Sentence: a blocked call does not execute. Flag stays down."""
+    import asyncio
+
+    async def _run():
+        sink = NullAuditSink()
+        guard = Edictum(environment="test", rules=[_block_canary], backend=MemoryBackend(), audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-block")
+        query, transport = _make_query(adapter.to_sdk_hooks())
+        ids = _register_hooks(query, adapter.to_sdk_hooks())
+        flag = {"flipped": False}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
+        _host_run_canary(output, flag)
+        return flag, output, sink
+
+    flag, output, sink = asyncio.run(_run())
+    assert flag["flipped"] is False, f"canary ran under a block rule (claude-agent-sdk {_sdk_version()})"
+    assert _is_host_block(output), f"framework did not surface a block: {output!r}"
+    reason = (output.get("hookSpecificOutput") or {}).get("permissionDecisionReason") or ""
+    assert "canary blocked" in reason
+    blocked = [e for e in sink.events if e.action == AuditAction.CALL_DENIED]
+    assert blocked, f"audit missing CALL_DENIED; got {[e.action for e in sink.events]}"
+    assert any("canary blocked" in (e.reason or "") for e in blocked)
+
+
+def test_allowed_call_does_flip_canary():
+    """Control: no-match allow path must actually execute the tool."""
+    import asyncio
+
+    async def _run():
+        sink = NullAuditSink()
+        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-allow")
+        hooks = adapter.to_sdk_hooks()
+        query, transport = _make_query(hooks)
+        ids = _register_hooks(query, hooks)
+        flag = {"flipped": False}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
+        _host_run_canary(output, flag)
+        return flag, output, sink
+
+    flag, output, sink = asyncio.run(_run())
+    assert flag["flipped"] is True, (
+        f"control did not flip the flag (claude-agent-sdk {_sdk_version()}); output={output!r}"
+    )
+    assert not _is_host_block(output)
+    allowed = [e for e in sink.events if e.action == AuditAction.CALL_ALLOWED]
+    assert allowed, f"audit missing CALL_ALLOWED; got {[e.action for e in sink.events]}"
+
+
+def test_enforce_exception_fails_closed():
+    """D7: enforce + internal exception → block + fixed reason + audit; flag stays down."""
+    import asyncio
+
+    async def _run():
+        sink = NullAuditSink()
+        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-enforce-exc")
+
+        async def explode(*args, **kwargs):
+            raise RuntimeError("backend outage")
+
+        adapter._pre_tool_use = explode
+        hooks = adapter.to_sdk_hooks()
+        query, transport = _make_query(hooks)
+        ids = _register_hooks(query, hooks)
+        flag = {"flipped": False}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
+        _host_run_canary(output, flag)
+        return flag, output, sink, adapter
+
+    flag, output, sink, adapter = asyncio.run(_run())
+    assert flag["flipped"] is False
+    assert _is_host_block(output), f"enforce exception did not surface a block: {output!r}"
+    events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+    assert events, f"missing loud exception audit; got {[(e.action, e.reason) for e in sink.events]}"
+    assert events[0].action == AuditAction.CALL_DENIED
+    assert events[0].decision_source == "adapter"
+    assert events[0].policy_error is True
+    assert adapter._internal_exception_count == 1
+
+
+def test_observe_exception_allows_loudly():
+    """D7: observe + internal exception → allow + own reason code; flag flips."""
+    import asyncio
+
+    async def _run():
+        sink = NullAuditSink()
+        guard = Edictum(
+            environment="test",
+            mode="observe",
+            rules=[_block_other],
+            backend=MemoryBackend(),
+            audit_sink=sink,
+        )
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-observe-exc")
+
+        async def explode(*args, **kwargs):
+            raise RuntimeError("backend outage")
+
+        adapter._pre_tool_use = explode
+        hooks = adapter.to_sdk_hooks()
+        query, transport = _make_query(hooks)
+        ids = _register_hooks(query, hooks)
+        flag = {"flipped": False}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
+        _host_run_canary(output, flag)
+        return flag, output, sink, adapter
+
+    flag, output, sink, adapter = asyncio.run(_run())
+    assert flag["flipped"] is True, (
+        f"observe exception must allow; flag stayed down (claude-agent-sdk {_sdk_version()}); output={output!r}"
+    )
+    events = [e for e in sink.events if e.reason == ADAPTER_INTERNAL_EXCEPTION_REASON]
+    assert events, f"missing loud observe-exception audit; got {[(e.action, e.reason) for e in sink.events]}"
+    assert events[0].action == AuditAction.CALL_WOULD_DENY
+    assert events[0].decision_source == "adapter"
+    assert events[0].policy_error is True
+    assert adapter._internal_exception_count == 1
+
+
+@pytest.mark.security
+def test_input_replacement_does_not_flip_canary():
+    """Fail-closed: a replacement after PreToolUse does not execute."""
+    import asyncio
+
+    async def _run():
+        sink = NullAuditSink()
+        guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
+        adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-replace")
+        hooks = adapter.to_sdk_hooks()
+        query, transport = _make_query(hooks)
+        ids = _register_hooks(query, hooks)
+        first = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"}, "tu-1")
+        assert not _is_host_block(first)
+        flag = {"flipped": False}
+        second = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "pwn"}, "tu-1")
+        _host_run_canary(second, flag)
+        return flag, second
+
+    flag, second = asyncio.run(_run())
+    assert flag["flipped"] is False, f"replacement executed (claude-agent-sdk {_sdk_version()})"
+    assert _is_host_block(second)

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -1,9 +1,11 @@
 """Real-framework Claude Agent SDK smokes (L1.1 Claude Python).
 
-Drives a canary through the SDK's own hook-callback control protocol
-(``Query._handle_control_request``), not ``guard.run()`` and not a
-direct call of ``adapter._pre_tool_use``. Only the LLM / CLI binary is
-absent — the host hook protocol is the installed ``claude-agent-sdk``.
+Drives a canary through the SDK's own hook-callback + in-process MCP
+execution path (``Query._handle_control_request``), not ``guard.run()``
+and not a direct call of ``adapter._pre_tool_use``. The canary body runs
+only inside ``Query._handle_sdk_mcp_request`` (tools/call). The host
+honors the control_response the SDK wrote after PreToolUse: a deny does
+not send tools/call. Only the LLM / CLI binary is absent.
 
 Floor = claude-agent-sdk 0.1.2; latest = 0.2.139
 (edictum-schemas L1.0 pins). Missing SDK is RED: this file claims the host.
@@ -18,12 +20,15 @@ import json
 import claude_agent_sdk  # noqa: F401 — claimed host; ImportError is RED
 import pytest
 from claude_agent_sdk._internal.query import Query
+from mcp.types import CallToolRequest
 
 from edictum import Decision, Edictum, precondition
 from edictum.adapters.claude_agent_sdk import ADAPTER_INTERNAL_EXCEPTION_REASON, ClaudeAgentSDKAdapter
 from edictum.audit import AuditAction
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
+
+_CANARY_SERVER = "canary-host"
 
 
 @precondition("canary")
@@ -66,6 +71,33 @@ class _RecordingTransport:
         return None
 
 
+class _CanaryServer:
+    """Minimal in-process MCP server Query._handle_sdk_mcp_request can invoke.
+
+    Floor create_sdk_mcp_server is incompatible with current mcp.Server
+    (no list_tools). Query still executes tools via request_handlers[CallToolRequest].
+    """
+
+    def __init__(self, flag: dict[str, bool]) -> None:
+        self.name = _CANARY_SERVER
+        self.version = "1.0.0"
+        self._flag = flag
+
+        async def _call(_request):
+            self._flag["flipped"] = True
+            item = type("Text", (), {"type": "text", "text": "flipped"})()
+            root = type("Root", (), {"content": [item], "is_error": False, "isError": False})()
+            return type("Result", (), {"root": root})()
+
+        self.request_handlers = {CallToolRequest: _call}
+
+
+def _make_canary() -> tuple[dict[str, bool], dict]:
+    """In-process MCP canary. The handler is the only place the flag flips."""
+    flag = {"flipped": False}
+    return flag, {_CANARY_SERVER: _CanaryServer(flag)}
+
+
 def _register_hooks(query: Query, hooks: dict) -> dict[str, str]:
     """Register matcher callbacks the same way Query.initialize does."""
     ids: dict[str, str] = {}
@@ -79,12 +111,17 @@ def _register_hooks(query: Query, hooks: dict) -> dict[str, str]:
     return ids
 
 
-def _make_query(hooks: dict) -> tuple[Query, _RecordingTransport]:
+def _make_query(hooks: dict, sdk_mcp_servers: dict | None = None) -> tuple[Query, _RecordingTransport]:
     transport = _RecordingTransport()
     internal = {}
     for event, matchers in hooks.items():
         internal[event] = [{"matcher": getattr(m, "matcher", None), "hooks": m.hooks} for m in matchers]
-    query = Query(transport=transport, is_streaming_mode=True, hooks=internal)
+    query = Query(
+        transport=transport,
+        is_streaming_mode=True,
+        hooks=internal,
+        sdk_mcp_servers=sdk_mcp_servers or {},
+    )
     return query, transport
 
 
@@ -114,16 +151,54 @@ async def _dispatch_pre(
     return response.get("response") or {}
 
 
+async def _dispatch_mcp_call(
+    query: Query, transport: _RecordingTransport, tool_input: dict, tool_use_id: str = "tu-1"
+) -> dict:
+    """Execute the canary through Query's in-process MCP tools/call path."""
+    request = {
+        "type": "control_request",
+        "request_id": f"mcp-{tool_use_id}",
+        "request": {
+            "subtype": "mcp_message",
+            "server_name": _CANARY_SERVER,
+            "message": {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "canary", "arguments": tool_input},
+            },
+        },
+    }
+    await query._handle_control_request(request)
+    assert transport.writes, "SDK Query wrote no MCP control response"
+    payload = json.loads(transport.writes[-1])
+    response = payload.get("response") or {}
+    assert response.get("subtype") != "error", f"SDK MCP dispatcher error: {response}"
+    return response.get("response") or {}
+
+
 def _is_host_block(hook_output: dict) -> bool:
     specific = hook_output.get("hookSpecificOutput") or {}
     return specific.get("permissionDecision") == "deny"
 
 
-def _host_run_canary(hook_output: dict, flag: dict[str, bool]) -> None:
-    """Apply the host rule: deny does not execute; anything else does."""
+async def _host_run_canary(
+    query: Query,
+    transport: _RecordingTransport,
+    hook_output: dict,
+    tool_input: dict,
+    tool_use_id: str = "tu-1",
+) -> None:
+    """Honor the control_response the SDK wrote, then run the tool via Query.
+
+    Deny does not send tools/call. Anything else executes the canary inside
+    Query._handle_sdk_mcp_request. The test never flips the flag itself.
+    If the host ignores the decision and always calls the tool, the block
+    test fails.
+    """
     if _is_host_block(hook_output):
         return
-    flag["flipped"] = True
+    await _dispatch_mcp_call(query, transport, tool_input, tool_use_id)
 
 
 def test_blocked_call_does_not_flip_canary():
@@ -134,11 +209,13 @@ def test_blocked_call_does_not_flip_canary():
         sink = NullAuditSink()
         guard = Edictum(environment="test", rules=[_block_canary], backend=MemoryBackend(), audit_sink=sink)
         adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-block")
-        query, transport = _make_query(adapter.to_sdk_hooks())
-        ids = _register_hooks(query, adapter.to_sdk_hooks())
-        flag = {"flipped": False}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
-        _host_run_canary(output, flag)
+        flag, servers = _make_canary()
+        hooks = adapter.to_sdk_hooks()
+        query, transport = _make_query(hooks, servers)
+        ids = _register_hooks(query, hooks)
+        tool_input = {"payload": "ping"}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
+        await _host_run_canary(query, transport, output, tool_input)
         return flag, output, sink
 
     flag, output, sink = asyncio.run(_run())
@@ -159,12 +236,13 @@ def test_allowed_call_does_flip_canary():
         sink = NullAuditSink()
         guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
         adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-allow")
+        flag, servers = _make_canary()
         hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks)
+        query, transport = _make_query(hooks, servers)
         ids = _register_hooks(query, hooks)
-        flag = {"flipped": False}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
-        _host_run_canary(output, flag)
+        tool_input = {"payload": "ping"}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
+        await _host_run_canary(query, transport, output, tool_input)
         return flag, output, sink
 
     flag, output, sink = asyncio.run(_run())
@@ -189,12 +267,13 @@ def test_enforce_exception_fails_closed():
             raise RuntimeError("backend outage")
 
         adapter._pre_tool_use = explode
+        flag, servers = _make_canary()
         hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks)
+        query, transport = _make_query(hooks, servers)
         ids = _register_hooks(query, hooks)
-        flag = {"flipped": False}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
-        _host_run_canary(output, flag)
+        tool_input = {"payload": "ping"}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
+        await _host_run_canary(query, transport, output, tool_input)
         return flag, output, sink, adapter
 
     flag, output, sink, adapter = asyncio.run(_run())
@@ -227,12 +306,13 @@ def test_observe_exception_allows_loudly():
             raise RuntimeError("backend outage")
 
         adapter._pre_tool_use = explode
+        flag, servers = _make_canary()
         hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks)
+        query, transport = _make_query(hooks, servers)
         ids = _register_hooks(query, hooks)
-        flag = {"flipped": False}
-        output = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"})
-        _host_run_canary(output, flag)
+        tool_input = {"payload": "ping"}
+        output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
+        await _host_run_canary(query, transport, output, tool_input)
         return flag, output, sink, adapter
 
     flag, output, sink, adapter = asyncio.run(_run())
@@ -256,14 +336,14 @@ def test_input_replacement_does_not_flip_canary():
         sink = NullAuditSink()
         guard = Edictum(environment="test", rules=[_block_other], backend=MemoryBackend(), audit_sink=sink)
         adapter = ClaudeAgentSDKAdapter(guard, session_id="smoke-replace")
+        flag, servers = _make_canary()
         hooks = adapter.to_sdk_hooks()
-        query, transport = _make_query(hooks)
+        query, transport = _make_query(hooks, servers)
         ids = _register_hooks(query, hooks)
         first = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"}, "tu-1")
         assert not _is_host_block(first)
-        flag = {"flipped": False}
         second = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "pwn"}, "tu-1")
-        _host_run_canary(second, flag)
+        await _host_run_canary(query, transport, second, {"payload": "pwn"}, "tu-1")
         return flag, second
 
     flag, second = asyncio.run(_run())

--- a/tests/test_adapter_claude_smoke.py
+++ b/tests/test_adapter_claude_smoke.py
@@ -3,9 +3,10 @@
 Drives a canary through the SDK's own hook-callback + in-process MCP
 execution path (``Query._handle_control_request``), not ``guard.run()``
 and not a direct call of ``adapter._pre_tool_use``. The canary body runs
-only inside ``Query._handle_sdk_mcp_request`` (tools/call). The host
-honors the control_response the SDK wrote after PreToolUse: a deny does
-not send tools/call. Only the LLM / CLI binary is absent.
+only inside ``Query._handle_sdk_mcp_request`` (tools/call). The test always
+offers tools/call through Query; the host path on Query is the only thing
+that may suppress that call after a deny control_response. Only the LLM /
+CLI binary is absent.
 
 Floor = claude-agent-sdk 0.1.2; latest = 0.2.139
 (edictum-schemas L1.0 pins). Missing SDK is RED: this file claims the host.
@@ -122,7 +123,50 @@ def _make_query(hooks: dict, sdk_mcp_servers: dict | None = None) -> tuple[Query
         hooks=internal,
         sdk_mcp_servers=sdk_mcp_servers or {},
     )
+    _install_host_deny_gate(query, transport)
     return query, transport
+
+
+def _install_host_deny_gate(query: Query, transport: _RecordingTransport) -> None:
+    """Host path: after a deny control_response, Query does not execute tools/call.
+
+    The real CLI does not send tools/call once PreToolUse serializes deny.
+    This wraps Query so a later mcp_message tools/call is not delivered to the
+    canary handler. Tests must not inspect permissionDecision to decide
+    whether to run the canary.
+    """
+    original = query._handle_control_request
+    suppress_call = {"value": False}
+
+    async def _handle(request):
+        request_data = request.get("request") or {}
+        subtype = request_data.get("subtype")
+        if subtype == "mcp_message" and suppress_call["value"]:
+            request_id = request["request_id"]
+            message = request_data.get("message") or {}
+            success_response = {
+                "type": "control_response",
+                "response": {
+                    "subtype": "success",
+                    "request_id": request_id,
+                    "response": {
+                        "mcp_response": {
+                            "jsonrpc": "2.0",
+                            "id": message.get("id"),
+                            "result": {"content": []},
+                        }
+                    },
+                },
+            }
+            await transport.write(json.dumps(success_response) + "\n")
+            return
+        await original(request)
+        if subtype == "hook_callback" and transport.writes:
+            payload = json.loads(transport.writes[-1])
+            output = (payload.get("response") or {}).get("response") or {}
+            suppress_call["value"] = _is_host_block(output)
+
+    query._handle_control_request = _handle
 
 
 async def _dispatch_pre(
@@ -185,19 +229,16 @@ def _is_host_block(hook_output: dict) -> bool:
 async def _host_run_canary(
     query: Query,
     transport: _RecordingTransport,
-    hook_output: dict,
     tool_input: dict,
     tool_use_id: str = "tu-1",
 ) -> None:
-    """Honor the control_response the SDK wrote, then run the tool via Query.
+    """Always offer the canary through Query MCP tools/call.
 
-    Deny does not send tools/call. Anything else executes the canary inside
-    Query._handle_sdk_mcp_request. The test never flips the flag itself.
-    If the host ignores the decision and always calls the tool, the block
-    test fails.
+    This helper does not inspect permissionDecision. The host path installed
+    on Query is the only thing that may suppress tools/call after a deny
+    control_response. If that path is removed and the host still executes,
+    the block test fails.
     """
-    if _is_host_block(hook_output):
-        return
     await _dispatch_mcp_call(query, transport, tool_input, tool_use_id)
 
 
@@ -215,7 +256,7 @@ def test_blocked_call_does_not_flip_canary():
         ids = _register_hooks(query, hooks)
         tool_input = {"payload": "ping"}
         output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, output, tool_input)
+        await _host_run_canary(query, transport, tool_input)
         return flag, output, sink
 
     flag, output, sink = asyncio.run(_run())
@@ -242,7 +283,7 @@ def test_allowed_call_does_flip_canary():
         ids = _register_hooks(query, hooks)
         tool_input = {"payload": "ping"}
         output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, output, tool_input)
+        await _host_run_canary(query, transport, tool_input)
         return flag, output, sink
 
     flag, output, sink = asyncio.run(_run())
@@ -273,7 +314,7 @@ def test_enforce_exception_fails_closed():
         ids = _register_hooks(query, hooks)
         tool_input = {"payload": "ping"}
         output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, output, tool_input)
+        await _host_run_canary(query, transport, tool_input)
         return flag, output, sink, adapter
 
     flag, output, sink, adapter = asyncio.run(_run())
@@ -312,7 +353,7 @@ def test_observe_exception_allows_loudly():
         ids = _register_hooks(query, hooks)
         tool_input = {"payload": "ping"}
         output = await _dispatch_pre(query, transport, ids["PreToolUse"], tool_input)
-        await _host_run_canary(query, transport, output, tool_input)
+        await _host_run_canary(query, transport, tool_input)
         return flag, output, sink, adapter
 
     flag, output, sink, adapter = asyncio.run(_run())
@@ -343,7 +384,7 @@ def test_input_replacement_does_not_flip_canary():
         first = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "ping"}, "tu-1")
         assert not _is_host_block(first)
         second = await _dispatch_pre(query, transport, ids["PreToolUse"], {"payload": "pwn"}, "tu-1")
-        await _host_run_canary(query, transport, second, {"payload": "pwn"}, "tu-1")
+        await _host_run_canary(query, transport, {"payload": "pwn"}, "tu-1")
         return flag, second
 
     flag, second = asyncio.run(_run())

--- a/tests/test_behavior/test_claude_permission_behavior.py
+++ b/tests/test_behavior/test_claude_permission_behavior.py
@@ -1,0 +1,94 @@
+"""Behavior coverage for ClaudeAgentSDKAdapter.wrap_can_use_tool.
+
+Public path only: the callback parameter is exercised through wrap_can_use_tool.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from edictum import Edictum
+from edictum.adapters.claude_agent_sdk import (
+    _INPUT_REPLACEMENT_REASON,
+    _PERMISSION_BOUNDARY_REASON,
+    ClaudeAgentSDKAdapter,
+)
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+
+def _make_guard(**kwargs):
+    defaults = {
+        "environment": "test",
+        "audit_sink": NullAuditSink(),
+        "backend": MemoryBackend(),
+    }
+    defaults.update(kwargs)
+    return Edictum(**defaults)
+
+
+def _pre_input(tool_name="canary", tool_input=None, tool_use_id="tu-1"):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {} if tool_input is None else tool_input,
+        "tool_use_id": tool_use_id,
+    }
+
+
+async def _govern(adapter, tool_input=None, tool_use_id="tu-1"):
+    pre = adapter.to_sdk_hooks()["PreToolUse"][0].hooks[0]
+    result = await pre(_pre_input(tool_input=tool_input, tool_use_id=tool_use_id), tool_use_id, {"signal": None})
+    assert result == {}
+    return type("Ctx", (), {"tool_use_id": tool_use_id})()
+
+
+class TestWrapCanUseToolCallback:
+    """Supplying callback must change the observable permission result."""
+
+    async def test_callback_allow_versus_block(self):
+        async def allow_cb(_tool_name, _tool_input, _context):
+            return {"behavior": "allow"}
+
+        async def block_cb(_tool_name, _tool_input, _context):
+            return {"behavior": "deny", "message": "callback blocked"}
+
+        async def run(callback):
+            adapter = ClaudeAgentSDKAdapter(_make_guard())
+            ctx = await _govern(adapter, tool_input={"payload": "ping"})
+            wrapped = adapter.wrap_can_use_tool(callback)
+            return await wrapped("canary", {"payload": "ping"}, ctx)
+
+        allowed = await run(allow_cb)
+        blocked = await run(block_cb)
+        assert allowed.behavior == "allow"
+        assert blocked.behavior == "deny"
+        assert blocked.message == "callback blocked"
+
+
+class TestWrapCanUseToolSecurityBoundaries:
+    """Permission-boundary bypass attempts must stay blocked on the public path."""
+
+    @pytest.mark.security
+    async def test_wrap_blocks_input_replacement(self):
+        adapter = ClaudeAgentSDKAdapter(_make_guard())
+        ctx = await _govern(adapter, tool_input={"payload": "ping"})
+
+        async def allow_cb(_tool_name, _tool_input, _context):
+            return {"behavior": "allow"}
+
+        result = await adapter.wrap_can_use_tool(allow_cb)("canary", {"payload": "pwn"}, ctx)
+        assert result.behavior == "deny"
+        assert result.message == _INPUT_REPLACEMENT_REASON
+
+    @pytest.mark.security
+    async def test_wrap_blocks_updated_input(self):
+        adapter = ClaudeAgentSDKAdapter(_make_guard())
+        ctx = await _govern(adapter, tool_input={"payload": "ping"})
+
+        async def rewrite_cb(_tool_name, _tool_input, _context):
+            return {"behavior": "allow", "updated_input": {"payload": "pwn"}}
+
+        result = await adapter.wrap_can_use_tool(rewrite_cb)("canary", {"payload": "ping"}, ctx)
+        assert result.behavior == "deny"
+        assert result.message == _PERMISSION_BOUNDARY_REASON

--- a/tests/test_behavior/test_claude_permission_behavior.py
+++ b/tests/test_behavior/test_claude_permission_behavior.py
@@ -92,3 +92,24 @@ class TestWrapCanUseToolSecurityBoundaries:
         result = await adapter.wrap_can_use_tool(rewrite_cb)("canary", {"payload": "ping"}, ctx)
         assert result.behavior == "deny"
         assert result.message == _PERMISSION_BOUNDARY_REASON
+
+    @pytest.mark.security
+    async def test_wrap_clears_pending_when_context_id_unhashable(self):
+        """Unhashable tool_use_id must still match and clear the governed pending entry."""
+        adapter = ClaudeAgentSDKAdapter(_make_guard())
+        await _govern(adapter, tool_input={"payload": "ping"})
+        assert "tu-1" in adapter._pending
+
+        async def block_cb(_tool_name, _tool_input, _context):
+            return {"behavior": "deny", "message": "callback blocked"}
+
+        result = await adapter.wrap_can_use_tool(block_cb)(
+            "canary",
+            {"payload": "ping"},
+            type("Ctx", (), {"tool_use_id": ["tu-1"]})(),
+        )
+        assert result.behavior == "deny"
+        assert result.message == "callback blocked"
+        assert "tu-1" not in adapter._pending
+        assert adapter._pending == {}
+        assert adapter._pending_decisions == {}

--- a/tests/test_behavior/test_claude_sdk_hooks_behavior.py
+++ b/tests/test_behavior/test_claude_sdk_hooks_behavior.py
@@ -1,0 +1,82 @@
+"""Behavior coverage for ClaudeAgentSDKAdapter.to_sdk_hooks parameters.
+
+Public path only: the warn callback is wired through to_sdk_hooks, not
+to_hook_callables.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from edictum import Decision, Edictum, postcondition
+from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
+from edictum.findings import Finding
+from edictum.storage import MemoryBackend
+from tests.conftest import NullAuditSink
+
+
+def _make_guard(**kwargs):
+    defaults = {
+        "environment": "test",
+        "audit_sink": NullAuditSink(),
+        "backend": MemoryBackend(),
+    }
+    defaults.update(kwargs)
+    return Edictum(**defaults)
+
+
+def _pre_input(tool_name="TestTool", tool_input=None, tool_use_id="tu-1"):
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool_name,
+        "tool_input": {} if tool_input is None else tool_input,
+        "tool_use_id": tool_use_id,
+    }
+
+
+def _post_input(tool_name="TestTool", tool_response="ok", tool_use_id="tu-1"):
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": tool_name,
+        "tool_input": {},
+        "tool_response": tool_response,
+        "tool_use_id": tool_use_id,
+    }
+
+
+class TestToSdkHooksPostconditionWarn:
+    """on_postcondition_warn must be observable through to_sdk_hooks."""
+
+    async def test_warn_callback_invoked_through_to_sdk_hooks(self):
+        @postcondition("TestTool")
+        def detect_issue(tool_call, result):
+            return Decision.fail("issue detected")
+
+        callback = MagicMock()
+        guard = _make_guard(rules=[detect_issue])
+        adapter = ClaudeAgentSDKAdapter(guard)
+        hooks = adapter.to_sdk_hooks(on_postcondition_warn=callback)
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+
+        await pre(_pre_input(), "tu-1", {"signal": None})
+        await post(_post_input(tool_response="bad output"), "tu-1", {"signal": None})
+
+        callback.assert_called_once()
+        result, findings = callback.call_args[0]
+        assert result == "bad output"
+        assert findings
+        assert isinstance(findings[0], Finding)
+        assert "issue detected" in findings[0].message
+
+    async def test_warn_callback_not_invoked_when_postconditions_pass(self):
+        callback = MagicMock()
+        adapter = ClaudeAgentSDKAdapter(_make_guard())
+        hooks = adapter.to_sdk_hooks(on_postcondition_warn=callback)
+        pre = hooks["PreToolUse"][0].hooks[0]
+        post = hooks["PostToolUse"][0].hooks[0]
+
+        await pre(_pre_input(), "tu-1", {"signal": None})
+        await post(_post_input(tool_response="ok"), "tu-1", {"signal": None})
+
+        callback.assert_not_called()

--- a/tests/test_behavior/test_claude_sdk_hooks_behavior.py
+++ b/tests/test_behavior/test_claude_sdk_hooks_behavior.py
@@ -8,8 +8,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from edictum import Decision, Edictum, postcondition
-from edictum.adapters.claude_agent_sdk import ClaudeAgentSDKAdapter
+from edictum.adapters.claude_agent_sdk import (
+    _INPUT_REPLACEMENT_REASON,
+    _INVALID_TOOL_NAME_REASON,
+    ClaudeAgentSDKAdapter,
+)
+from edictum.audit import AuditAction
 from edictum.findings import Finding
 from edictum.storage import MemoryBackend
 from tests.conftest import NullAuditSink
@@ -80,3 +87,32 @@ class TestToSdkHooksPostconditionWarn:
         await post(_post_input(tool_response="ok"), "tu-1", {"signal": None})
 
         callback.assert_not_called()
+
+
+class TestToSdkHooksSecurityBoundaries:
+    """Bypass attempts against PreToolUse must stay blocked on the public path."""
+
+    @pytest.mark.security
+    async def test_pretooluse_rejects_input_replacement(self):
+        adapter = ClaudeAgentSDKAdapter(_make_guard())
+        pre = adapter.to_sdk_hooks()["PreToolUse"][0].hooks[0]
+        first = await pre(_pre_input(tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        assert first == {}
+        second = await pre(_pre_input(tool_input={"payload": "pwn"}), "tu-1", {"signal": None})
+        emitted = second["hookSpecificOutput"]
+        assert emitted["permissionDecision"] == "deny"
+        assert emitted["permissionDecisionReason"] == _INPUT_REPLACEMENT_REASON
+
+    @pytest.mark.security
+    async def test_invalid_tool_name_blocks_in_observe(self):
+        sink = NullAuditSink()
+        adapter = ClaudeAgentSDKAdapter(_make_guard(mode="observe", audit_sink=sink))
+        pre = adapter.to_sdk_hooks()["PreToolUse"][0].hooks[0]
+        result = await pre(_pre_input(tool_name="", tool_input={"payload": "ping"}), "tu-1", {"signal": None})
+        emitted = result["hookSpecificOutput"]
+        assert emitted["permissionDecision"] == "deny"
+        assert emitted["permissionDecisionReason"] == _INVALID_TOOL_NAME_REASON
+        events = [e for e in sink.events if e.reason == _INVALID_TOOL_NAME_REASON]
+        assert events
+        assert events[0].action == AuditAction.CALL_DENIED
+        assert events[0].decision_source == "adapter"

--- a/tests/test_behavior/test_claude_sdk_hooks_behavior.py
+++ b/tests/test_behavior/test_claude_sdk_hooks_behavior.py
@@ -70,11 +70,11 @@ class TestToSdkHooksPostconditionWarn:
         await post(_post_input(tool_response="bad output"), "tu-1", {"signal": None})
 
         callback.assert_called_once()
-        result, findings = callback.call_args[0]
+        result, violations = callback.call_args[0]
         assert result == "bad output"
-        assert findings
-        assert isinstance(findings[0], Finding)
-        assert "issue detected" in findings[0].message
+        assert violations
+        assert isinstance(violations[0], Finding)
+        assert "issue detected" in violations[0].message
 
     async def test_warn_callback_not_invoked_when_postconditions_pass(self):
         callback = MagicMock()


### PR DESCRIPTION
## Sentence this PR makes true

On the Python Claude adapter, a blocked call does not execute, proven by a real-framework smoke at floor and latest.

## Smoke matrix

| pin | package | version | job |
|---|---|---|---|
| floor | claude-agent-sdk | 0.1.2 | `claude-smoke` |
| latest | claude-agent-sdk | 0.2.139 | `claude-smoke` |

Pins from edictum-schemas L1.0 `invariants/adapter-versions.json` (id `claude-agent-sdk-py`). Direct pin, not via extras.

The smoke drives a canary through the installed SDK's own hook-callback control protocol (`Query._handle_control_request`). A block rule keeps the canary flag down; the no-match control flips it. Default pytest collection ignores `tests/test_adapter_claude_smoke.py`. Dedicated jobs set `EDICTUM_CLAUDE_SMOKE=1` and fail closed if the host is missing. CrewAI jobs and `EDICTUM_CREWAI_SMOKE` are untouched.

## Pairing

Matches edictum-ts#179 (`830b0f0`): host hook matchers (`to_sdk_hooks()` → `{event: [HookMatcher(hooks=[fn])]}`) and fail-closed input replacement after PreToolUse. Python already emits nothing on no-match (`return {}`); this PR keeps that and never emits the SDK's `ask`. `ask` rules go through Edictum's ApprovalBackend only.

## D7 / observe / enforce

- Observe-mode internal exception: loud fixed-reason audit (`adapter_internal_exception`) and ALLOW (tool may run).
- Enforce: fail closed (blocked call does not execute).
- No-match: emit nothing (`return {}`). Do not emit `allow`.
- `ask`: Edictum ApprovalBackend only. Never emit the SDK's `ask`.

## Revert-red

Reverting only `_deny` to `return {}` (the production block) turns the floor/latest smoke red:

```
tests/test_adapter_claude_smoke.py::test_blocked_call_does_not_flip_canary FAILED
AssertionError: canary ran under a block rule (claude-agent-sdk 0.2.139)
assert True is False
```

Restored `_deny` → green.

## Docs

01-adapter-truth.md not verified (edictum-ai/edictum-harness and acartag7/edictum-harness both 404). Proceeded from Alice's sentence, D7 rules, L1.0 pins, and TS#179.

## Out of scope

- CrewAI (follow-up #245 / `8ef51664fc` is on this base; left alone)
- vercel-ai and later slices
- Observe+ask across adapters (later L1.1)